### PR TITLE
Fixup `FetchContent` docs.

### DIFF
--- a/doc/setup.hpp
+++ b/doc/setup.hpp
@@ -69,7 +69,6 @@
   project(kumi-fetch LANGUAGES CXX)
 
   include(FetchContent)
-  set(KUMI_BUILD_TEST OFF)
   FetchContent_Declare(kumi GIT_REPOSITORY "https://github.com/jfalcou/kumi.git" GIT_TAG main)
   FetchContent_MakeAvailable(kumi)
 

--- a/doc/setup.hpp
+++ b/doc/setup.hpp
@@ -69,6 +69,7 @@
   project(kumi-fetch LANGUAGES CXX)
 
   include(FetchContent)
+  set(KUMI_BUILD_TEST OFF)
   FetchContent_Declare(kumi GIT_REPOSITORY "https://github.com/jfalcou/kumi.git" GIT_TAG main)
   FetchContent_MakeAvailable(kumi)
 

--- a/doc/setup.hpp
+++ b/doc/setup.hpp
@@ -69,7 +69,7 @@
   project(kumi-fetch LANGUAGES CXX)
 
   include(FetchContent)
-  FetchContent_Declare(kumi GIT_REPOSITORY "https://github.com/jfalcou/kumi.git")
+  FetchContent_Declare(kumi GIT_REPOSITORY "https://github.com/jfalcou/kumi.git" GIT_TAG main)
   FetchContent_MakeAvailable(kumi)
 
   add_executable(test_kumi ../main.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,9 +9,9 @@ set(root "${CMAKE_SOURCE_DIR}/test")
 ##======================================================================================================================
 ## Documentation tests
 ##======================================================================================================================
-copa_glob_unit(QUIET PATTERN "doc/*.cpp"  INTERFACE kumi_docs)
+copa_glob_unit(QUIET PATTERN "doc/*.cpp"  INTERFACE kumi_docs OPT_RELATIVE ${CMAKE_CURRENT_SOURCE_DIR})
 
 ##======================================================================================================================
 ## Unit tests
 ##======================================================================================================================
-copa_glob_unit(QUIET PATTERN "unit/*.cpp" INTERFACE kumi_test)
+copa_glob_unit(QUIET PATTERN "unit/*.cpp" INTERFACE kumi_test OPT_RELATIVE ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
Make sure GIT_TAG is set in FetchContent docs, else will default to `master` which doesn't exist.

Temporarily disable `KUMI_BUILD_TEST`. Not sure what the good default is for `FetchContent`, as I haven't used it much, but currently you might get errors when also building tests due to <https://github.com/jfalcou/copacabana/blob/main/copacabana/cmake/make_unit.cmake#L135>, see commit message in 612ec00d4bfe5609b29685b073c9382d98aa4b80 for details.

Maybe instead of changing the `copacabana` default (as suggested in the commit message), one could explicitly specify the `OPT_RELATIVE` in `kumi`.