### PR TITLE
Make std::is_empty work as expected on tuples and record

### DIFF
--- a/include/kumi/product_types/record.hpp
+++ b/include/kumi/product_types/record.hpp
@@ -261,6 +261,23 @@ namespace kumi
     }
   };
 
+  template<> struct record<>  
+  {
+    using is_product_type   = void;
+    using is_record_type    = void;
+    static constexpr bool is_homogeneous = false;
+
+    static constexpr auto size()  noexcept { return std::size_t{0}; }
+    static constexpr auto empty() noexcept { return true;           }
+    
+    KUMI_ABI friend constexpr auto operator<=>(record<>, record<>) noexcept = default;
+
+    friend std::ostream& operator<<(std::ostream& os, record<>)
+    {
+      return os << "()";
+    }
+  };
+
   //================================================================================================
   //! @name Record Deduction Guides
   //! @{

--- a/include/kumi/product_types/tuple.hpp
+++ b/include/kumi/product_types/tuple.hpp
@@ -351,6 +351,22 @@ namespace kumi
     }
   };
 
+  template<> struct tuple<>  
+  {
+    using is_product_type = void;
+    static constexpr bool is_homogeneous = false;
+
+    static constexpr auto size()  noexcept { return std::size_t{0}; }
+    static constexpr auto empty() noexcept { return true;           }
+    
+    KUMI_ABI friend constexpr auto operator<=>(tuple<>, tuple<>) noexcept = default;
+
+    friend std::ostream& operator<<(std::ostream& os, tuple<>)
+    {
+      return os << "()";
+    }
+  };
+
   //================================================================================================
   //! @name Tuple Deduction Guides
   //! @{

--- a/test/unit/std_type_traits.cpp
+++ b/test/unit/std_type_traits.cpp
@@ -1,0 +1,33 @@
+//==================================================================================================
+/*
+  KUMI - Compact Tuple Tools
+  Copyright : KUMI Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#define TTS_MAIN
+#include <kumi/kumi.hpp>
+#include <tts/tts.hpp>
+#include <type_traits>
+
+TTS_CASE("Check std::is_empty behavior for tuple & record")
+{
+  using namespace kumi;
+
+  TTS_CONSTEXPR_EXPECT_NOT(( std::is_empty_v<tuple<int>>    ));
+  TTS_CONSTEXPR_EXPECT((     std::is_empty_v<kumi::tuple<>> ));
+
+  TTS_CONSTEXPR_EXPECT_NOT(( std::is_empty_v<record<field_capture<"toto", int>>> ));
+  TTS_CONSTEXPR_EXPECT(( std::is_empty_v<kumi::record<>> ));
+};
+
+TTS_CASE("Check std::is_aggregate behavior for tuple & record")
+{
+  using namespace kumi;
+
+  TTS_CONSTEXPR_EXPECT(( std::is_aggregate_v<tuple<int>>    ));
+  TTS_CONSTEXPR_EXPECT(( std::is_aggregate_v<kumi::tuple<>> ));
+
+  TTS_CONSTEXPR_EXPECT(( std::is_aggregate_v<record<field_capture<"toto", int>>> ));
+  TTS_CONSTEXPR_EXPECT(( std::is_aggregate_v<record<>> ));
+};


### PR DESCRIPTION
Maybe the empty tuple, the empty record and `kumi::unit` shall be implicitely convertible to one an other as they are basically the same (in the sens of the theory it makes perfect sens).
In fact the empty versions are basically `kumi::unit` with some tuple related stuff.
Maybe unit should be templated on an NTTP representing how it would show in output stream and the empty versions would then be : `template<> kumi::tuple<> : kumi::unit<"()">{}` ?