### PR TITLE
Feat/builder

### DIFF
--- a/include/kumi/algorithm/cat.hpp
+++ b/include/kumi/algorithm/cat.hpp
@@ -7,6 +7,8 @@
 //==================================================================================================
 #pragma once
 
+#include <kumi/detail/builder.hpp>
+
 namespace kumi
 {
   //================================================================================================
@@ -56,16 +58,20 @@ namespace kumi
 
         return that;
       }();
+    
+      using res_type = kumi::result::common_product_type_t<std::remove_cvref_t<Tuples>...>;
 
       return [&]<std::size_t... N>(auto&& tuples, std::index_sequence<N...>)
       {
         using rts  = std::remove_cvref_t<decltype(tuples)>;
-        using type =  kumi::tuple
-                      < std::tuple_element_t< pos.e[N]
-                                            , std::remove_cvref_t<std::tuple_element_t<pos.t[N],rts>>
-                                            >...
-                      >;
-        return type{get<pos.e[N]>(get<pos.t[N]>(KUMI_FWD(tuples)))...};
+        
+        using final_t = _::builder_t<res_type
+                        , std::tuple_element_t<pos.e[N]
+                            , std::remove_cvref_t<std::tuple_element_t<pos.t[N], rts>>
+                            >...
+                        >;
+
+        return final_t{ get<pos.e[N]>(get<pos.t[N]>(KUMI_FWD(tuples)))... };
       }(kumi::forward_as_tuple(KUMI_FWD(ts)...), std::make_index_sequence<count-1>{});
     }
   }

--- a/include/kumi/algorithm/extract.hpp
+++ b/include/kumi/algorithm/extract.hpp
@@ -7,6 +7,8 @@
 //==================================================================================================
 #pragma once
 
+#include <kumi/detail/builder.hpp>
+
 namespace kumi
 {
   //================================================================================================
@@ -47,7 +49,10 @@ namespace kumi
   {
     return [&]<std::size_t... N>(std::index_sequence<N...>)
     {
-      return kumi::tuple<std::tuple_element_t<N + I0, Tuple>...> {get<N + I0>(t)...};
+        using final_t = _::builder_t<std::remove_cvref_t<Tuple>
+                        , std::tuple_element_t<N + I0, Tuple>...>;
+
+        return final_t{ get<N + I0>(t)... };
     }
     (std::make_index_sequence<I1 - I0>());
   }
@@ -95,7 +100,8 @@ namespace kumi
                                     , [[maybe_unused]] index_t<I0> i0
                                     ) noexcept
   {
-    return kumi::make_tuple(extract(t,index<0>, index<I0>), extract(t,index<I0>));
+    return _::builder<std::remove_cvref_t<Tuple>>
+            ::make(extract(t,index<0>, index<I0>), extract(t,index<I0>));
   }
 
   namespace result

--- a/include/kumi/algorithm/flatten.hpp
+++ b/include/kumi/algorithm/flatten.hpp
@@ -7,6 +7,8 @@
 //==================================================================================================
 #pragma once
 
+#include <kumi/detail/builder.hpp>
+
 namespace kumi
 {
   //================================================================================================
@@ -42,7 +44,10 @@ namespace kumi
                             auto v_or_t = []<typename V>(V&& v)
                             {
                               if constexpr(product_type<V>) return KUMI_FWD(v);
-                              else                          return kumi::tuple{KUMI_FWD(v)};
+                              else  
+                              {
+                                return kumi::tuple{KUMI_FWD(v)};
+                              }
                             };
 
                             return cat( v_or_t(KUMI_FWD(m))... );

--- a/include/kumi/algorithm/map.hpp
+++ b/include/kumi/algorithm/map.hpp
@@ -7,6 +7,8 @@
 //==================================================================================================
 #pragma once
 
+#include <kumi/detail/builder.hpp>
+
 namespace kumi
 {
   //================================================================================================
@@ -56,7 +58,8 @@ namespace kumi
 
       return [&]<std::size_t... I>(std::index_sequence<I...>)
       {
-        return kumi::make_tuple(call(index<I>, KUMI_FWD(t0), KUMI_FWD(others)...)...);
+        return _::builder<std::remove_cvref_t<Tuple>>
+                ::make(call(index<I>, KUMI_FWD(t0), KUMI_FWD(others)...)...);
       }(std::make_index_sequence<size<Tuple>::value>());
     }
   }
@@ -121,7 +124,8 @@ namespace kumi
 
       return [&]<std::size_t... I>(std::index_sequence<I...>)
       {
-        return kumi::make_tuple(call(index<I>, KUMI_FWD(t0), KUMI_FWD(others)...)...);
+        return _::builder<std::remove_cvref_t<Tuple>>
+                ::make(call(index<I>, KUMI_FWD(t0), KUMI_FWD(others)...)...);
       }(std::make_index_sequence<size<Tuple>::value>());
     }
   }

--- a/include/kumi/algorithm/partition.hpp
+++ b/include/kumi/algorithm/partition.hpp
@@ -7,6 +7,8 @@
 //==================================================================================================
 #pragma once
 
+#include <kumi/detail/builder.hpp>
+
 namespace kumi
 {
   //================================================================================================
@@ -55,13 +57,17 @@ namespace kumi
 
     auto select = [&]<typename O, std::size_t... I>(O, std::index_sequence<I...>)
     {
-      using type = kumi::tuple<std::tuple_element_t< pos.t[O::value+I], std::remove_cvref_t<decltype(tup)>>...>;
+      using rts = std::remove_cvref_t<decltype(tup)>;
+      using type = _::builder_t<rts, std::tuple_element_t< pos.t[O::value+I], rts>...>;
       return type{get<pos.t[O::value+I]>(KUMI_FWD(tup))...};
     };
+    
+    using type = _::builder_t<std::remove_cvref_t<T>, decltype(select(kumi::index<0>       , std::make_index_sequence<pos.cut>{}))
+                                                    , decltype(select(kumi::index<pos.cut> , std::make_index_sequence<kumi::size_v<T> - pos.cut>{}))>;
 
-    return kumi::tuple{ select(kumi::index<0>      , std::make_index_sequence<pos.cut>{})
-                      , select(kumi::index<pos.cut>, std::make_index_sequence<kumi::size<T>::value - pos.cut>{})
-                      };
+    return type{ select(kumi::index<0>      , std::make_index_sequence<pos.cut>{})
+               , select(kumi::index<pos.cut>, std::make_index_sequence<kumi::size<T>::value - pos.cut>{})
+               };
   }
 
   namespace result

--- a/include/kumi/algorithm/push_pop.hpp
+++ b/include/kumi/algorithm/push_pop.hpp
@@ -7,6 +7,8 @@
 //==================================================================================================
 #pragma once
 
+#include <kumi/detail/builder.hpp>
+
 namespace kumi
 {
 
@@ -39,7 +41,7 @@ namespace kumi
   {
     return [&]<std::size_t... I>(std::index_sequence<I...>)
     {
-      return kumi::make_tuple(KUMI_FWD(v), get<I>(KUMI_FWD(t))...);
+      return _::builder<std::remove_cvref_t<Tuple>>::make( KUMI_FWD(v), get<I>(KUMI_FWD(t))...);
     }
     (std::make_index_sequence<Tuple::size()>());
   }
@@ -103,7 +105,7 @@ namespace kumi
   {
     return [&]<std::size_t... I>(std::index_sequence<I...>)
     {
-      return kumi::make_tuple(get<I>(KUMI_FWD(t))..., KUMI_FWD(v));
+      return _::builder<std::remove_cvref_t<Tuple>>::make(get<I>(KUMI_FWD(t))..., KUMI_FWD(v));
     }
     (std::make_index_sequence<Tuple::size()>());
   }

--- a/include/kumi/algorithm/reorder.hpp
+++ b/include/kumi/algorithm/reorder.hpp
@@ -38,11 +38,13 @@ namespace kumi
   //! ## Example
   //! @include doc/reorder.cpp
   //================================================================================================
+  #include <kumi/detail/builder.hpp>
+
   template<std::size_t... Idx, product_type Tuple>
   requires((Idx < size_v<Tuple>) && ...)
   KUMI_TRIVIAL_NODISCARD constexpr auto reorder(Tuple &&t)
   {
-    return kumi::make_tuple( get<Idx>(KUMI_FWD(t))...);
+    return _::builder<std::remove_cvref_t<Tuple>>::make( get<Idx>(KUMI_FWD(t))... );
   }
 
   namespace result

--- a/include/kumi/algorithm/reverse.hpp
+++ b/include/kumi/algorithm/reverse.hpp
@@ -7,6 +7,8 @@
 //==================================================================================================
 #pragma once
 
+#include <kumi/detail/builder.hpp>
+
 namespace kumi
 {
   //================================================================================================
@@ -40,7 +42,7 @@ namespace kumi
     {
       return [&]<std::size_t... I>(std::index_sequence<I...>)
       {
-        return kumi::make_tuple(get<(size_v<Tuple> - 1 - I)>(KUMI_FWD(t))...);
+        return _::builder<std::remove_cvref_t<Tuple>>::make(get<(size_v<Tuple> - 1 - I)>(KUMI_FWD(t))...);
       }
       (std::make_index_sequence<size<Tuple>::value>());
     }

--- a/include/kumi/algorithm/transpose.hpp
+++ b/include/kumi/algorithm/transpose.hpp
@@ -7,6 +7,8 @@
 //==================================================================================================
 #pragma once
 
+#include <kumi/detail/builder.hpp>
+
 namespace kumi
 {
   //================================================================================================
@@ -40,10 +42,10 @@ namespace kumi
       return [&]<std::size_t... I>(std::index_sequence<I...>)
       {
         constexpr auto uz = []<typename N>(N const &, auto const &u) {
-          return apply([](auto const &...m) { return kumi::make_tuple(get<N::value>(m)...); }, u);
+          return apply([](auto const &...m) { return _::builder<std::remove_cvref_t<Tuple>>::make(get<N::value>(m)...); }, u);
         };
 
-        return kumi::make_tuple(uz(index_t<I> {}, t)...);
+        return _::builder<std::remove_cvref_t<Tuple>>::make(uz(index_t<I> {}, t)...);
       }
       (std::make_index_sequence<size<element_t<0,Tuple>>::value>());
     }

--- a/include/kumi/algorithm/zip.hpp
+++ b/include/kumi/algorithm/zip.hpp
@@ -7,6 +7,8 @@
 //==================================================================================================
 #pragma once
 
+#include <kumi/detail/builder.hpp>
+
 namespace kumi
 {
   //================================================================================================
@@ -36,7 +38,12 @@ namespace kumi
   template<product_type T0, sized_product_type<size_v<T0>>... Ts>
   [[nodiscard]] constexpr auto zip(T0 const &t0, Ts const &...ts)
   {
-    return kumi::map( [](auto const &m0, auto const &...ms) { return kumi::make_tuple(m0, ms...); }
+    using res_type = kumi::result::common_product_type_t<std::remove_cvref_t<T0>, std::remove_cvref_t<Ts>...>;
+
+    return kumi::map( [](auto const &m0, auto const &...ms) 
+                    { 
+                        return _::builder<res_type>::make(m0, ms...);
+                    }
                     , t0,ts...
                     );
   }

--- a/include/kumi/detail/builder.hpp
+++ b/include/kumi/detail/builder.hpp
@@ -19,7 +19,6 @@ namespace kumi
     };
 
     template<template<class ...> class Box, typename... Ts>
-    requires requires { typename Box<>; }
     struct template_of<Box<Ts...>>
     {
       using type = Box<>;
@@ -58,6 +57,8 @@ namespace kumi::_
 {
   template<typename T> struct builder
   {
+    static constexpr bool is_primary = true;  
+    
     template<typename... Ts>
     using to = kumi::tuple<Ts...>;
 
@@ -71,6 +72,8 @@ namespace kumi::_
   template<template<class...> class Box, typename... Ts>
   struct builder<Box<Ts...>>
   {
+    static constexpr bool is_primary = false; 
+    
     template<typename... Us>
     using to = Box<Us...>;
 

--- a/include/kumi/detail/builder.hpp
+++ b/include/kumi/detail/builder.hpp
@@ -1,0 +1,86 @@
+//======================================================================================================================
+/*
+  KUMI - Compact Tuple Tools
+  Copyright : KUMI Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//======================================================================================================================
+#pragma once
+
+#include<kumi/utils/concepts.hpp>
+
+namespace kumi
+{
+  namespace result
+  {
+    template<typename T> struct template_of
+    {
+        using type = kumi::tuple<>;
+    };
+
+    template<template<class ...> class Box, typename... Ts>
+    requires requires { typename Box<>; }
+    struct template_of<Box<Ts...>>
+    {
+      using type = Box<>;
+    };
+
+    template<typename T>
+    using template_of_t = typename template_of<T>::type;
+  }
+    
+
+  template<typename T, typename... Ts>
+  constexpr auto common_product_type()
+  {
+      if constexpr((std::is_same_v< result::template_of_t<T>,
+                                    result::template_of_t<Ts>
+                                > && ...))
+          return result::template_of_t<T>{};
+      else
+          return kumi::tuple<>{};
+  }
+
+  namespace result
+  {
+    template<typename T, typename... Ts>
+    struct common_product_type
+    {
+        using type = decltype( kumi::common_product_type<T, Ts...>() );
+    };
+
+    template<typename... Ts>
+    using common_product_type_t = typename common_product_type<Ts...>::type;
+  }
+}
+
+namespace kumi::_
+{
+  template<typename T> struct builder
+  {
+    template<typename... Ts>
+    using to = kumi::tuple<Ts...>;
+
+    template<typename...Args>
+    static constexpr auto make(Args&&... args)
+    {
+      return kumi::tuple{ KUMI_FWD(args)... };
+    }
+  };
+
+  template<template<class...> class Box, typename... Ts>
+  struct builder<Box<Ts...>>
+  {
+    template<typename... Us>
+    using to = Box<Us...>;
+
+    template<typename... Args>
+    static constexpr auto make(Args&&... args)
+    {
+      return Box{ KUMI_FWD(args)... };
+    } 
+  }; 
+
+  template <typename T, typename... Args>
+  using builder_t = typename builder<T>::to<Args...>;
+}

--- a/include/kumi/tuple.hpp
+++ b/include/kumi/tuple.hpp
@@ -60,7 +60,7 @@ namespace kumi
     requires(I < sizeof...(Ts))
     KUMI_TRIVIAL constexpr decltype(auto) operator[]([[maybe_unused]] index_t<I> i) &noexcept
     {
-      return unwrap_field_value(_::get_leaf<I>(impl));
+      return _::get_leaf<I>(impl);
     }
 
     /// @overload
@@ -68,7 +68,7 @@ namespace kumi
     requires(I < sizeof...(Ts))
     KUMI_TRIVIAL constexpr decltype(auto) operator[](index_t<I>) &&noexcept
     {
-      return unwrap_field_value(_::get_leaf<I>(static_cast<decltype(impl) &&>(impl)));
+      return _::get_leaf<I>(static_cast<decltype(impl) &&>(impl));
     }
 
     /// @overload
@@ -76,7 +76,7 @@ namespace kumi
     requires(I < sizeof...(Ts))
     KUMI_TRIVIAL constexpr decltype(auto) operator[](index_t<I>) const &&noexcept
     {
-      return unwrap_field_value(_::get_leaf<I>(static_cast<decltype(impl) const &&>(impl)));
+      return _::get_leaf<I>(static_cast<decltype(impl) const &&>(impl));
     }
 
     /// @overload
@@ -84,7 +84,7 @@ namespace kumi
     requires(I < sizeof...(Ts))
     KUMI_TRIVIAL constexpr decltype(auto) operator[](index_t<I>) const &noexcept
     {
-      return unwrap_field_value(_::get_leaf<I>(impl));
+      return _::get_leaf<I>(impl);
     }
  
     //==============================================================================================

--- a/test/unit/access.cpp
+++ b/test/unit/access.cpp
@@ -55,32 +55,32 @@ TTS_CASE("Check access to kumi::tuple with named fields via indexing")
   kumi::tuple t3 = {"x"_f = 1., "y"_f = 2.f, "z"_f = 3};
   kumi::tuple t4 = {"x"_f = '1', "y"_f = 2., "z"_f = 3.f, "t"_f = 4};
   
-  t1[0_c] = 42;
-  TTS_EQUAL(t1[0_c], 42);
+  t1[0_c] = ("x"_f = 42);
+  TTS_EQUAL(t1[0_c].value, 42);
 
-  t2[0_c] = 4.2f;
-  t2[1_c] = 69;
-  TTS_EQUAL(t2[0_c], 4.2f);
-  TTS_EQUAL(t2[1_c], 69);
+  t2[0_c] = ( "x"_f = 4.2f);
+  t2[1_c] = ( "y"_f = 69  );
+  TTS_EQUAL(t2[0_c].value, 4.2f);
+  TTS_EQUAL(t2[1_c].value, 69);
 
-  t3[0_c] = 13.37;
-  t3[1_c] = 4.2f;
-  t3[2_c] = 40;
-  TTS_EQUAL(t3[0_c], 13.37);
-  TTS_EQUAL(t3[1_c], 4.2f);
-  TTS_EQUAL(t3[2_c], 40);
+  t3[0_c] = ( "x"_f = 13.37);
+  t3[1_c] = ( "y"_f = 4.2f );
+  t3[2_c] = ( "z"_f = 40   );
+  TTS_EQUAL(t3[0_c].value, 13.37);
+  TTS_EQUAL(t3[1_c].value, 4.2f);
+  TTS_EQUAL(t3[2_c].value, 40);
 
-  t4[0_c] = 'z';
-  t4[1_c] = 6.9;
-  t4[2_c] = 4.2f;
-  t4[3_c] = 1337;
-  TTS_EQUAL(t4[0_c], 'z');
-  TTS_EQUAL(t4[1_c], 6.9);
-  TTS_EQUAL(t4[2_c], 4.2f);
-  TTS_EQUAL(t4[3_c], 1337);
+  t4[0_c] = ( "x"_f = 'z' );
+  t4[1_c] = ( "y"_f = 6.9 );
+  t4[2_c] = ( "z"_f = 4.2f);
+  t4[3_c] = ( "t"_f =1337 );
+  TTS_EQUAL(t4[0_c].value, 'z');
+  TTS_EQUAL(t4[1_c].value, 6.9);
+  TTS_EQUAL(t4[2_c].value, 4.2f);
+  TTS_EQUAL(t4[3_c].value, 1337);
 
-  TTS_EQUAL(kumi::get<0>(std::move(t3)), 13.37);
-  TTS_EQUAL(std::move(t3)[1_c], 4.2f);
+  TTS_EQUAL(kumi::get<0>(std::move(t3)).value, 13.37);
+  TTS_EQUAL(std::move(t3)[1_c].value, 4.2f);
 };
 
 TTS_CASE("Check access to kumi::tuple with names via names")
@@ -177,19 +177,19 @@ TTS_CASE("Check constexpr access to kumi::tuple with named fields via indexing")
   constexpr kumi::tuple t3 = {"x"_f = 1., "y"_f = 2.f, "z"_f = 3};
   constexpr kumi::tuple t4 = {"x"_f = '1', "y"_f = 2., "z"_f = 3.f, "t"_f = 4};
   
-  TTS_CONSTEXPR_EQUAL(get<0>(t1), t1[0_c]);
+  TTS_CONSTEXPR_EQUAL(get<0>(t1).value, t1[0_c].value);
 
-  TTS_CONSTEXPR_EQUAL(get<0>(t2), t2[0_c]);
-  TTS_CONSTEXPR_EQUAL(get<1>(t2), t2[1_c]);
+  TTS_CONSTEXPR_EQUAL(get<0>(t2).value, t2[0_c].value);
+  TTS_CONSTEXPR_EQUAL(get<1>(t2).value, t2[1_c].value);
 
-  TTS_CONSTEXPR_EQUAL(get<0>(t3), t3[0_c]);
-  TTS_CONSTEXPR_EQUAL(get<1>(t3), t3[1_c]);
-  TTS_CONSTEXPR_EQUAL(get<2>(t3), t3[2_c]);
+  TTS_CONSTEXPR_EQUAL(get<0>(t3).value, t3[0_c].value);
+  TTS_CONSTEXPR_EQUAL(get<1>(t3).value, t3[1_c].value);
+  TTS_CONSTEXPR_EQUAL(get<2>(t3).value, t3[2_c].value);
 
-  TTS_CONSTEXPR_EQUAL(get<0>(t4), t4[0_c]);
-  TTS_CONSTEXPR_EQUAL(get<1>(t4), t4[1_c]);
-  TTS_CONSTEXPR_EQUAL(get<2>(t4), t4[2_c]);
-  TTS_CONSTEXPR_EQUAL(get<3>(t4), t4[3_c]);
+  TTS_CONSTEXPR_EQUAL(get<0>(t4).value, t4[0_c].value);
+  TTS_CONSTEXPR_EQUAL(get<1>(t4).value, t4[1_c].value);
+  TTS_CONSTEXPR_EQUAL(get<2>(t4).value, t4[2_c].value);
+  TTS_CONSTEXPR_EQUAL(get<3>(t4).value, t4[3_c].value);
 };
 
 TTS_CASE("Check constexpr access to kumi::tuple with named fields via names")

--- a/test/unit/builder.cpp
+++ b/test/unit/builder.cpp
@@ -1,0 +1,20 @@
+//==================================================================================================
+/*
+  KUMI - Compact Tuple Tools
+  Copyright : KUMI Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#define TTS_MAIN
+#include <kumi/tuple.hpp>
+#include <tts/tts.hpp>
+
+#include<kumi/detail/builder.hpp>
+#include <array>
+
+TTS_CASE("Check _::builder<Tuple...> behavior")
+{
+    TTS_EQUAL((kumi::_::builder<kumi::tuple<int, float>>::is_primary), false);
+    TTS_EQUAL((kumi::_::builder<int>::is_primary), true);
+    TTS_EQUAL((kumi::_::builder<std::array<int, 30>>::is_primary), true);
+};


### PR DESCRIPTION
Introducing builder instead of hard-coded `kumi::tuple` as the return type for the algorithms in order to enable other product types to work.