### PR TITLE
Fix #77 - Adjust type computation of cat.

### DIFF
--- a/include/kumi/algorithm/cat.hpp
+++ b/include/kumi/algorithm/cat.hpp
@@ -65,7 +65,7 @@ namespace kumi
                                             , std::remove_cvref_t<std::tuple_element_t<pos.t[N],ts>>
                                             >...
                       >;
-        return type{get<pos.e[N]>(get<pos.t[N]>(tuples))...};
+        return type{get<pos.e[N]>(get<pos.t[N]>(KUMI_FWD(tuples)))...};
       }(kumi::forward_as_tuple(KUMI_FWD(ts)...), std::make_index_sequence<count-1>{});
     }
   }

--- a/test/unit/cat.cpp
+++ b/test/unit/cat.cpp
@@ -30,6 +30,26 @@ TTS_CASE("Check result::cat<Tuple...> behavior")
   TTS_TYPE_IS ( (kumi::result::cat_t<kumi::tuple<char,short&>,kumi::tuple<int&,double>>)
               , (kumi::tuple<char,short&,int&,double>)
               );
+
+  TTS_TYPE_IS ( (kumi::result::cat_t<kumi::tuple<char &&> &&>)
+              , (kumi::tuple<char &&>)
+              );
+
+  TTS_TYPE_IS ( (kumi::result::cat_t<kumi::tuple<char &&> &&, kumi::tuple<char &> &, kumi::tuple<char> &>)
+              , (kumi::tuple<char &&, char &, char>)
+              );
+
+  TTS_TYPE_IS ( (kumi::result::cat_t<kumi::tuple<char &&> &&, kumi::tuple<char &> &&, kumi::tuple<char> &>)
+                , (kumi::tuple<char &&, char &, char>)
+              );
+
+  TTS_TYPE_IS ( (kumi::result::cat_t<kumi::tuple<char &&> &&, kumi::tuple<char &> &, kumi::tuple<char> &&>)
+              , (kumi::tuple<char &&, char &, char>)
+              );
+
+  TTS_TYPE_IS ( (kumi::result::cat_t<kumi::tuple<char &&> &&, kumi::tuple<char &> &&, kumi::tuple<char> &&>)
+                , (kumi::tuple<char &&, char &, char>)
+              );
 };
 
 TTS_CASE("Check cat(tuple) behavior")
@@ -44,10 +64,19 @@ TTS_CASE("Check cat(tuple) behavior")
             (kumi::tuple {1, 2., 3.f, 4, s, 6.7}));
 
   // Check behavior with tuple of references
-  auto ref = kumi::tie(s);
-  auto val = kumi::tuple<float const>{3.14f};;
+  {
+    auto ref = kumi::tie(s);
+    auto val = kumi::tuple<float const>{3.14f};
 
-  TTS_EQUAL(kumi::cat(ref, val), (kumi::tuple<short&,float const>{s,3.14f}) );
+    TTS_EQUAL(kumi::cat(ref, val), (kumi::tuple<short&,float const>{s,3.14f}) );
+  }
+  {
+    auto ref = kumi::tie(s);
+    auto rref = kumi::tuple<short &&>{std::move(s)};
+    auto val = kumi::tuple<float const>{3.14f};
+
+    TTS_EQUAL(kumi::cat(ref, std::move(rref), val), (kumi::tuple<short&, short &&, float const>{s,std::move(s),3.14f}) );
+  }
 };
 
 TTS_CASE("Check cat(tuple) constexpr behavior")


### PR DESCRIPTION
Ensure that rvalue-ref elements of rvalue-tuples end up as rvalue-ref elements of the tuple cat.

The `cat_element_t` is very ugly, should be something niceer.

Closes #77.