### PR TITLE
Make extract algorithm forward tuple.

### DIFF
--- a/include/kumi/algorithm/extract.hpp
+++ b/include/kumi/algorithm/extract.hpp
@@ -40,14 +40,14 @@ namespace kumi
   template<std::size_t I0, std::size_t I1, product_type Tuple>
   requires( (I0 <= size_v<Tuple>) && (I1 <= size_v<Tuple>) )
   [[nodiscard]] constexpr
-  auto extract( Tuple const& t
+  auto extract( Tuple && t
               , [[maybe_unused]] index_t<I0> i0
               , [[maybe_unused]] index_t<I1> i1
               ) noexcept
   {
     return [&]<std::size_t... N>(std::index_sequence<N...>)
     {
-      return kumi::tuple<std::tuple_element_t<N + I0, Tuple>...> {get<N + I0>(t)...};
+      return kumi::tuple<element_t<N + I0, Tuple &&>...> {get<N + I0>(KUMI_FWD(t))...};
     }
     (std::make_index_sequence<I1 - I0>());
   }
@@ -55,9 +55,9 @@ namespace kumi
   //! @overload
   template<std::size_t I0, product_type Tuple>
   requires(I0<= size_v<Tuple>)
-  KUMI_TRIVIAL_NODISCARD constexpr  auto extract(Tuple const& t, index_t<I0> i0) noexcept
+  KUMI_TRIVIAL_NODISCARD constexpr auto extract(Tuple && t, index_t<I0> i0) noexcept
   {
-    return extract(t,i0, index<size_v<Tuple>>);
+    return extract(KUMI_FWD(t), i0, index<size_v<Tuple>>);
   }
 
   //================================================================================================
@@ -91,11 +91,11 @@ namespace kumi
   //================================================================================================
   template<std::size_t I0, product_type Tuple>
   requires(I0 <= size_v<Tuple>)
-  [[nodiscard]] constexpr auto split( Tuple const& t
+  [[nodiscard]] constexpr auto split( Tuple && t
                                     , [[maybe_unused]] index_t<I0> i0
                                     ) noexcept
   {
-    return kumi::make_tuple(extract(t,index<0>, index<I0>), extract(t,index<I0>));
+    return kumi::make_tuple(extract(KUMI_FWD(t), index<0>, index<I0>), extract(KUMI_FWD(t), index<I0>));
   }
 
   namespace result

--- a/test/unit/extract.cpp
+++ b/test/unit/extract.cpp
@@ -64,3 +64,19 @@ TTS_CASE("Check tuple::extract constexpr behavior")
   TTS_CONSTEXPR_EQUAL((kumi::extract(t,4_c))      , kumi::tuple {}                  );
   TTS_CONSTEXPR_EQUAL((kumi::extract(t,4_c, 4_c)) , kumi::tuple {}                  );
 };
+
+TTS_CASE("Check tuple::extract forwarding behavior")
+{
+  using namespace kumi::literals;
+
+  struct moveonly{
+    moveonly() = default;
+    moveonly(const moveonly &) = delete;
+    moveonly(moveonly &&) = default;
+    moveonly &operator=(const moveonly &) = delete;
+    moveonly &operator=(moveonly &&) = default;
+  };
+
+  kumi::tuple t = {moveonly{}, 3., 'f'};
+  TTS_EXPECT_COMPILES(t, { kumi::extract(std::move(t),0_c); });
+};


### PR DESCRIPTION
Use forwarding for `extract`, use `kumi::element_t` instead of `std::tuple_element_t` and add a test.

Didn't constrain the algo, so didn't add test for compilation failure.