### PR TITLE
Fix issue in builder

### DIFF
--- a/include/kumi/algorithm/extract.hpp
+++ b/include/kumi/algorithm/extract.hpp
@@ -100,7 +100,7 @@ namespace kumi
                                     , [[maybe_unused]] index_t<I0> i0
                                     ) noexcept
   {
-    return _::builder<std::remove_cvref_t<Tuple>>
+    return _::builder<Tuple>
             ::make(extract(t,index<0>, index<I0>), extract(t,index<I0>));
   }
 

--- a/include/kumi/algorithm/push_pop.hpp
+++ b/include/kumi/algorithm/push_pop.hpp
@@ -41,7 +41,7 @@ namespace kumi
   {
     return [&]<std::size_t... I>(std::index_sequence<I...>)
     {
-      return _::builder<std::remove_cvref_t<Tuple>>::make( KUMI_FWD(v), get<I>(KUMI_FWD(t))...);
+      return _::builder<Tuple>::make( KUMI_FWD(v), get<I>(KUMI_FWD(t))...);
     }
     (std::make_index_sequence<Tuple::size()>());
   }
@@ -73,7 +73,7 @@ namespace kumi
   [[nodiscard]] KUMI_ABI constexpr auto pop_front(Tuple const& t)
   {
     if constexpr(Tuple::size()>0) return extract(t, index<1>);
-    else                          return _::builder<std::remove_cvref_t<Tuple>>::make();
+    else                          return _::builder<Tuple>::make();
   }
 
   //================================================================================================
@@ -105,7 +105,7 @@ namespace kumi
   {
     return [&]<std::size_t... I>(std::index_sequence<I...>)
     {
-      return _::builder<std::remove_cvref_t<Tuple>>::make(get<I>(KUMI_FWD(t))..., KUMI_FWD(v));
+      return _::builder<Tuple>::make(get<I>(KUMI_FWD(t))..., KUMI_FWD(v));
     }
     (std::make_index_sequence<Tuple::size()>());
   }
@@ -137,7 +137,7 @@ namespace kumi
   [[nodiscard]] KUMI_ABI constexpr auto pop_back(Tuple const& t)
   {
     if constexpr(Tuple::size()>1) return extract(t,index<0>, index<Tuple::size()-1>);
-    else                          return _::builder<std::remove_cvref_t<Tuple>>::make();
+    else                          return _::builder<Tuple>::make();
   }
 
   namespace result

--- a/include/kumi/detail/builder.hpp
+++ b/include/kumi/detail/builder.hpp
@@ -88,10 +88,16 @@ namespace kumi
       template<typename... Args>
       static constexpr auto make(Args&&... args)
       {
+        if constexpr ( record_type<T> ) return kumi::make_record( KUMI_FWD(args)...);
+        else                            return kumi::make_tuple ( KUMI_FWD(args)...);
+      } 
+    
+      template<typename... Args>
+      static constexpr auto build(Args&&... args)
+      {
         if constexpr ( record_type<T> ) return kumi::record{ KUMI_FWD(args)...};
         else                            return kumi::tuple { KUMI_FWD(args)...};
       } 
-
     };
 
     template <kumi::product_type T>

--- a/test/unit/builder.cpp
+++ b/test/unit/builder.cpp
@@ -16,7 +16,7 @@ namespace udt
     struct point_2D 
     {
         using is_product_type = void;
-        std::string name; int x; int y; float t;
+        kumi::str name; int x; int y; float t;
          
         template<std::size_t I>
         friend constexpr auto const& get(point_2D const& s) noexcept requires(I < 4)
@@ -39,12 +39,12 @@ namespace udt
 }
 
 template<> struct std::tuple_size<udt::point_2D> : std::integral_constant<std::size_t,4> {};
-template<> struct std::tuple_element<0,udt::point_2D> { using type = std::string;   };
+template<> struct std::tuple_element<0,udt::point_2D> { using type = kumi::str;   };
 template<> struct std::tuple_element<1,udt::point_2D> { using type = int;           };
 template<> struct std::tuple_element<2,udt::point_2D> { using type = int;           };
 template<> struct std::tuple_element<3,udt::point_2D> { using type = float;         };
 
-TTS_CASE("Check tuple_element of the output of builder")
+TTS_CASE("Check tuple_element of the output of result::builder_make_t")
 {
   using namespace kumi::literals;
 
@@ -92,9 +92,9 @@ TTS_CASE("Check tuple_element of the output of builder")
   TTS_TYPE_IS((std::tuple_element_t<3, decltype(arr)>), int);
   TTS_TYPE_IS((std::tuple_element_t<4, decltype(arr)>), int);
 
-  auto pt = kumi::_::builder<udt::point_2D>::make(std::string{"Cain"}, 1, 2, 3.0f);
-  TTS_TYPE_IS((decltype(pt)), (kumi::tuple<std::string, int, int, float>));
-  TTS_TYPE_IS((std::tuple_element_t<0, decltype(pt)>), std::string);
+  auto pt = kumi::_::builder<udt::point_2D>::make(kumi::str{"Cain"}, 1, 2, 3.0f);
+  TTS_TYPE_IS((decltype(pt)), (kumi::tuple<kumi::str, int, int, float>));
+  TTS_TYPE_IS((std::tuple_element_t<0, decltype(pt)>), kumi::str);
   TTS_TYPE_IS((std::tuple_element_t<1, decltype(pt)>), int);
   TTS_TYPE_IS((std::tuple_element_t<2, decltype(pt)>), int);
   TTS_TYPE_IS((std::tuple_element_t<3, decltype(pt)>), float);
@@ -105,4 +105,49 @@ TTS_CASE("Check tuple_element of the output of builder")
   TTS_TYPE_IS((std::tuple_element_t<0, decltype(rt)>), (kumi::field_capture<"a", int>   ));
   TTS_TYPE_IS((std::tuple_element_t<1, decltype(rt)>), (kumi::field_capture<"b", char>  ));
   TTS_TYPE_IS((std::tuple_element_t<2, decltype(rt)>), (kumi::field_capture<"c", short> ));
+
+  auto nt = kumi::_::builder<kumi::tuple<>>::make(kumi::tuple{1});
+  TTS_TYPE_IS((decltype(nt)), (kumi::tuple<kumi::tuple<int>>));
+
+  auto ft = kumi::_::builder<kumi::tuple<>>::build(kumi::tuple{1});
+  TTS_TYPE_IS((decltype(ft)), (kumi::tuple<int>));
+};
+
+TTS_CASE("Check constexpr tuple_element of the output of builder")
+{
+  using namespace kumi::literals;
+
+  constexpr auto tpl = kumi::_::builder<kumi::tuple<char, float>>::make('1', 2., 3.f);
+  TTS_TYPE_IS((decltype(tpl)), (const kumi::tuple<char, double, float>));
+  TTS_TYPE_IS((std::tuple_element_t<0, decltype(tpl)>), const char);
+  TTS_TYPE_IS((std::tuple_element_t<1, decltype(tpl)>), const double);
+  TTS_TYPE_IS((std::tuple_element_t<2, decltype(tpl)>), const float);
+
+  constexpr auto arr = kumi::_::builder<std::array<int, 5>>::make(1,2,3,4,5);
+  TTS_TYPE_IS((decltype(arr)), (const kumi::tuple<int, int, int, int, int>));
+  TTS_TYPE_IS((std::tuple_element_t<0, decltype(arr)>), const int);
+  TTS_TYPE_IS((std::tuple_element_t<1, decltype(arr)>), const int);
+  TTS_TYPE_IS((std::tuple_element_t<2, decltype(arr)>), const int);
+  TTS_TYPE_IS((std::tuple_element_t<3, decltype(arr)>), const int);
+  TTS_TYPE_IS((std::tuple_element_t<4, decltype(arr)>), const int);
+
+  constexpr auto pt = kumi::_::builder<udt::point_2D>::make(kumi::str{"Cain"}, 1, 2, 3.0f);
+  TTS_TYPE_IS((decltype(pt)), (const kumi::tuple<kumi::str, int, int, float>));
+  TTS_TYPE_IS((std::tuple_element_t<0, decltype(pt)>), const kumi::str);
+  TTS_TYPE_IS((std::tuple_element_t<1, decltype(pt)>), const int);
+  TTS_TYPE_IS((std::tuple_element_t<2, decltype(pt)>), const int);
+  TTS_TYPE_IS((std::tuple_element_t<3, decltype(pt)>), const float);
+
+  constexpr auto rt = kumi::_::builder<kumi::record<>>::make("a"_f = 2, "b"_f = 'y', "c"_f = short{77});
+  TTS_TYPE_IS((decltype(rt)), (const kumi::record< kumi::field_capture<"a", int>, kumi::field_capture<"b", char>
+                                           , kumi::field_capture<"c", short>>));
+  TTS_TYPE_IS((std::tuple_element_t<0, decltype(rt)>), (const kumi::field_capture<"a", int>   ));
+  TTS_TYPE_IS((std::tuple_element_t<1, decltype(rt)>), (const kumi::field_capture<"b", char>  ));
+  TTS_TYPE_IS((std::tuple_element_t<2, decltype(rt)>), (const kumi::field_capture<"c", short> ));
+
+  constexpr auto nt = kumi::_::builder<kumi::tuple<>>::make(kumi::tuple{1});
+  TTS_TYPE_IS((decltype(nt)), (const kumi::tuple<kumi::tuple<int>>));
+
+  constexpr auto ft = kumi::_::builder<kumi::tuple<>>::build(kumi::tuple{1});
+  TTS_TYPE_IS((decltype(ft)), (const kumi::tuple<int>));
 };

--- a/test/unit/map.cpp
+++ b/test/unit/map.cpp
@@ -27,6 +27,10 @@ TTS_CASE("Check result::map<F,Tuple...> behavior")
                 )
               , (kumi::tuple<int,int,int,double>)
               );
+
+  auto to_tuple = [](auto){ return kumi::make_tuple(1); };
+  using to_t = decltype(to_tuple);
+  TTS_TYPE_IS((kumi::result::map_t<to_t, kumi::tuple<int>>), (kumi::tuple<kumi::tuple<int>>));
 };
 
 TTS_CASE("Check map(f, {}) behavior")

--- a/test/unit/map_index.cpp
+++ b/test/unit/map_index.cpp
@@ -27,6 +27,10 @@ TTS_CASE("Check result::map_index<F,Tuple...> behavior")
                 )
               , (kumi::tuple<double,double,double,double>)
               );
+
+  auto to_tuple = [](auto, auto){ return kumi::make_tuple(1); };
+  using to_t = decltype(to_tuple);
+  TTS_TYPE_IS((kumi::result::map_index_t<to_t, kumi::tuple<int>>), (kumi::tuple<kumi::tuple<int>>));
 };
 
 TTS_CASE("Check map_index(f, {}) behavior")

--- a/test/unit/push_pop.cpp
+++ b/test/unit/push_pop.cpp
@@ -16,6 +16,7 @@ TTS_CASE("Check kumi::push_front/pop_front type computation")
   TTS_TYPE_IS((push_front_t<kumi::tuple<>,int>), kumi::tuple<int>);
   TTS_TYPE_IS((push_front_t<kumi::tuple<float>,int>),(kumi::tuple<int,float>));
   TTS_TYPE_IS((push_front_t<kumi::tuple<float,char>,int>),(kumi::tuple<int,float,char>));
+  TTS_TYPE_IS((push_front_t<kumi::tuple<>, kumi::tuple<int>>), (kumi::tuple<kumi::tuple<int>>));
 
   TTS_TYPE_IS((pop_front_t<kumi::tuple<>>), kumi::tuple<>);
   TTS_TYPE_IS((pop_front_t<kumi::tuple<float>>), kumi::tuple<>);
@@ -54,6 +55,7 @@ TTS_CASE("Check kumi::push_back/pop_back type computation")
   TTS_TYPE_IS((push_back_t<kumi::tuple<>,int>),kumi::tuple<int>);
   TTS_TYPE_IS((push_back_t<kumi::tuple<float>,int>),(kumi::tuple<float,int>));
   TTS_TYPE_IS((push_back_t<kumi::tuple<float,char>,int>),(kumi::tuple<float,char,int>));
+  TTS_TYPE_IS((push_back_t<kumi::tuple<>, kumi::tuple<int>>), (kumi::tuple<kumi::tuple<int>>));
 
   TTS_TYPE_IS((pop_back_t<kumi::tuple<>>),kumi::tuple<>);
   TTS_TYPE_IS((pop_back_t<kumi::tuple<float>>),kumi::tuple<>);

--- a/test/unit/reorder.cpp
+++ b/test/unit/reorder.cpp
@@ -17,6 +17,9 @@ TTS_CASE("Check result::reorder<Tuple,I...> behavior")
   TTS_TYPE_IS( (kumi::result::reorder_t<tuple_t,1,2,3,0>), (kumi::tuple<short,int,double,char>) );
   TTS_TYPE_IS( (kumi::result::reorder_t<tuple_t,3,3>    ), (kumi::tuple<double,double>)         );
   TTS_TYPE_IS( (kumi::result::reorder_t<tuple_t>        ), kumi::tuple<>                        );
+
+  using nested_t = kumi::tuple<kumi::tuple<int, float>, int>;
+  TTS_TYPE_IS( (kumi::result::reorder_t<nested_t, 0>), (kumi::tuple<kumi::tuple<int, float>>));
 };
 
 TTS_CASE("Check reorder<I...>(tuple) behavior")

--- a/test/unit/transpose.cpp
+++ b/test/unit/transpose.cpp
@@ -23,6 +23,9 @@ TTS_CASE("Check result::transpose<Tuple> behavior")
                                                                     >
                                                       )
               );
+
+  using nested_t = kumi::tuple<kumi::tuple<int>>;
+  TTS_TYPE_IS((kumi::result::transpose_t<nested_t>), (kumi::tuple<kumi::tuple<int>>));
 };
 
 TTS_CASE("Check tuple::transpose behavior")

--- a/test/unit/zip.cpp
+++ b/test/unit/zip.cpp
@@ -24,6 +24,9 @@ TTS_CASE("Check result::zip<Tuple...> behavior")
                               >
                 )
               );
+
+  using one_element_t = kumi::tuple<int>;
+  TTS_TYPE_IS((kumi::result::zip_t<one_element_t>), (kumi::tuple<kumi::tuple<int>>));
 };
 
 TTS_CASE("Check tuple::zip behavior")


### PR DESCRIPTION
Builder should use `make_tuple` instead of `tuple{}` to correctly construct `tuple<tuple<>>` as the latter collapses them