### PR TITLE
Introducing from_record & to_record

### DIFF
--- a/include/kumi/algorithm/convert.hpp
+++ b/include/kumi/algorithm/convert.hpp
@@ -78,6 +78,29 @@ namespace kumi
 
   //================================================================================================
   //! @ingroup utility
+  //! @brief Converts a kumi::record to an instance of a type that models kumi::record_type
+  //!
+  //! Constructs an instance of `Type` by passing elements of `t` to the appropriate constructor.
+  //!
+  //! @tparam Type Type to generate
+  //! @param  r    kumi::record to convert
+  //! @return An instance of `Type` constructed from each element of `t` in order.
+  //!
+  //! ## Example
+  //! @include doc/record/from_record.cpp
+  //================================================================================================
+  template<record_type Type, typename... Ts>
+  requires ( equivalent<Type, record<Ts...>> )
+  [[nodiscard]] KUMI_ABI constexpr auto from_record(record<Ts...> const &r)
+  {
+    return [&]<std::size_t... I>(std::index_sequence<I...>) 
+    { 
+      return Type{ get<name_of(as<element_t<I,Type>>{})>(r)... };
+    }(std::make_index_sequence<size_v<Type>>());
+  }
+
+  //================================================================================================
+  //! @ingroup utility
   //! @brief Converts a kumi::product_type to an instance kumi::tuple
   //!
   //! Constructs an instance kumi::tuple from the elements of the kumi::product_type parameters
@@ -105,6 +128,29 @@ namespace kumi
     {
       return tuple{ KUMI_FWD(s)[I]... };
     }(std::make_index_sequence<N>{});
+  }
+
+  //================================================================================================
+  //! @ingroup utility
+  //! @brief Converts a kumi::record_type to an instance kumi::record
+  //!
+  //! Constructs an instance kumi::record from the elements of the kumi::product_type parameters
+  //!
+  //! @param  r    kumi::product_type to convert
+  //! @return An instance of kumi::record constructed from each elements of `t` in order.
+  //!
+  //! ## Example
+  //! @include doc/record/to_record.cpp
+  //================================================================================================
+  template<record_type Type>
+  [[nodiscard]] KUMI_ABI constexpr auto to_record(Type && r)
+  {
+    if constexpr ( sized_product_type<Type, 0> ) return kumi::record{};
+    else return [&]<std::size_t...I>(std::index_sequence<I...>)
+    {
+      return record{field<name_of(as<element_t<I,Type>>{})> = 
+                      get<name_of(as<element_t<I,Type>>{})>(KUMI_FWD(r))... };
+    }(std::make_index_sequence<size_v<Type>>{});
   }
 
   //================================================================================================

--- a/include/kumi/detail/concepts.hpp
+++ b/include/kumi/detail/concepts.hpp
@@ -145,7 +145,6 @@ namespace kumi::_
   //============================================================================================== 
   template<typename From, typename To> struct is_fieldwise_constructible;
   template<typename From, typename To> struct is_fieldwise_convertible;
-  template<typename From, typename To> struct is_fieldwise_ordered;
   
   template<template<class...> class Box, typename... From, typename... To>
   struct is_fieldwise_convertible<Box<From...>, Box<To...>>

--- a/test/doc/record/from_record.cpp
+++ b/test/doc/record/from_record.cpp
@@ -1,0 +1,56 @@
+/**
+  KUMI - Compact Tuple Tools
+  Copyright : KUMI Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+#include <kumi/kumi.hpp>
+#include <iostream>
+#include <string>
+
+struct my_struct
+{
+  int         i;
+  float       f;
+  std::string name;
+};
+
+template<std::size_t I>
+decltype(auto) get(my_struct const & m) noexcept
+{
+  if constexpr (I==0) return kumi::capture_field<"i">(m.i);
+  if constexpr (I==1) return kumi::capture_field<"f">(m.f);
+  if constexpr (I==2) return kumi::capture_field<"name">(m.name);
+}
+
+template<std::size_t I>
+decltype(auto) get(my_struct & m) noexcept
+{
+  if constexpr (I==0) return kumi::capture_field<"i">(m.i);
+  if constexpr (I==1) return kumi::capture_field<"f">(m.f);
+  if constexpr (I==2) return kumi::capture_field<"name">(m.name);
+}
+
+// Opt-in for Record Type semantic
+template<>
+struct kumi::is_record_type<my_struct> : std::true_type
+{};
+
+// Adapt as structured bindable type
+template<>
+struct  std::tuple_size<my_struct> : std::integral_constant<std::size_t,3> 
+{};
+
+template<> struct std::tuple_element<0,my_struct> { using type = kumi::field_capture<"i"   , int        >; };
+template<> struct std::tuple_element<1,my_struct> { using type = kumi::field_capture<"f"   , float      >; };
+template<> struct std::tuple_element<2,my_struct> { using type = kumi::field_capture<"name", std::string>; };
+
+int main()
+{
+  using namespace kumi::literals;
+
+  auto a = kumi::make_record("f"_f=2.3475f, "name"_f="John", "i"_f=1337);
+  auto b = from_record<my_struct>( a );
+
+  std::cout << a << "\n";
+  std::cout << b.i << ' ' << b.f << ' ' << b.name << "\n";
+}

--- a/test/doc/record/to_record.cpp
+++ b/test/doc/record/to_record.cpp
@@ -1,0 +1,53 @@
+/**
+  KUMI - Compact Tuple Tools
+  Copyright : KUMI Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+#include <kumi/kumi.hpp>
+#include <cstdint>
+#include <iostream>
+#include <type_traits>
+#include <utility>
+
+struct pixel
+{
+  int r, g, b;
+};
+
+template<std::size_t I>
+decltype(auto) get(pixel const& p) noexcept
+{
+  if constexpr(I==0) return kumi::capture_field<"r">(p.r);
+  if constexpr(I==1) return kumi::capture_field<"g">(p.g);
+  if constexpr(I==2) return kumi::capture_field<"b">(p.b);
+}
+
+template<std::size_t I>
+decltype(auto) get(pixel& p) noexcept
+{
+  if constexpr(I==0) return kumi::capture_field<"r">(p.r);
+  if constexpr(I==1) return kumi::capture_field<"g">(p.g);
+  if constexpr(I==2) return kumi::capture_field<"b">(p.b);
+}
+
+// Opt-in for Record Type semantic
+template<>
+struct kumi::is_record_type<pixel> : std::true_type
+{};
+
+// Adapt as structured bindable type
+template<>
+struct  std::tuple_size<pixel> : std::integral_constant<std::size_t,3> 
+{};
+
+template<> struct std::tuple_element<0,pixel> { using type = kumi::field_capture<"r", int>; };
+template<> struct std::tuple_element<1,pixel> { using type = kumi::field_capture<"g", int>; };
+template<> struct std::tuple_element<2,pixel> { using type = kumi::field_capture<"b", int>; };
+
+int main()
+{
+  pixel a = { 37, 15, 27 };
+  auto b = kumi::to_record(a);
+
+  std::cout << b << "\n";
+}

--- a/test/unit/record/convert.cpp
+++ b/test/unit/record/convert.cpp
@@ -1,0 +1,73 @@
+
+//==================================================================================================
+/*
+  KUMI - Compact Tuple Tools
+  Copyright : KUMI Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#define TTS_MAIN
+#include <kumi/kumi.hpp>
+#include <tts/tts.hpp>
+#include "test.hpp"
+
+struct my_record_type
+{
+  std::size_t n;
+  std::size_t data;
+  constexpr auto operator<=>(my_record_type const&) const = default;
+};
+
+template<std::size_t I>
+constexpr decltype(auto) get(my_record_type const& m) noexcept
+{
+  if constexpr (I == 0) return kumi::capture_field<"a">(m.n);
+  if constexpr (I == 1) return kumi::capture_field<"data">(m.data);
+}
+
+template<std::size_t I>
+constexpr decltype(auto) get(my_record_type & m) noexcept
+{
+  if constexpr (I == 0) return kumi::capture_field<"n">(m.n);
+  if constexpr (I == 1) return kumi::capture_field<"data">(m.data);
+}
+
+template<>
+struct kumi::is_record_type<my_record_type> : std::true_type
+{};
+
+// Adapt as structured bindable type
+template<>
+struct std::tuple_size<my_record_type> : std::integral_constant<std::size_t,2> {};
+
+template<> struct std::tuple_element<0,my_record_type> { using type = kumi::field_capture<"n", std::size_t>; };
+template<> struct std::tuple_element<1,my_record_type> { using type = kumi::field_capture<"data", std::size_t>; };
+
+TTS_CASE("Check record to constructible type conversion")
+{
+  kumi::record in{"data"_f=std::size_t{13}, "n"_f=std::size_t{9}};
+
+  TTS_EQUAL ( kumi::from_record<my_record_type>(in), (my_record_type{9,13}) );
+};
+
+TTS_CASE("Check tuple to constructible type constexpr conversion")
+{
+  constexpr kumi::record in{"data"_f=std::size_t{13}, "n"_f=std::size_t{9}};
+
+  TTS_CONSTEXPR_EQUAL ( kumi::from_record<my_record_type>(in), (my_record_type{9,13}) );
+};
+
+TTS_CASE("Check type to record conversion")
+{
+  my_record_type in{9, 13};
+
+  TTS_EQUAL ( kumi::to_record(in), (kumi::record{"n"_f=std::size_t{9},"data"_f=std::size_t{13}}) );
+};
+
+TTS_CASE("Check type to tuple constexpr conversion")
+{
+  using namespace kumi::literals;
+  constexpr my_record_type in{9, 13};
+
+  TTS_CONSTEXPR_EQUAL ( kumi::to_record(in), (kumi::record{"n"_f=std::size_t{9}, "data"_f=std::size_t{13}}) );
+};


### PR DESCRIPTION
One may want to fill a struct based on a kumi::record instance even with fields in a different order hence kumi::from_record.
Similarly one might want to construct a kumi::record from a compatible struct hence kumi::to_record.