### PR TITLE
Naming coherence

### DIFF
--- a/include/kumi/algorithm/back_front.hpp
+++ b/include/kumi/algorithm/back_front.hpp
@@ -83,11 +83,11 @@ namespace kumi
 
   namespace result
   {
-    template<concepts::product_type T> struct front : raw_member<0, T>
+    template<concepts::product_type T> struct front : stored_member<0, T>
     {
     };
 
-    template<concepts::product_type T> struct back : raw_member<size_v<T> - 1, T>
+    template<concepts::product_type T> struct back : stored_member<size_v<T> - 1, T>
     {
     };
 

--- a/include/kumi/algorithm/flatten.hpp
+++ b/include/kumi/algorithm/flatten.hpp
@@ -47,7 +47,7 @@ namespace kumi
     else
     {
       constexpr auto proj = [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return function::concatenater(std::index_sequence<function::size_or_v<raw_element_t<I, T>, 1>...>{});
+        return function::concatenater(std::index_sequence<function::size_or_v<stored_element_t<I, T>, 1>...>{});
       }(std::make_index_sequence<size_v<T>>{});
 
       auto process = [&]<typename V>(auto J, V&& v) {

--- a/include/kumi/algorithm/partition.hpp
+++ b/include/kumi/algorithm/partition.hpp
@@ -47,7 +47,7 @@ namespace kumi
     else
     {
       constexpr auto pos = []<std::size_t... I>(std::index_sequence<I...>) {
-        return function::selector(std::bool_constant<Pred<raw_element_t<I, T>>::value>{}...);
+        return function::selector(std::bool_constant<Pred<stored_element_t<I, T>>::value>{}...);
       }(std::make_index_sequence<size_v<T>>{});
 
       auto select = [&]<typename O, std::size_t... I>(O, std::index_sequence<I...>) {
@@ -97,7 +97,7 @@ namespace kumi
     else
     {
       constexpr auto pos = []<std::size_t... I>(std::index_sequence<I...>) {
-        return function::selector(std::bool_constant<Pred<raw_element_t<I, T>>::value>{}...);
+        return function::selector(std::bool_constant<Pred<stored_element_t<I, T>>::value>{}...);
       }(std::make_index_sequence<size_v<T>>{});
 
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
@@ -144,7 +144,7 @@ namespace kumi
     else
     {
       constexpr auto pos = []<std::size_t... I>(std::index_sequence<I...>) {
-        return function::selector(std::bool_constant<Pred<raw_element_t<I, T>>::value>{}...);
+        return function::selector(std::bool_constant<Pred<stored_element_t<I, T>>::value>{}...);
       }(std::make_index_sequence<size_v<T>>{});
 
       return [&]<std::size_t... I>(std::index_sequence<I...>) {

--- a/include/kumi/algorithm/unique.hpp
+++ b/include/kumi/algorithm/unique.hpp
@@ -87,7 +87,7 @@ namespace kumi
     else
     {
       constexpr auto proj = [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return function::uniquer(std::type_identity<raw_element_t<I, T>>{}...);
+        return function::uniquer(std::type_identity<stored_element_t<I, T>>{}...);
       }(std::make_index_sequence<size_v<T>>{});
 
       return [&]<std::size_t... I>(std::index_sequence<I...>) {

--- a/include/kumi/detail/concepts.hpp
+++ b/include/kumi/detail/concepts.hpp
@@ -173,8 +173,8 @@ namespace kumi::_
   struct sort<Box<Ts...>, Box<Us...>> : check_value<Ts>...
   {
     using check_value<Ts>::get...;
-    using t_list = tuple<decltype(get(std::declval<Us>()))...>;
-    using u_list = tuple<decltype(get(std::declval<Us>()))...>;
+    using t_list = Box<decltype(get(std::declval<Us>()))...>;
+    using u_list = Box<decltype(get(std::declval<Us>()))...>;
 
     using is_fieldwise_constructible = is_piecewise_constructible<t_list, u_list>;
     using is_fieldwise_convertible = is_piecewise_convertible<t_list, u_list>;

--- a/include/kumi/functional/set.hpp
+++ b/include/kumi/functional/set.hpp
@@ -94,7 +94,8 @@ namespace kumi
         that.t[0] = 0;
 
         [&]<std::size_t... I>(std::index_sequence<I...>) {
-          (((std::is_same_v<raw_element_t<I, T>, raw_element_t<I + 1, T>>) ? I : (that.t[that.count++] = I + 1)), ...);
+          (((std::is_same_v<stored_element_t<I, T>, stored_element_t<I + 1, T>>) ? I : (that.t[that.count++] = I + 1)),
+           ...);
         }(std::make_index_sequence<size_v<T> - 1>{});
 
         return that;

--- a/include/kumi/product_types/record.hpp
+++ b/include/kumi/product_types/record.hpp
@@ -200,7 +200,7 @@ namespace kumi
     //==================================================================================================================
     template<concepts::identifier Id>
     KUMI_ABI constexpr decltype(auto) operator[](Id const&) & noexcept
-    requires(concepts::contains_field<Id, Ts...>)
+    requires(concepts::contains_identifier<Id, Ts...>)
     {
       return impl(_::tag_of_t<Id>{});
     }
@@ -208,7 +208,7 @@ namespace kumi
     /// @overload
     template<concepts::identifier Id>
     KUMI_ABI constexpr decltype(auto) operator[](Id const&) && noexcept
-    requires(concepts::contains_field<Id, Ts...>)
+    requires(concepts::contains_identifier<Id, Ts...>)
     {
       return static_cast<decltype(impl)&&>(impl)(_::tag_of_t<Id>{});
     }
@@ -216,7 +216,7 @@ namespace kumi
     /// @overload
     template<concepts::identifier Id>
     KUMI_ABI constexpr decltype(auto) operator[](Id const&) const&& noexcept
-    requires(concepts::contains_field<Id, Ts...>)
+    requires(concepts::contains_identifier<Id, Ts...>)
     {
       return static_cast<decltype(impl) const&&>(impl)(_::tag_of_t<Id>{});
     }
@@ -224,7 +224,7 @@ namespace kumi
     /// @overload
     template<concepts::identifier Id>
     KUMI_ABI constexpr decltype(auto) operator[](Id const&) const& noexcept
-    requires(concepts::contains_field<Id, Ts...>)
+    requires(concepts::contains_identifier<Id, Ts...>)
     {
       return impl(_::tag_of_t<Id>{});
     }
@@ -256,7 +256,7 @@ namespace kumi
     [[nodiscard]] KUMI_ABI constexpr auto values() noexcept
     {
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return tuple<raw_member_t<I, decltype(*this)>...>{field_value_of(get<I>(*this))...};
+        return tuple<stored_member_t<I, decltype(*this)>...>{field_value_of(get<I>(*this))...};
       }(std::make_index_sequence<sizeof...(Ts)>{});
     }
 
@@ -264,7 +264,7 @@ namespace kumi
     [[nodiscard]] KUMI_ABI constexpr auto values() const noexcept
     {
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return tuple<raw_member_t<I, decltype(*this)>...>{field_value_of(get<I>(*this))...};
+        return tuple<stored_member_t<I, decltype(*this)>...>{field_value_of(get<I>(*this))...};
       }(std::make_index_sequence<sizeof...(Ts)>{});
     }
 
@@ -315,7 +315,7 @@ namespace kumi
     /// @brief Compares a record with an other for equality
     template<typename... Us>
     KUMI_ABI friend constexpr auto operator==(record const& self, record<Us...> const& other) noexcept
-    requires(concepts::named_equality_comparable<record, record<Us...>>)
+    requires(concepts::equality_comparable<record, record<Us...>>)
     {
       return ((get<identifier_of<Ts>()>(self) == get<identifier_of<Ts>()>(other)) && ...);
     }
@@ -323,7 +323,7 @@ namespace kumi
     /// @brief Compares a record with an other for inequality
     template<typename... Us>
     KUMI_ABI friend constexpr auto operator!=(record const& self, record<Us...> const& other) noexcept
-    requires(concepts::named_equality_comparable<record, record<Us...>>)
+    requires(concepts::equality_comparable<record, record<Us...>>)
     {
       return !(self == other);
     }
@@ -392,11 +392,12 @@ namespace kumi
   // Specialisation to clearly signal errors due to duplicate fields
   //====================================================================================================================
   template<typename... Ts>
-  requires(!concepts::entirely_uniquely_named<Ts...> || !concepts::unique_label<Ts...>)
+  requires(!concepts::uniquely_named<Ts...> || !concepts::fully_named<Ts...> || !concepts::uniquely_labeled<Ts...>)
   struct record<Ts...>
   {
-    static_assert(concepts::entirely_uniquely_named<Ts...>, "Duplicate fields in record definition");
-    static_assert(concepts::unique_label<Ts...>, "Duplicate identifier representation in record definition");
+    static_assert(concepts::uniquely_named<Ts...>, "Duplicate fields in record definition");
+    static_assert(concepts::uniquely_labeled<Ts...>, "Duplicate identifier representation in record definition");
+    static_assert(concepts::fully_named<Ts...>, "Anonymous field usage in record definition");
     record(Ts&&...) = delete;
   };
 
@@ -486,7 +487,7 @@ namespace kumi
   //====================================================================================================================
   template<typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr auto make_record(Ts&&... ts) -> record<std::unwrap_ref_decay_t<Ts>...>
-  requires(concepts::entirely_uniquely_named<Ts...>)
+  requires(concepts::uniquely_named<Ts...> && concepts::fully_named<Ts...>)
   {
     return {KUMI_FWD(ts)...};
   }
@@ -708,7 +709,7 @@ namespace kumi
   //====================================================================================================================
   template<concepts::identifier auto Id, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(record<Ts...>& r) noexcept
-  requires(concepts::contains_field<decltype(Id), Ts...>)
+  requires(concepts::contains_identifier<decltype(Id), Ts...>)
   {
     return r[Id];
   }
@@ -717,7 +718,7 @@ namespace kumi
   /// @overload
   template<concepts::identifier auto Id, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(record<Ts...>&& r) noexcept
-  requires(concepts::contains_field<decltype(Id), Ts...>)
+  requires(concepts::contains_identifier<decltype(Id), Ts...>)
   {
     return static_cast<record<Ts...>&&>(r)[Id];
   }
@@ -726,7 +727,7 @@ namespace kumi
   /// @overload
   template<concepts::identifier auto Id, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(record<Ts...> const& r) noexcept
-  requires(concepts::contains_field<decltype(Id), Ts...>)
+  requires(concepts::contains_identifier<decltype(Id), Ts...>)
   {
     return r[Id];
   }
@@ -735,7 +736,7 @@ namespace kumi
   /// @overload
   template<concepts::identifier auto Id, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(record<Ts...> const&& r) noexcept
-  requires(concepts::contains_field<decltype(Id), Ts...>)
+  requires(concepts::contains_identifier<decltype(Id), Ts...>)
   {
     return static_cast<record<Ts...> const&&>(r)[Id];
   }
@@ -804,12 +805,12 @@ namespace kumi
 
   /// Improves diagnostic for non present label
   template<str S, typename R>
-  requires(is_kumi_record_v<std::remove_cvref_t<R>> && !_::contains_field<S, R>())
+  requires(is_kumi_record_v<std::remove_cvref_t<R>> && !_::contains_identifier<S, R>())
   constexpr auto get(R&& r) = delete;
 
   /// Improves diagnostic for non present identifier
   template<concepts::identifier auto S, typename R>
-  requires(is_kumi_record_v<std::remove_cvref_t<R>> && !concepts::contains_field<decltype(S), R>)
+  requires(is_kumi_record_v<std::remove_cvref_t<R>> && !concepts::contains_identifier<decltype(S), R>)
   constexpr auto get(R&& r) = delete;
 
   /// Improves diagnostic for non present type

--- a/include/kumi/product_types/tuple.hpp
+++ b/include/kumi/product_types/tuple.hpp
@@ -191,7 +191,7 @@ namespace kumi
     //==================================================================================================================
     template<concepts::identifier Id>
     KUMI_ABI constexpr decltype(auto) operator[](Id const&) & noexcept
-    requires(concepts::uniquely_named<Ts...> && concepts::contains_field<Id, Ts...>)
+    requires(concepts::uniquely_named<Ts...> && concepts::contains_identifier<Id, Ts...>)
     {
       return impl(_::tag_of_t<Id>{});
     }
@@ -199,7 +199,7 @@ namespace kumi
     /// @overload
     template<concepts::identifier Id>
     KUMI_ABI constexpr decltype(auto) operator[](Id const&) && noexcept
-    requires(concepts::uniquely_named<Ts...> && concepts::contains_field<Id, Ts...>)
+    requires(concepts::uniquely_named<Ts...> && concepts::contains_identifier<Id, Ts...>)
     {
       return static_cast<decltype(impl)&&>(impl)(_::tag_of_t<Id>{});
     }
@@ -207,7 +207,7 @@ namespace kumi
     /// @overload
     template<concepts::identifier Id>
     KUMI_ABI constexpr decltype(auto) operator[](Id const&) const&& noexcept
-    requires(concepts::uniquely_named<Ts...> && concepts::contains_field<Id, Ts...>)
+    requires(concepts::uniquely_named<Ts...> && concepts::contains_identifier<Id, Ts...>)
     {
       return static_cast<decltype(impl) const&&>(impl)(_::tag_of_t<Id>{});
     }
@@ -215,7 +215,7 @@ namespace kumi
     /// @overload
     template<concepts::identifier Id>
     KUMI_ABI constexpr decltype(auto) operator[](Id const&) const& noexcept
-    requires(concepts::uniquely_named<Ts...> && concepts::contains_field<Id, Ts...>)
+    requires(concepts::uniquely_named<Ts...> && concepts::contains_identifier<Id, Ts...>)
     {
       return impl(_::tag_of_t<Id>{});
     }
@@ -915,7 +915,7 @@ namespace kumi
   //====================================================================================================================
   template<concepts::identifier auto Id, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(tuple<Ts...>& t) noexcept
-  requires(concepts::uniquely_named<Ts...> && concepts::contains_field<decltype(Id), Ts...>)
+  requires(concepts::uniquely_named<Ts...> && concepts::contains_identifier<decltype(Id), Ts...>)
   {
     return t[Id];
   }
@@ -924,7 +924,7 @@ namespace kumi
   /// @overload
   template<concepts::identifier auto Id, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(tuple<Ts...>&& t) noexcept
-  requires(concepts::uniquely_named<Ts...> && concepts::contains_field<decltype(Id), Ts...>)
+  requires(concepts::uniquely_named<Ts...> && concepts::contains_identifier<decltype(Id), Ts...>)
   {
     return static_cast<tuple<Ts...>&&>(t)[Id];
   }
@@ -933,7 +933,7 @@ namespace kumi
   /// @overload
   template<concepts::identifier auto Id, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(tuple<Ts...> const& t) noexcept
-  requires(concepts::uniquely_named<Ts...> && concepts::contains_field<decltype(Id), Ts...>)
+  requires(concepts::uniquely_named<Ts...> && concepts::contains_identifier<decltype(Id), Ts...>)
   {
     return t[Id];
   }
@@ -942,7 +942,7 @@ namespace kumi
   /// @overload
   template<concepts::identifier auto Id, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(tuple<Ts...> const&& t) noexcept
-  requires(concepts::uniquely_named<Ts...> && concepts::contains_field<decltype(Id), Ts...>)
+  requires(concepts::uniquely_named<Ts...> && concepts::contains_identifier<decltype(Id), Ts...>)
   {
     return static_cast<tuple<Ts...> const&&>(t)[Id];
   }
@@ -1009,12 +1009,12 @@ namespace kumi
 
   /// Improves diagnostic for non present label
   template<str S, typename T>
-  requires(is_kumi_tuple_v<std::remove_cvref_t<T>> && !_::contains_field<S, T>())
+  requires(is_kumi_tuple_v<std::remove_cvref_t<T>> && !_::contains_identifier<S, T>())
   constexpr auto get(T&& t) = delete;
 
   /// Improves diagnostic for non present identifier
   template<concepts::identifier auto S, typename T>
-  requires(is_kumi_tuple_v<std::remove_cvref_t<T>> && !concepts::contains_field<decltype(S), T>)
+  requires(is_kumi_tuple_v<std::remove_cvref_t<T>> && !concepts::contains_identifier<decltype(S), T>)
   constexpr auto get(T&& t) = delete;
 
   /// Improves diagnostic for non present type

--- a/include/kumi/utils/concepts.hpp
+++ b/include/kumi/utils/concepts.hpp
@@ -16,25 +16,25 @@ namespace kumi
     //==================================================================================================================
     template<typename F, typename T>
     concept supports_apply = []<std::size_t... N>(std::index_sequence<N...>) {
-      return std::invocable<F, raw_member_t<N, T>...>;
+      return std::invocable<F, stored_member_t<N, T>...>;
     }(std::make_index_sequence<size_v<T>>{});
 
     template<typename F, typename T>
     concept supports_nothrow_apply = []<std::size_t... N>(std::index_sequence<N...>) {
-      return std::is_nothrow_invocable_v<F, raw_member_t<N, T>...>;
+      return std::is_nothrow_invocable_v<F, stored_member_t<N, T>...>;
     }(std::make_index_sequence<size_v<T>>{});
 
     template<typename F, typename... Ts>
     concept supports_call = []<std::size_t... I>(std::index_sequence<I...>) {
       return ([]<std::size_t J>(std::integral_constant<std::size_t, J>) {
-        return std::invocable<F, raw_member_t<J, Ts>...>;
+        return std::invocable<F, stored_member_t<J, Ts>...>;
       }(std::integral_constant<std::size_t, I>{}) &&
               ...);
     }(std::make_index_sequence<(size_v<Ts>, ...)>{});
 
     template<typename T>
     concept supports_transpose = (size_v<T> <= 1) || ([]<std::size_t... N>(std::index_sequence<N...>) {
-                                   return ((size_v<raw_member_t<0, T>> == size_v<raw_member_t<N + 1, T>>) && ...);
+                                   return ((size_v<stored_member_t<0, T>> == size_v<stored_member_t<N + 1, T>>) && ...);
                                  }(std::make_index_sequence<size_v<T> - 1>{}));
 
     template<typename Ints, typename... Ts> struct matches;
@@ -195,6 +195,34 @@ namespace kumi
     //==================================================================================================================
     /**
       @ingroup concepts
+      @brief Concept specifying if a type can be used as sequence of projections in algorithms
+
+      A type `T` models `kumi::projection_map` if it contains constant evaluable members which are themselves either
+      integral types, identifiers or others `projection_map`.
+
+      ## Example types :
+      + std::index_sequence<...>;
+      + kumi::projection_map<...>;
+    **/
+    //==================================================================================================================
+    template<typename T>
+    concept projection_map = is_projection_map_v<std::remove_cvref_t<T>>;
+
+    //==================================================================================================================
+    /**
+      @ingroup concepts
+      @brief Concept specifying if a type is suitable to be used as a projection
+
+      A type `T` models `kumi::projection` if it models `kumi::projection_map` or `kumi::index`
+      or `kumi::identifier`
+    **/
+    //==================================================================================================================
+    template<typename T>
+    concept projection = projection_map<T> || identifier<T> || index<T>;
+
+    //==================================================================================================================
+    /**
+      @ingroup concepts
       @brief Concept specifying a type follows the Product Type semantic and has a known size
 
       A type `T` models `kumi::concepts::sized_product_type<N>` if it models `kumi::concepts::product_type` and has
@@ -243,30 +271,6 @@ namespace kumi
     //==================================================================================================================
     /**
       @ingroup concepts
-      @brief Concept specifying if a type can be used as sequence of projections in algorithms
-
-      A type `T` models `kumi::projection_map` if it contains constant evaluable members which are themselves either
-      integral types, identifiers or others `projection_map`
-    **/
-    //==================================================================================================================
-    template<typename T>
-    concept projection_map = is_projection_map_v<std::remove_cvref_t<T>>;
-
-    //==================================================================================================================
-    /**
-      @ingroup concepts
-      @brief Concept specifying if a type is suitable to be used as a projection
-
-      A type `T` models `kumi::projection` if it models `kumi::projection_map` or `kumi::index`
-      or `kumi::identifier`
-    **/
-    //==================================================================================================================
-    template<typename T>
-    concept projection = projection_map<T> || identifier<T> || index<T>;
-
-    //==================================================================================================================
-    /**
-      @ingroup concepts
       @brief Concept specifying is Product Type which types are all the same
 
       A type `T` models `kumi::cocnepts::homogenous_product_type` if it models `kumi::concepts::product_type` and
@@ -284,18 +288,6 @@ namespace kumi
     //==================================================================================================================
     /**
       @ingroup concepts
-      @brief Concept specifying if a type is comparable for each of its components
-
-      A type `T` models `kumi::concepts::equality_comparable<T,U>`if it's a kumi::concepts::product_type where each
-      of its elements satisfies kumi::concepts::equality_comparable for all their respective elements.
-    **/
-    //==================================================================================================================
-    template<typename T, typename U>
-    concept equality_comparable = (size_v<T> == size_v<U>) && _::piecewise_comparable<T, U>;
-
-    //==================================================================================================================
-    /**
-      @ingroup concepts
       @brief Concept specifying if parameter pack contains a kumi::concepts::field.
     **/
     //==================================================================================================================
@@ -309,7 +301,7 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename... Ts>
-    concept is_fully_named = (... && field<Ts>);
+    concept fully_named = (... && field<Ts>);
 
     //==================================================================================================================
     /**
@@ -318,7 +310,8 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename... Ts>
-    concept uniquely_typed = (!has_named_fields<Ts...>) && all_uniques_v<std::remove_cvref_t<Ts>...>;
+    concept uniquely_typed =
+      (sizeof...(Ts) == 0) || (!has_named_fields<Ts...> && all_uniques_v<std::remove_cvref_t<Ts>...>);
 
     //==================================================================================================================
     /**
@@ -327,7 +320,8 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename... Ts>
-    concept uniquely_named = (has_named_fields<Ts...>) && all_unique_names_v<std::remove_cvref_t<Ts>...>;
+    concept uniquely_named =
+      (sizeof...(Ts) == 0) || (has_named_fields<Ts...> && all_unique_names_v<std::remove_cvref_t<Ts>...>);
 
     //==================================================================================================================
     /**
@@ -337,20 +331,8 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename... Ts>
-    concept unique_label =
-      (sizeof...(Ts) == 0) || (is_fully_named<Ts...> && (all_uniques_v<_::value<std::remove_cvref_t<Ts>::label()>...>));
-
-    //==================================================================================================================
-    /**
-      @ingroup concepts
-      @brief  Concept specifying if a parameter pack only holds kumi::concepts::field. Each of their names
-              beeing unique.
-
-      @note  If there are no element in the parameter pack the concept returns true
-    **/
-    //==================================================================================================================
-    template<typename... Ts>
-    concept entirely_uniquely_named = (sizeof...(Ts) == 0) || (is_fully_named<Ts...> && uniquely_named<Ts...>);
+    concept uniquely_labeled =
+      (sizeof...(Ts) == 0) || (fully_named<Ts...> && (all_uniques_v<_::value<std::remove_cvref_t<Ts>::label()>...>));
 
     //==================================================================================================================
     /**
@@ -370,7 +352,7 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename Name, typename... Ts>
-    concept contains_field = identifier<Name> && kumi::_::can_get_field_by_value<Name, Ts...>;
+    concept contains_identifier = identifier<Name> && kumi::_::can_get_field_by_value<Name, Ts...>;
 
     //==================================================================================================================
     /**
@@ -400,15 +382,16 @@ namespace kumi
     //==================================================================================================================
     /**
       @ingroup concepts
-      @brief Concept specifying if two product types are comparable by matching labels
+      @brief Concept specifying if a type is comparable for each of its components
 
-      A type `T` models kumi::concepts::named_equality_comparable<T,U> if it's a kumi::concepts::product_type that
-      satisfies kumi::concepts::equivalent<T,U> and if each of its fields satisfies
-      kumi::concepts::equality_comparable with the corresponding field in `U`
+      A type `T` models `kumi::concepts::equality_comparable<T,U>`if it's a kumi::concepts::product_type where each
+      of its elements satisfies kumi::concepts::equality_comparable for all their respective elements.
     **/
     //==================================================================================================================
     template<typename T, typename U>
-    concept named_equality_comparable = equivalent<T, U> && _::fieldwise_comparable<T, U>;
+    concept equality_comparable =
+      equivalent<T, U> && ((product_type<T> && product_type<U> && _::piecewise_comparable<T, U>) ||
+                           (record_type<T> && record_type<U> && _::fieldwise_comparable<T, U>));
 
     //==================================================================================================================
     /**
@@ -434,8 +417,7 @@ namespace kumi
     //==================================================================================================================
     template<typename T, typename... Us>
     concept compatible_product_types =
-      (follows_same_semantic<T, Us...> &&
-       ((!record_type<T>) || (equivalent<std::remove_cvref_t<T>, std::remove_cvref_t<Us>> && ...)));
+      (follows_same_semantic<T, Us...> && ((!record_type<T>) || (equivalent<T, Us> && ...)));
 
     //==================================================================================================================
     /**
@@ -465,13 +447,13 @@ namespace kumi
       @ingroup concepts
       @brief Concept specifying if a product type can be queried via a `get<type>`
 
-      A type `T` models `kumi::concepts::typed_get_compliant` if it's fields are uniquely typed.
+      A type `T` models `kumi::concepts::queryable_by_type` if it's fields are uniquely typed.
       For a `record_type` it inspects the underlying type of the fields.
     **/
     //==================================================================================================================
     template<typename Type, typename T>
-    concept typed_get_compliant = product_type<T> && []<std::size_t... I>(std::index_sequence<I...>) {
-      return _::can_get_field_by_type<Type, raw_element_t<I, T>...>;
+    concept queryable_by_type = product_type<T> && []<std::size_t... I>(std::index_sequence<I...>) {
+      return _::can_get_field_by_type<Type, stored_element_t<I, T>...>;
     }(std::make_index_sequence<size_v<T>>{});
 
     //==================================================================================================================
@@ -479,28 +461,29 @@ namespace kumi
       @ingroup concepts
       @brief Concept specifying if a product type can be queried via a `get<identifier>`
 
-      A type `T` models `named_get_compliant` if it's a kumi::concepts::product_type with it's element modeling
+      A type `T` models `queryable_by_identifier` if it's a kumi::concepts::product_type with it's element modeling
       kumi::concepts::uniquely_named and a field with the same identifier as the template parameter `Id` can be found
       inside.
     **/
     //==================================================================================================================
     template<typename Id, typename T>
-    concept named_get_compliant = identifier<Id> && product_type<T> && []<std::size_t... I>(std::index_sequence<I...>) {
-      return _::can_get_field_by_value<Id, element_t<I, T>...>;
-    }(std::make_index_sequence<size_v<T>>{});
+    concept queryable_by_identifier =
+      identifier<Id> && product_type<T> && []<std::size_t... I>(std::index_sequence<I...>) {
+        return _::can_get_field_by_value<Id, element_t<I, T>...>;
+      }(std::make_index_sequence<size_v<T>>{});
 
     //==================================================================================================================
     /**
       @ingroup concepts
       @brief Concept specifying if a product type can be queried via a `get<label>`
 
-      A type `T` models `labeled_get_compliant` if it's a kumi::concepts::product_type with it's element modeling
+      A type `T` models `queryable_by_label` if it's a kumi::concepts::product_type with it's element modeling
       kumi::concepts::uniquely_named and a field with the same label as the template parameter `L` can be found
       inside.
     **/
     //==================================================================================================================
     template<typename L, typename T>
-    concept labeled_get_compliant = _::label<L> && product_type<T> && []<std::size_t... I>(std::index_sequence<I...>) {
+    concept queryable_by_label = _::label<L> && product_type<T> && []<std::size_t... I>(std::index_sequence<I...>) {
       return _::can_get_field_by_label<L, element_t<I, T>...>;
     }(std::make_index_sequence<size_v<T>>{});
   }

--- a/include/kumi/utils/ct_helpers.hpp
+++ b/include/kumi/utils/ct_helpers.hpp
@@ -157,10 +157,10 @@ namespace kumi
   //====================================================================================================================
   template<typename U, concepts::product_type T>
   KUMI_ABI consteval auto get_index_of_type()
-  requires(concepts::typed_get_compliant<U, T>)
+  requires(concepts::queryable_by_type<U, T>)
   {
     return [&]<std::size_t... I>(std::index_sequence<I...>) {
-      return _::get_index_by_type_v<U, raw_element_t<I, T>...>;
+      return _::get_index_by_type_v<U, stored_element_t<I, T>...>;
     }(std::make_index_sequence<size_v<T>>{});
   }
 
@@ -177,7 +177,7 @@ namespace kumi
   //====================================================================================================================
   template<concepts::identifier Id, concepts::product_type T>
   KUMI_ABI consteval auto get_index_of_field()
-  requires(concepts::named_get_compliant<Id, T>)
+  requires(concepts::queryable_by_identifier<Id, T>)
   {
     return [&]<std::size_t... I>(std::index_sequence<I...>) {
       return _::get_index_by_value_v<Id, element_t<I, T>...>;
@@ -197,7 +197,7 @@ namespace kumi
   //====================================================================================================================
   template<str L, concepts::product_type T>
   KUMI_ABI consteval auto get_index_of_label()
-  requires(concepts::labeled_get_compliant<label_t<L>, T>)
+  requires(concepts::queryable_by_label<label_t<L>, T>)
   {
     return [&]<std::size_t... I>(std::index_sequence<I...>) {
       return _::get_index_by_label_v<label_t<L>, element_t<I, T>...>;

--- a/include/kumi/utils/identifier.hpp
+++ b/include/kumi/utils/identifier.hpp
@@ -200,7 +200,7 @@ namespace kumi
   {
     // MSVC workaround for get<>
     // MSVC evaluates a requires clause before checking the type of an NTTP
-    template<auto N, typename... Ts> KUMI_ABI constexpr auto contains_field()
+    template<auto N, typename... Ts> KUMI_ABI constexpr auto contains_identifier()
     {
       if constexpr (std::integral<std::remove_cvref_t<decltype(N)>>) return false;
       else if constexpr (concepts::index<decltype(N)>) return false;

--- a/include/kumi/utils/projections.hpp
+++ b/include/kumi/utils/projections.hpp
@@ -11,21 +11,21 @@ namespace kumi
 {
   namespace _
   {
-    template<std::size_t I, typename T> struct projection_at
+    template<std::size_t I, typename T> struct value_at
     {
     };
 
     template<std::size_t I, auto Head, auto... Tail>
-    struct projection_at<I, kumi::projection_map<Head, Tail...>> : projection_at<I - 1, kumi::projection_map<Tail...>>
+    struct value_at<I, kumi::projection_map<Head, Tail...>> : value_at<I - 1, kumi::projection_map<Tail...>>
     {
     };
 
-    template<std::size_t I, auto... Vs> struct projection_at<I, kumi::projection_map<Vs...> const>
+    template<std::size_t I, auto... Vs> struct value_at<I, kumi::projection_map<Vs...> const>
     {
-      static constexpr auto value = projection_at<I, kumi::projection_map<Vs...>>::value;
+      static constexpr auto value = value_at<I, kumi::projection_map<Vs...>>::value;
     };
 
-    template<auto Head, auto... Tail> struct projection_at<0, kumi::projection_map<Head, Tail...>>
+    template<auto Head, auto... Tail> struct value_at<0, kumi::projection_map<Head, Tail...>>
     {
       static constexpr auto value = Head;
     };
@@ -67,10 +67,10 @@ namespace kumi
     **/
     //==================================================================================================================
 
-    /// Returns the number of elements in a kumi::indexes_t
+    /// Returns the number of elements in a kumi::projection_map
     [[nodiscard]] KUMI_ABI static constexpr auto size() noexcept { return sizeof...(V); }
 
-    /// Returns `true` if a kumi::indexes_t contains 0 elements
+    /// Returns `true` if a kumi::projection_map contains 0 elements
     [[nodiscard]] KUMI_ABI static constexpr auto empty() noexcept { return sizeof...(V) == 0; }
 
     //==================================================================================================================
@@ -87,7 +87,7 @@ namespace kumi
     requires(I < sizeof...(V))
     KUMI_ABI constexpr decltype(auto) operator[]([[maybe_unused]] index_t<I> i) const noexcept
     {
-      return _::projection_at<I, projection_map>::value;
+      return _::value_at<I, projection_map>::value;
     }
 
     //==================================================================================================================
@@ -96,7 +96,7 @@ namespace kumi
 
       @note Does not participate in overload resolution if `I` is not in [0, sizeof...(Ts)).
       @tparam  I Compile-time index of the element to access
-      @return A copy of the value of the selected element of current indexes_t.
+      @return A copy of the value of the selected element of current projection_map.
     **/
     //==================================================================================================================
     template<std::size_t I>
@@ -124,8 +124,8 @@ namespace kumi
   //====================================================================================================================
   /**
     @ingroup utility
-    @brief kumi::indexes_t deduction guide
-    @tparam Ts  Type lists to build the indexes with.
+    @brief kumi::projection_map deduction guide
+    @tparam Ts  Type lists to build the projections with.
   **/
   //====================================================================================================================
   template<concepts::projection... Ts> KUMI_CUDA projection_map(Ts...) -> projection_map<Ts{}...>;
@@ -137,7 +137,7 @@ namespace kumi
 
     @note The arguments should model kumi::index
 
-    @tparam Ts	Zero or more indexes to construct the indexes from.
+    @tparam Ts	Zero or more indexes to construct the projection from.
     @return A kumi::projection_map constructed from the ts
 
     ## Examples:
@@ -156,7 +156,7 @@ namespace kumi
 
     @note The arguments should model kumi::index
 
-    @tparam vs	Zero or more values convertible to size_t to construct the indexes from.
+    @tparam vs	Zero or more values convertible to size_t to construct the projection from.
     @return A kumi::projection_map constructed from the vs
 
     ## Examples:
@@ -175,7 +175,7 @@ namespace kumi
 
     @note The arguments should model kumi::identifier
 
-    @tparam Ts	Zero or more indexes to construct the indexes from.
+    @tparam Ts	Zero or more indexes to construct the projection from.
     @return A kumi::projection_map constructed from the ts
 
     ## Examples:

--- a/include/kumi/utils/traits.hpp
+++ b/include/kumi/utils/traits.hpp
@@ -388,25 +388,25 @@ namespace kumi
     @code
     namespace kumi
     {
-      template<std::size_t I, typename T> using raw_member_t = typename raw_member<I,T>::type;
+      template<std::size_t I, typename T> using stored_member_t = typename stored_member<I,T>::type;
     }
     @endcode
   **/
   //====================================================================================================================
-  template<std::size_t I, typename T> struct raw_member
+  template<std::size_t I, typename T> struct stored_member
   {
     using type = member_t<I, T>;
   };
 
   template<std::size_t I, typename T>
   requires(is_record_type<std::remove_cvref_t<T>>::value)
-  struct raw_member<I, T>
+  struct stored_member<I, T>
   {
     using field_type = decltype(get<I>(std::declval<T&&>()));
     using type = decltype(std::declval<field_type&&>()(typename std::remove_cvref_t<field_type>::identifier_type{}));
   };
 
-  template<std::size_t I, typename T> using raw_member_t = typename raw_member<I, T>::type;
+  template<std::size_t I, typename T> using stored_member_t = typename stored_member<I, T>::type;
 
   //====================================================================================================================
   /**
@@ -424,24 +424,24 @@ namespace kumi
     namespace kumi
     {
       template<std::size_t I, typename T>
-      using raw_element_t = typename raw_element_t<I,T>::type;
+      using stored_element_t = typename stored_element_t<I,T>::type;
     }
     @endcode
   **/
   //====================================================================================================================
-  template<std::size_t I, typename T> struct raw_element
+  template<std::size_t I, typename T> struct stored_element
   {
     using type = element_t<I, T>;
   };
 
   template<std::size_t I, typename T>
   requires(is_record_type<std::remove_cvref_t<T>>::value)
-  struct raw_element<I, T>
+  struct stored_element<I, T>
   {
     using type = typename element_t<I, T>::type;
   };
 
-  template<std::size_t I, typename T> using raw_element_t = typename raw_element<I, T>::type;
+  template<std::size_t I, typename T> using stored_element_t = typename stored_element<I, T>::type;
 
   //====================================================================================================================
   /**
@@ -543,6 +543,103 @@ namespace kumi
 
   template<typename... Ts> inline constexpr auto all_unique_names_v = all_unique_names_t<Ts...>::value;
 
+  //====================================================================================================================
+  /**
+    @ingroup traits
+    @brief   Unpacks a product type and applies its element types as arguments to a meta-function.
+
+    ` apply_traits` takes a template meta-function (a template template parameter) and a product type. It expands the
+      types contained within the product type and passes them as a parameter pack to the provided `Traits`.
+
+    @tparam Traits Meta-function to be applied.
+    @tparam Tuple  The product type whose elements will be unpacked.
+
+    ## Helper type
+    @code
+    namespace kumi
+    {
+      template<template<typename...> typename Traits, typename Tuple>
+      using apply_traits_t = typename apply_traits<Traits, Tuple>::type;
+    }
+    @endcode
+
+    ## Example
+    @code
+    using my_tuple = kumi::tuple<int, float, char>;
+
+    // Equivalent to std::common_type<int, float, char>::type
+    using common = kumi::apply_traits_t<std::common_type, my_tuple>;
+    @endcode
+  **/
+  //====================================================================================================================
+  template<template<typename...> typename Traits,
+           typename Tuple,
+           typename Seq = std::make_index_sequence<size<Tuple>::value>>
+  requires is_product_type_v<std::remove_cvref_t<Tuple>>
+  struct apply_traits;
+
+  template<template<typename...> typename Traits, typename Tuple, std::size_t... Is>
+  requires is_product_type_v<std::remove_cvref_t<Tuple>> &&
+           (requires { typename Traits<element_t<Is, Tuple>...>::type; })
+  struct apply_traits<Traits, Tuple, std::index_sequence<Is...>>
+  {
+    using type = typename Traits<element_t<Is, Tuple>...>::type;
+  };
+
+  template<template<typename...> typename Traits, typename Tuple>
+  requires is_product_type_v<std::remove_cvref_t<Tuple>>
+  using apply_traits_t = typename apply_traits<Traits, Tuple>::type;
+
+  //====================================================================================================================
+  /**
+    @ingroup traits
+    @brief   Applies a unary meta-function to each element of a product type.
+
+    `map_traits` transforms a product type by applying a given meta-function `Traits` to every element type
+    individually. The result is a new product type containing the transformed types.
+
+    @tparam Traits Unary meta-function to apply to each element.
+    @tparam Tuple  The product type to transform.
+
+    ## Helper type
+    @code
+    namespace kumi
+    {
+      template<template<typename...> typename Traits, typename Tuple>
+      using map_traits_t = typename map_traits<Traits, Tuple>::type;
+    }
+    @endcode
+
+    ## Example
+    @code
+    using my_tuple = kumi::tuple<int, double, char>;
+
+    // Result: kumi::tuple<int*, double*, char*>
+    using ptr_tuple = kumi::map_traits_t<std::add_pointer, my_tuple>;
+    @endcode
+  **/
+  //====================================================================================================================
+  template<template<typename...> typename Traits,
+           typename Tuple,
+           typename Seq = std::make_index_sequence<size<Tuple>::value>>
+  requires is_product_type_v<std::remove_cvref_t<Tuple>>
+  struct map_traits;
+
+  template<template<typename...> typename Traits, typename Tuple, std::size_t... Is>
+  requires is_product_type_v<std::remove_cvref_t<Tuple>> &&
+           (requires { typename Traits<element_t<Is, Tuple>>::type; } && ...)
+  struct map_traits<Traits, Tuple, std::index_sequence<Is...>>
+  {
+    using type = tuple<typename Traits<element_t<Is, Tuple>>::type...>;
+  };
+
+  template<template<typename...> typename Traits, typename Tuple>
+  requires is_product_type_v<std::remove_cvref_t<Tuple>>
+  using map_traits_t = typename map_traits<Traits, Tuple>::type;
+}
+
+namespace kumi
+{
 #ifndef KUMI_DOXYGEN_INVOKED
   // A type with the tuple interface is automatically a product_type
   template<typename T>
@@ -558,6 +655,7 @@ namespace kumi
   {
   };
 
+  // An index sequence is a one dimensional projection map
   template<std::size_t... I> struct is_projection_map<std::index_sequence<I...>> : std::true_type
   {
   };
@@ -583,42 +681,4 @@ namespace kumi
 
   template<typename T> inline constexpr bool is_kumi_record_v = is_kumi_record<T>::value;
 #endif
-
-  ///
-  template<template<typename...> typename Traits,
-           typename Tuple,
-           typename Seq = std::make_index_sequence<size<Tuple>::value>>
-  requires is_product_type_v<std::remove_cvref_t<Tuple>>
-  struct apply_traits;
-
-  template<template<typename...> typename Traits, typename Tuple, std::size_t... Is>
-  requires is_product_type_v<std::remove_cvref_t<Tuple>> &&
-           (requires { typename Traits<element_t<Is, Tuple>...>::type; })
-  struct apply_traits<Traits, Tuple, std::index_sequence<Is...>>
-  {
-    using type = typename Traits<element_t<Is, Tuple>...>::type;
-  };
-
-  template<template<typename...> typename Traits, typename Tuple>
-  requires is_product_type_v<std::remove_cvref_t<Tuple>>
-  using apply_traits_t = typename apply_traits<Traits, Tuple>::type;
-
-  template<template<typename...> typename Traits,
-           typename Tuple,
-           typename Seq = std::make_index_sequence<size<Tuple>::value>>
-  requires is_product_type_v<std::remove_cvref_t<Tuple>>
-  struct map_traits;
-
-  template<template<typename...> typename Traits, typename Tuple, std::size_t... Is>
-  requires is_product_type_v<std::remove_cvref_t<Tuple>> &&
-           (requires { typename Traits<element_t<Is, Tuple>>::type; } && ...)
-  struct map_traits<Traits, Tuple, std::index_sequence<Is...>>
-  {
-    using type = tuple<typename Traits<element_t<Is, Tuple>>::type...>;
-  };
-
-  template<template<typename...> typename Traits, typename Tuple>
-  requires is_product_type_v<std::remove_cvref_t<Tuple>>
-  using map_traits_t = typename map_traits<Traits, Tuple>::type;
-
 }


### PR DESCRIPTION
At the moment some concepts are not coherent with the overall naming scheme of field/identifier/label, some other concepts have lengthy names that are not particularily meaningfull.
This PR addresses those changes. 

It's based on [PR 189](https://github.com/jfalcou/kumi/pull/189)