### PR TITLE
Guard doxygen CMake target in option, and namespace it.

### DIFF
--- a/.github/actions/run_tests/entrypoint.sh
+++ b/.github/actions/run_tests/entrypoint.sh
@@ -7,7 +7,7 @@ cmake .. -G Ninja -DCMAKE_CXX_COMPILER="$1"
 echo "::endgroup::"
 
 echo "::group::Compiling test" ;
-ninja unit -k 0 ;
+ninja -k 0 ;
 if [ "$?" -ne "0" ]
 then
   echo "::error Tests can not be compiled!" ;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(kumi::kumi ALIAS kumi_lib)
 ## Options
 ##==================================================================================================
 option( KUMI_BUILD_TEST  "Build tests for kumi" ON )
+option( KUMI_BUILD_DOCS  "Build docs for kumi" OFF )
 
 ##==================================================================================================
 ## Test target
@@ -52,21 +53,23 @@ endif()
 ##==================================================================================================
 ## Add Doxygen building target
 ##==================================================================================================
-find_package(Doxygen QUIET)
+if( KUMI_BUILD_DOCS )
+  find_package(Doxygen QUIET)
 
-if (DOXYGEN_FOUND)
-  message( STATUS "[kumi] Doxygen available")
-else (DOXYGEN_FOUND)
-  message( STATUS "[kumi] Doxygen need to be installed to generate the doxygen documentation")
-endif (DOXYGEN_FOUND)
+  if (DOXYGEN_FOUND)
+    message( STATUS "[kumi] Doxygen available")
+  else (DOXYGEN_FOUND)
+    message( STATUS "[kumi] Doxygen need to be installed to generate the doxygen documentation")
+  endif (DOXYGEN_FOUND)
 
 
-if (DOXYGEN_FOUND)
-  set(DOXYGEN_CONFIG ${PROJECT_SOURCE_DIR}/doc/Doxyfile)
-  add_custom_target ( doxygen
-                      COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_CONFIG}
-                      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/doc
-                      COMMENT "[kumi] Generating API documentation with Doxygen"
-                      VERBATIM
-                    )
-endif (DOXYGEN_FOUND)
+  if (DOXYGEN_FOUND)
+    set(DOXYGEN_CONFIG ${PROJECT_SOURCE_DIR}/doc/Doxyfile)
+    add_custom_target ( kumi-doxygen
+      COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_CONFIG}
+      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/doc
+      COMMENT "[kumi] Generating API documentation with Doxygen"
+      VERBATIM
+    )
+  endif (DOXYGEN_FOUND)
+endif()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,8 @@ build_script:
 - mkdir build
 - cd build
 - cmake -G "Visual Studio 17 2022" -A x64 ..
-- cmake --build . --target unit --verbose --config Debug
-- cmake --build . --target unit --verbose --config Release
+- cmake --build . --verbose --config Debug
+- cmake --build . --verbose --config Release
 
 test_script:
 - ctest -C Release -VV

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,7 +28,7 @@ function(generate_test file)
   string(REPLACE ".cpp" ".exe" base ${file})
   string(REPLACE "/"    "." base ${base})
   string(REPLACE "\\"   "." base ${base})
-  set(test "${base}")
+  set(test "kumi-${base}")
 
   add_executable( ${test}  "${file}")
   target_link_libraries(${test} PUBLIC kumi_test)
@@ -49,12 +49,6 @@ function(generate_test file)
             )
   endif()
 
-  set_target_properties ( ${test} PROPERTIES
-                          EXCLUDE_FROM_DEFAULT_BUILD TRUE
-                          EXCLUDE_FROM_ALL TRUE
-                          ${MAKE_UNIT_TARGET_PROPERTIES}
-                        )
-
   target_include_directories( ${test}
                               PRIVATE
                               ${tts_SOURCE_DIR}/include
@@ -62,10 +56,10 @@ function(generate_test file)
                               ${PROJECT_SOURCE_DIR}/include
                             )
 
-  add_dependencies(unit ${test})
+  add_dependencies(kumi-unit ${test})
 endfunction()
 
-add_custom_target(unit)
+add_custom_target(kumi-unit)
 
 ##==================================================================================================
 ## Actual tests


### PR DESCRIPTION
Prevent collision with targets of other CMake-projects, like if someone fetch-contents both eve and kumi, as I think eve exposes a similar target (https://github.com/jfalcou/eve/blob/main/cmake/config/doxygen.cmake#L12). 

Off by default so `cmake && cmake --build && ctest && cmake --install` does not do anything unecessary.

Added tests to default target and removed explicit targets from CI. Also removed `MAKE_UNIT_TARGET_PROPERTIES`, since it seemed unnused, and now one would have to check if it exists, since other parameters of `set_target_properties` was removed.