### PR TITLE
Add `std::array` as a product type.

### DIFF
--- a/include/kumi/utils/std.hpp
+++ b/include/kumi/utils/std.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <kumi/utils/concepts.hpp>
+#include <kumi/utils/traits.hpp>
+#include <array>
 #include <type_traits>
 #include <utility>
 
@@ -48,5 +50,11 @@ struct std::basic_common_reference<kumi::tuple<Ts...>, kumi::tuple<Us...>, TQual
   using type = kumi::tuple<std::common_reference_t<TQual<Ts>, UQual<Us>>...>;
 };
 #endif
+
+//==================================================================================================
+// Standard array support
+//==================================================================================================
+template< typename T, std::size_t N >
+struct kumi::is_product_type<std::array<T , N>> : std::true_type {};
 
 #endif

--- a/standalone/kumi/tuple.hpp
+++ b/standalone/kumi/tuple.hpp
@@ -585,6 +585,7 @@ namespace kumi
     }
   }
 }
+#include <array>
 #include <type_traits>
 #include <utility>
 #if !defined(KUMI_DOXYGEN_INVOKED)
@@ -614,6 +615,8 @@ struct std::basic_common_reference<kumi::tuple<Ts...>, kumi::tuple<Us...>, TQual
   using type = kumi::tuple<std::common_reference_t<TQual<Ts>, UQual<Us>>...>;
 };
 #endif
+template< typename T, std::size_t N >
+struct kumi::is_product_type<std::array<T , N>> : std::true_type {};
 #endif
 #include <iosfwd>
 #include <type_traits>

--- a/test/doc/as_tuple.cpp
+++ b/test/doc/as_tuple.cpp
@@ -4,19 +4,49 @@
   SPDX-License-Identifier: BSL-1.0
 **/
 #include <kumi/tuple.hpp>
+#include <concepts>
+#include <cstdint>
 #include <type_traits>
-#include <array>
+#include <utility>
 
-// std::array supports structured bindings so we just need to opt-in the Product Type semantic
-template<typename T, std::size_t N>
-struct  kumi::is_product_type<std::array<T,N>> : std::true_type
+struct vec3
+{
+  float x, y, z;
+};
+
+template<std::size_t I>
+decltype(auto) get(vec3 const& v) noexcept
+{
+  if constexpr(I==0) return v.x;
+  if constexpr(I==1) return v.y;
+  if constexpr(I==2) return v.z;
+}
+
+template<std::size_t I>
+decltype(auto) get(vec3& v) noexcept
+{
+  if constexpr(I==0) return v.x;
+  if constexpr(I==1) return v.y;
+  if constexpr(I==2) return v.z;
+}
+
+// Opt-in for Product Type semantic
+template<>
+struct kumi::is_product_type<vec3> : std::true_type
 {};
+
+// Adapt as structured bindable type
+template<>
+struct  std::tuple_size<vec3>
+      : std::integral_constant<std::size_t,3> {};
+
+template<std::size_t I> struct std::tuple_element<I,vec3> { using type = float; };
 
 int main()
 {
-  using three_floats   = kumi::as_tuple_t<std::array<float,3>>;
+  using three_floats   = kumi::as_tuple_t<vec3>;
   using single_type    = kumi::as_tuple_t<float>;
-  using three_pointers = kumi::as_tuple_t<std::array<float,3>, std::add_pointer>;
+  using three_pointers = kumi::as_tuple_t<vec3, std::add_pointer>;
   using single_pointer = kumi::as_tuple_t<float, std::add_pointer>;
 
   static_assert( std::same_as<three_floats  , kumi::tuple<float ,float ,float > >);

--- a/test/doc/to_tuple.cpp
+++ b/test/doc/to_tuple.cpp
@@ -4,17 +4,47 @@
   SPDX-License-Identifier: BSL-1.0
 **/
 #include <kumi/tuple.hpp>
+#include <cstdint>
 #include <iostream>
-#include <array>
+#include <type_traits>
+#include <utility>
 
-// std::array supports structured bindings so we just need to opt-in the Product Type semantic
-template<typename T, std::size_t N>
-struct  kumi::is_product_type<std::array<T,N>> : std::true_type
+struct pixel
+{
+  int r, g, b;
+};
+
+template<std::size_t I>
+decltype(auto) get(pixel const& p) noexcept
+{
+  if constexpr(I==0) return p.r;
+  if constexpr(I==1) return p.g;
+  if constexpr(I==2) return p.b;
+}
+
+template<std::size_t I>
+decltype(auto) get(pixel& p) noexcept
+{
+  if constexpr(I==0) return p.r;
+  if constexpr(I==1) return p.g;
+  if constexpr(I==2) return p.b;
+}
+
+// Opt-in for Product Type semantic
+template<>
+struct kumi::is_product_type<pixel> : std::true_type
 {};
+
+// Adapt as structured bindable type
+template<>
+struct  std::tuple_size<pixel>
+      : std::integral_constant<std::size_t,3> {};
+
+template<std::size_t I> struct std::tuple_element<I,pixel> { using type = int; };
 
 int main()
 {
-  std::array<int,3> a = { 37, 15, 27};
+  pixel a = { 37, 15, 27 };
   auto b = kumi::to_tuple(a);
 
   std::cout << b << "\n";

--- a/test/unit/adapt.cpp
+++ b/test/unit/adapt.cpp
@@ -8,14 +8,7 @@
 #define TTS_MAIN
 #include <kumi/tuple.hpp>
 #include <tts/tts.hpp>
-#include <array>
 
-// --
-// -- Adapt a non-modifiable type
-// -- std::array already is already set for structured bindings so we just need to opt-in
-// --
-template<typename T, std::size_t N>
-struct kumi::is_product_type<std::array<T,N>> : std::true_type {};
 
 // --
 // -- Make a pre adapted type

--- a/test/unit/is_homogeneous.cpp
+++ b/test/unit/is_homogeneous.cpp
@@ -8,6 +8,7 @@
 #define TTS_MAIN
 #include <kumi/tuple.hpp>
 #include <tts/tts.hpp>
+#include <array>
 #include <concepts>
 
 TTS_CASE("Check is_homogeneous for kumi::tuple")
@@ -58,11 +59,6 @@ TTS_CASE("Check is_homogeneous for kumi::tuple derived types")
   TTS_CONSTEXPR_EXPECT_NOT((trivial_product_type<int,false>::is_homogeneous                ));
   TTS_CONSTEXPR_EXPECT_NOT((kumi::homogeneous_product_type<trivial_product_type<int,false>>));
 };
-
-#include <array>
-
-template<typename T, std::size_t N>
-struct kumi::is_product_type<std::array<T,N>> : std::true_type {};
 
 struct some_box
 {


### PR DESCRIPTION
Adds `std::array` as product type in `kumi/utils/std.hpp` header. Already was tested. Assuming the #include <kumi/tuple.hpp> in the tests are the standalone complete package, might be wrong!