### PR TITLE
Fully qualify internal calls

### DIFF
--- a/include/kumi/algorithm/apply.hpp
+++ b/include/kumi/algorithm/apply.hpp
@@ -43,46 +43,47 @@ namespace kumi
     @include doc/record/algo/apply.cpp
   **/
   //====================================================================================================================
-  template<typename Function, concepts::product_type T>
-  KUMI_ABI constexpr decltype(auto) apply(Function&& f, T&& t) noexcept(_::supports_nothrow_apply<Function&&, T&&>)
+  template<typename Function, kumi::concepts::product_type T>
+  KUMI_ABI constexpr decltype(auto) apply(Function&& f, T&& t)
+    noexcept(kumi::_::supports_nothrow_apply<Function&&, T&&>)
 #ifndef KUMI_DOXYGEN_INVOKED
-  requires(_::supports_apply<Function, T>)
+  requires(kumi::_::supports_apply<Function, T>)
 #endif
   {
-    if constexpr (concepts::empty_product_type<T>) return invoke(KUMI_FWD(f));
-    else if constexpr (concepts::record_type<T>) return apply(KUMI_FWD(f), values_of(KUMI_FWD(t)));
+    if constexpr (kumi::concepts::empty_product_type<T>) return kumi::invoke(KUMI_FWD(f));
+    else if constexpr (kumi::concepts::record_type<T>) return kumi::apply(KUMI_FWD(f), kumi::values_of(KUMI_FWD(t)));
     else
       return [&]<std::size_t... I>(std::index_sequence<I...>) -> decltype(auto) {
-        return invoke(KUMI_FWD(f), get<I>(KUMI_FWD(t))...);
-      }(std::make_index_sequence<size_v<T>>{});
+        return kumi::invoke(KUMI_FWD(f), get<I>(KUMI_FWD(t))...);
+      }(std::make_index_sequence<kumi::size_v<T>>{});
   }
 
   namespace result
   {
-    template<typename Function, concepts::product_type T> struct apply
+    template<typename Function, kumi::concepts::product_type T> struct apply
     {
       using type = decltype(kumi::apply(std::declval<Function>(), std::declval<T>()));
     };
 
-    template<typename Function, concepts::product_type T> using apply_t = typename apply<Function, T>::type;
+    template<typename Function, kumi::concepts::product_type T> using apply_t = typename apply<Function, T>::type;
   }
 
   namespace _
   {
-    template<typename Function, concepts::record_type R>
+    template<typename Function, kumi::concepts::record_type R>
     KUMI_ABI constexpr decltype(auto) apply_field(Function&& f, R&& t)
     {
-      if constexpr (concepts::empty_product_type<R>) return invoke(KUMI_FWD(f));
+      if constexpr (kumi::concepts::empty_product_type<R>) return kumi::invoke(KUMI_FWD(f));
       else
         return [&]<std::size_t... I>(std::index_sequence<I...>) -> decltype(auto) {
-          return invoke(KUMI_FWD(f), get<I>(KUMI_FWD(t))...);
-        }(std::make_index_sequence<size_v<R>>{});
+          return kumi::invoke(KUMI_FWD(f), get<I>(KUMI_FWD(t))...);
+        }(std::make_index_sequence<kumi::size_v<R>>{});
       ;
     }
 
     namespace result
     {
-      template<typename Function, concepts::record_type R> struct apply_field
+      template<typename Function, kumi::concepts::record_type R> struct apply_field
       {
         using type = decltype(kumi::_::apply_field(std::declval<Function>(), std::declval<R>()));
       };

--- a/include/kumi/algorithm/back_front.hpp
+++ b/include/kumi/algorithm/back_front.hpp
@@ -39,9 +39,9 @@ namespace kumi
     @include doc/record/algo/back-front.cpp
   **/
   //====================================================================================================================
-  template<concepts::non_empty_product_type T> [[nodiscard]] KUMI_ABI constexpr decltype(auto) front(T&& t)
+  template<kumi::concepts::non_empty_product_type T> [[nodiscard]] KUMI_ABI constexpr decltype(auto) front(T&& t)
   {
-    if constexpr (concepts::record_type<T>) return front(values_of(KUMI_FWD(t)));
+    if constexpr (kumi::concepts::record_type<T>) return kumi::front(kumi::values_of(KUMI_FWD(t)));
     else return get<0>(KUMI_FWD(t));
   }
 
@@ -75,23 +75,23 @@ namespace kumi
     @include doc/record/algo/back-front.cpp
   **/
   //====================================================================================================================
-  template<concepts::non_empty_product_type T> [[nodiscard]] KUMI_ABI constexpr decltype(auto) back(T&& t)
+  template<kumi::concepts::non_empty_product_type T> [[nodiscard]] KUMI_ABI constexpr decltype(auto) back(T&& t)
   {
-    if constexpr (concepts::record_type<T>) return back(values_of(KUMI_FWD(t)));
-    else return get<size_v<T> - 1>(KUMI_FWD(t));
+    if constexpr (kumi::concepts::record_type<T>) return kumi::back(values_of(KUMI_FWD(t)));
+    else return get<kumi::size_v<T> - 1>(KUMI_FWD(t));
   }
 
   namespace result
   {
-    template<concepts::product_type T> struct front : stored_member<0, T>
+    template<kumi::concepts::product_type T> struct front : kumi::stored_member<0, T>
     {
     };
 
-    template<concepts::product_type T> struct back : stored_member<size_v<T> - 1, T>
+    template<kumi::concepts::product_type T> struct back : kumi::stored_member<kumi::size_v<T> - 1, T>
     {
     };
 
-    template<concepts::product_type T> using front_t = typename front<T>::type;
-    template<concepts::product_type T> using back_t = typename back<T>::type;
+    template<kumi::concepts::product_type T> using front_t = typename front<T>::type;
+    template<kumi::concepts::product_type T> using back_t = typename back<T>::type;
   }
 }

--- a/include/kumi/algorithm/back_front.hpp
+++ b/include/kumi/algorithm/back_front.hpp
@@ -91,7 +91,7 @@ namespace kumi
     {
     };
 
-    template<kumi::concepts::product_type T> using front_t = typename front<T>::type;
-    template<kumi::concepts::product_type T> using back_t = typename back<T>::type;
+    template<kumi::concepts::product_type T> using front_t = typename kumi::result::front<T>::type;
+    template<kumi::concepts::product_type T> using back_t = typename kumi::result::back<T>::type;
   }
 }

--- a/include/kumi/algorithm/cartesian_product.hpp
+++ b/include/kumi/algorithm/cartesian_product.hpp
@@ -40,15 +40,16 @@ namespace kumi
     @include doc/record/algo/cartesian_product.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type... Ts>
+  template<kumi::concepts::product_type... Ts>
   [[nodiscard]] KUMI_ABI constexpr auto cartesian_product(Ts&&... ts)
-  requires(concepts::follows_same_semantic<Ts...>)
+  requires(kumi::concepts::follows_same_semantic<Ts...>)
   {
-    if constexpr (sizeof...(Ts) == 0) return tuple{};
+    if constexpr (sizeof...(Ts) == 0) return kumi::tuple{};
     else
     {
-      using res_type = common_product_type_t<std::remove_cvref_t<Ts>...>;
-      constexpr auto idx = function::cartesian_producer(index<(size_v<Ts> * ...)>, index<size_v<Ts>>...);
+      using res_type = kumi::common_product_type_t<std::remove_cvref_t<Ts>...>;
+      constexpr auto idx =
+        kumi::function::cartesian_producer(kumi::index<(kumi::size_v<Ts> * ...)>, kumi::index<kumi::size_v<Ts>>...);
 
       auto maps = [&]<std::size_t... E, std::size_t... I>(std::index_sequence<E...>, std::index_sequence<I...>) {
         auto tps = kumi::forward_as_tuple(KUMI_FWD(ts)...);
@@ -59,7 +60,7 @@ namespace kumi
       return [&]<std::size_t... N>(std::index_sequence<N...>) {
         std::make_index_sequence<sizeof...(Ts)> ids;
         return kumi::make_tuple(maps(get<N>(idx), ids)...);
-      }(std::make_index_sequence<(size_v<Ts> * ...)>{});
+      }(std::make_index_sequence<(kumi::size_v<Ts> * ...)>{});
     }
   }
 

--- a/include/kumi/algorithm/cartesian_product.hpp
+++ b/include/kumi/algorithm/cartesian_product.hpp
@@ -53,7 +53,7 @@ namespace kumi
 
       auto maps = [&]<std::size_t... E, std::size_t... I>(std::index_sequence<E...>, std::index_sequence<I...>) {
         auto tps = kumi::forward_as_tuple(KUMI_FWD(ts)...);
-        using res_t = builder_make_t<res_type, element_t<E, element_t<I, decltype(tps)>>...>;
+        using res_t = builder_make_t<res_type, kumi::element_t<E, kumi::element_t<I, decltype(tps)>>...>;
         return res_t{get<E>(get<I>(tps))...};
       };
 
@@ -71,6 +71,6 @@ namespace kumi
       using type = decltype(kumi::cartesian_product(std::declval<Ts>()...));
     };
 
-    template<typename... Ts> using cartesian_product_t = typename cartesian_product<Ts...>::type;
+    template<typename... Ts> using cartesian_product_t = typename kumi::result::cartesian_product<Ts...>::type;
   }
 }

--- a/include/kumi/algorithm/cast.hpp
+++ b/include/kumi/algorithm/cast.hpp
@@ -38,28 +38,29 @@ namespace kumi
     @include doc/record/algo/member_cast.cpp
   **/
   //====================================================================================================================
-  template<typename Target, concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto member_cast(T&& t)
+  template<typename Target, kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto member_cast(T&& t)
   {
-    if constexpr (concepts::empty_product_type<T>) return t;
-    else if constexpr (concepts::record_type<T>)
+    if constexpr (kumi::concepts::empty_product_type<T>) return t;
+    else if constexpr (kumi::concepts::record_type<T>)
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        using type = builder_make_t<T, result::field_cast_t<Target, element_t<I, T>>...>;
+        using type = builder_make_t<T, kumi::result::field_cast_t<Target, element_t<I, T>>...>;
         return type{field_cast<Target>(get<I>(KUMI_FWD(t)))...};
-      }(std::make_index_sequence<size_v<T>>{});
+      }(std::make_index_sequence<kumi::size_v<T>>{});
     else
     {
-      using type = _::as_homogeneous_t<Target, size_v<T>>;
+      using type = kumi::_::as_homogeneous_t<Target, kumi::size_v<T>>;
       return static_cast<type>(KUMI_FWD(t));
     }
   }
 
   namespace result
   {
-    template<typename Target, concepts::product_type T> struct member_cast
+    template<typename Target, kumi::concepts::product_type T> struct member_cast
     {
       using type = decltype(kumi::member_cast<Target, T>(std::declval<T>()));
     };
 
-    template<typename Target, concepts::product_type T> using member_cast_t = typename member_cast<Target, T>::type;
+    template<typename Target, kumi::concepts::product_type T>
+    using member_cast_t = typename member_cast<Target, T>::type;
   }
 }

--- a/include/kumi/algorithm/cast.hpp
+++ b/include/kumi/algorithm/cast.hpp
@@ -43,8 +43,8 @@ namespace kumi
     if constexpr (kumi::concepts::empty_product_type<T>) return t;
     else if constexpr (kumi::concepts::record_type<T>)
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        using type = builder_make_t<T, kumi::result::field_cast_t<Target, element_t<I, T>>...>;
-        return type{field_cast<Target>(get<I>(KUMI_FWD(t)))...};
+        using type = builder_make_t<T, kumi::result::field_cast_t<Target, kumi::element_t<I, T>>...>;
+        return type{kumi::field_cast<Target>(get<I>(KUMI_FWD(t)))...};
       }(std::make_index_sequence<kumi::size_v<T>>{});
     else
     {
@@ -61,6 +61,6 @@ namespace kumi
     };
 
     template<typename Target, kumi::concepts::product_type T>
-    using member_cast_t = typename member_cast<Target, T>::type;
+    using member_cast_t = typename kumi::result::member_cast<Target, T>::type;
   }
 }

--- a/include/kumi/algorithm/cat.hpp
+++ b/include/kumi/algorithm/cat.hpp
@@ -51,7 +51,7 @@ namespace kumi
 
       return [&]<typename T, std::size_t... E, std::size_t... N>(T&& t, std::index_sequence<E...>,
                                                                  std::index_sequence<N...>) {
-        using type = builder_make_t<res_type, element_t<E, element_t<N, T>>...>;
+        using type = builder_make_t<res_type, kumi::element_t<E, kumi::element_t<N, T>>...>;
         return type{get<E>(get<N>(KUMI_FWD(t)))...};
       }(kumi::forward_as_tuple(KUMI_FWD(ts)...), get<1>(pos), get<0>(pos));
     }
@@ -59,11 +59,11 @@ namespace kumi
 
   namespace result
   {
-    template<concepts::product_type... Ts> struct cat
+    template<kumi::concepts::product_type... Ts> struct cat
     {
       using type = decltype(kumi::cat(std::declval<Ts>()...));
     };
 
-    template<concepts::product_type... Ts> using cat_t = typename cat<Ts...>::type;
+    template<concepts::product_type... Ts> using cat_t = typename kumi::result::cat<Ts...>::type;
   }
 }

--- a/include/kumi/algorithm/cat.hpp
+++ b/include/kumi/algorithm/cat.hpp
@@ -39,15 +39,15 @@ namespace kumi
     @include doc/record/algo/cat.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type... Ts>
+  template<kumi::concepts::product_type... Ts>
   [[nodiscard]] KUMI_ABI constexpr auto cat(Ts&&... ts)
-  requires(concepts::follows_same_semantic<Ts...>)
+  requires(kumi::concepts::follows_same_semantic<Ts...>)
   {
-    if constexpr (sizeof...(Ts) == 0) return tuple{};
+    if constexpr (sizeof...(Ts) == 0) return kumi::tuple{};
     else
     {
-      constexpr auto pos = function::concatenater(std::index_sequence<size_v<Ts>...>{});
-      using res_type = common_product_type_t<std::remove_cvref_t<Ts>...>;
+      constexpr auto pos = kumi::function::concatenater(std::index_sequence<kumi::size_v<Ts>...>{});
+      using res_type = kumi::common_product_type_t<std::remove_cvref_t<Ts>...>;
 
       return [&]<typename T, std::size_t... E, std::size_t... N>(T&& t, std::index_sequence<E...>,
                                                                  std::index_sequence<N...>) {

--- a/include/kumi/algorithm/contains.hpp
+++ b/include/kumi/algorithm/contains.hpp
@@ -12,7 +12,7 @@ namespace kumi
   namespace _
   {
     template<typename T, typename... Ts>
-    inline constexpr bool contains = ((concepts::field<T> && std::invocable<T, tag_of_t<Ts>>) || ...);
+    inline constexpr bool contains = ((kumi::concepts::field<T> && std::invocable<T, kumi::_::tag_of_t<Ts>>) || ...);
   }
 
   //====================================================================================================================
@@ -45,20 +45,22 @@ namespace kumi
     @include doc/record/algo/contains.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T, concepts::identifier ID>
+  template<kumi::concepts::product_type T, kumi::concepts::identifier ID>
   [[nodiscard]] KUMI_ABI constexpr auto contains([[maybe_unused]] T&& t, [[maybe_unused]] ID const& id) noexcept
   {
-    if constexpr (concepts::empty_product_type<T>) return std::false_type{};
-    else if constexpr (concepts::record_type<T>)
+    if constexpr (kumi::concepts::empty_product_type<T>) return std::false_type{};
+    else if constexpr (kumi::concepts::record_type<T>)
       return []<std::size_t... I>(std::index_sequence<I...>) {
-        return std::bool_constant<_::can_get_field_by_value<std::remove_cvref_t<ID>, element_t<I, T>...>>{};
-      }(std::make_index_sequence<size_v<T>>{});
+        return std::bool_constant<kumi::_::can_get_field_by_value<std::remove_cvref_t<ID>, kumi::element_t<I, T>...>>{};
+      }(std::make_index_sequence<kumi::size_v<T>>{});
     else
       return []<std::size_t... I>(std::index_sequence<I...>) {
-        if constexpr (((concepts::field<element_t<I, T>> && std::invocable<element_t<I, T>, _::tag_of_t<ID>>) || ...))
+        if constexpr (((kumi::concepts::field<element_t<I, T>> &&
+                        std::invocable<kumi::element_t<I, T>, kumi::_::tag_of_t<ID>>) ||
+                       ...))
           return std::true_type{};
         else return std::false_type{};
-      }(std::make_index_sequence<size_v<T>>{});
+      }(std::make_index_sequence<kumi::size_v<T>>{});
   }
 
   //====================================================================================================================
@@ -90,12 +92,12 @@ namespace kumi
     @include doc/record/algo/contains_any.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T, concepts::identifier... Is>
+  template<kumi::concepts::product_type T, kumi::concepts::identifier... Is>
   [[nodiscard]] KUMI_ABI constexpr auto contains_any([[maybe_unused]] T&& t, Is const&... ids) noexcept
   {
-    if constexpr (concepts::empty_product_type<T>) return std::false_type{};
+    if constexpr (kumi::concepts::empty_product_type<T>) return std::false_type{};
     else if constexpr (sizeof...(Is) == 0) return std::false_type{};
-    else return std::bool_constant<(decltype(contains(std::declval<T>(), ids)){} || ...)>{};
+    else return std::bool_constant<(decltype(kumi::contains(std::declval<T>(), ids)){} || ...)>{};
   }
 
   //====================================================================================================================
@@ -127,17 +129,17 @@ namespace kumi
     @include doc/record/algo/contains_only.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T, concepts::identifier... Is>
+  template<kumi::concepts::product_type T, kumi::concepts::identifier... Is>
   [[nodiscard]] KUMI_ABI constexpr auto contains_only([[maybe_unused]] T&& t,
                                                       [[maybe_unused]] Is const&... ids) noexcept
   {
-    if constexpr (concepts::empty_product_type<T>) return std::false_type{};
+    if constexpr (kumi::concepts::empty_product_type<T>) return std::false_type{};
     else if constexpr (sizeof...(Is) == 0) return std::false_type{};
-    else if constexpr (sizeof...(Is) < size_v<T>) return std::false_type{};
+    else if constexpr (sizeof...(Is) < kumi::size_v<T>) return std::false_type{};
     else
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return std::bool_constant<(_::contains<element_t<I, T>, Is...> && ...)>{};
-      }(std::make_index_sequence<size_v<T>>{});
+        return std::bool_constant<(kumi::_::contains<element_t<I, T>, Is...> && ...)>{};
+      }(std::make_index_sequence<kumi::size_v<T>>{});
   }
 
   //====================================================================================================================
@@ -169,43 +171,44 @@ namespace kumi
     @include doc/record/algo/contains_none.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T, concepts::identifier... Is>
+  template<kumi::concepts::product_type T, kumi::concepts::identifier... Is>
   [[nodiscard]] KUMI_ABI constexpr auto contains_none([[maybe_unused]] T&& t, Is const&... ids) noexcept
   {
-    return std::bool_constant<!decltype(contains_any(std::declval<T>(), ids...)){}>{};
+    return std::bool_constant<!decltype(kumi::contains_any(std::declval<T>(), ids...)){}>{};
   }
 
   namespace result
   {
-    template<concepts::product_type T, concepts::identifier ID> struct contains
+    template<kumi::concepts::product_type T, kumi::concepts::identifier ID> struct contains
     {
       using type = decltype(kumi::contains(std::declval<T>(), std::declval<ID>()));
     };
 
-    template<concepts::product_type T, concepts::identifier... IDs> struct contains_any
+    template<kumi::concepts::product_type T, kumi::concepts::identifier... IDs> struct contains_any
     {
       using type = decltype(kumi::contains_any(std::declval<T>(), std::declval<IDs>()...));
     };
 
-    template<concepts::product_type T, concepts::identifier... IDs> struct contains_only
+    template<kumi::concepts::product_type T, kumi::concepts::identifier... IDs> struct contains_only
     {
       using type = decltype(kumi::contains_only(std::declval<T>(), std::declval<IDs>()...));
     };
 
-    template<concepts::product_type T, concepts::identifier... IDs> struct contains_none
+    template<kumi::concepts::product_type T, kumi::concepts::identifier... IDs> struct contains_none
     {
       using type = decltype(kumi::contains_none(std::declval<T>(), std::declval<IDs>()...));
     };
 
-    template<concepts::product_type T, concepts::identifier ID> using contains_t = typename contains<T, ID>::type;
+    template<kumi::concepts::product_type T, kumi::concepts::identifier ID>
+    using contains_t = typename contains<T, ID>::type;
 
-    template<concepts::product_type T, concepts::identifier... IDs>
+    template<kumi::concepts::product_type T, kumi::concepts::identifier... IDs>
     using contains_any_t = typename contains_any<T, IDs...>::type;
 
-    template<concepts::product_type T, concepts::identifier... IDs>
+    template<kumi::concepts::product_type T, kumi::concepts::identifier... IDs>
     using contains_only_t = typename contains_only<T, IDs...>::type;
 
-    template<concepts::product_type T, concepts::identifier... IDs>
+    template<kumi::concepts::product_type T, kumi::concepts::identifier... IDs>
     using contains_none_t = typename contains_none<T, IDs...>::type;
 
   }

--- a/include/kumi/algorithm/contains.hpp
+++ b/include/kumi/algorithm/contains.hpp
@@ -55,7 +55,7 @@ namespace kumi
       }(std::make_index_sequence<kumi::size_v<T>>{});
     else
       return []<std::size_t... I>(std::index_sequence<I...>) {
-        if constexpr (((kumi::concepts::field<element_t<I, T>> &&
+        if constexpr (((kumi::concepts::field<kumi::element_t<I, T>> &&
                         std::invocable<kumi::element_t<I, T>, kumi::_::tag_of_t<ID>>) ||
                        ...))
           return std::true_type{};
@@ -138,7 +138,7 @@ namespace kumi
     else if constexpr (sizeof...(Is) < kumi::size_v<T>) return std::false_type{};
     else
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return std::bool_constant<(kumi::_::contains<element_t<I, T>, Is...> && ...)>{};
+        return std::bool_constant<(kumi::_::contains<kumi::element_t<I, T>, Is...> && ...)>{};
       }(std::make_index_sequence<kumi::size_v<T>>{});
   }
 
@@ -200,16 +200,16 @@ namespace kumi
     };
 
     template<kumi::concepts::product_type T, kumi::concepts::identifier ID>
-    using contains_t = typename contains<T, ID>::type;
+    using contains_t = typename kumi::result::contains<T, ID>::type;
 
     template<kumi::concepts::product_type T, kumi::concepts::identifier... IDs>
-    using contains_any_t = typename contains_any<T, IDs...>::type;
+    using contains_any_t = typename kumi::result::contains_any<T, IDs...>::type;
 
     template<kumi::concepts::product_type T, kumi::concepts::identifier... IDs>
-    using contains_only_t = typename contains_only<T, IDs...>::type;
+    using contains_only_t = typename kumi::result::contains_only<T, IDs...>::type;
 
     template<kumi::concepts::product_type T, kumi::concepts::identifier... IDs>
-    using contains_none_t = typename contains_none<T, IDs...>::type;
+    using contains_none_t = typename kumi::result::contains_none<T, IDs...>::type;
 
   }
 }

--- a/include/kumi/algorithm/extract.hpp
+++ b/include/kumi/algorithm/extract.hpp
@@ -46,24 +46,24 @@ namespace kumi
     @include doc/record/algo/extract.cpp
   **/
   //====================================================================================================================
-  template<std::size_t I0, std::size_t I1, concepts::product_type T>
+  template<std::size_t I0, std::size_t I1, kumi::concepts::product_type T>
   [[nodiscard]] KUMI_ABI constexpr auto extract(T&& t,
-                                                [[maybe_unused]] index_t<I0> i0,
-                                                [[maybe_unused]] index_t<I1> i1) noexcept
+                                                [[maybe_unused]] kumi::index_t<I0> i0,
+                                                [[maybe_unused]] kumi::index_t<I1> i1) noexcept
   {
-    static_assert((I0 <= size_v<T>) && (I1 <= size_v<T>), "[KUMI] - Invalid index");
+    static_assert((I0 <= kumi::size_v<T>) && (I1 <= kumi::size_v<T>), "[KUMI] - Invalid index");
     return [&]<std::size_t... N>(std::index_sequence<N...>) {
-      using final_t = builder_make_t<T, element_t<N + I0, T>...>;
+      using final_t = builder_make_t<T, kumi::element_t<N + I0, T>...>;
       return final_t{get<N + I0>(KUMI_FWD(t))...};
     }(std::make_index_sequence<I1 - I0>{});
   }
 
   //! @overload
-  template<std::size_t I0, concepts::product_type T>
-  [[nodiscard]] KUMI_ABI constexpr auto extract(T&& t, index_t<I0> i0) noexcept
+  template<std::size_t I0, kumi::concepts::product_type T>
+  [[nodiscard]] KUMI_ABI constexpr auto extract(T&& t, kumi::index_t<I0> i0) noexcept
   {
-    static_assert(I0 <= size_v<T>, "[KUMI] - Invalid index");
-    return extract(KUMI_FWD(t), i0, index<size_v<T>>);
+    static_assert(I0 <= kumi::size_v<T>, "[KUMI] - Invalid index");
+    return kumi::extract(KUMI_FWD(t), i0, kumi::index<size_v<T>>);
   }
 
   //====================================================================================================================
@@ -101,11 +101,11 @@ namespace kumi
     @include doc/record/algo/split.cpp
   **/
   //====================================================================================================================
-  template<std::size_t I0, concepts::product_type T>
-  [[nodiscard]] KUMI_ABI constexpr auto split(T&& t, [[maybe_unused]] index_t<I0> i0) noexcept
+  template<std::size_t I0, kumi::concepts::product_type T>
+  [[nodiscard]] KUMI_ABI constexpr auto split(T&& t, [[maybe_unused]] kumi::index_t<I0> i0) noexcept
   {
-    static_assert(I0 <= size_v<T>, "[KUMI] - Invalid index");
-    constexpr auto proj = function::splitter(index<I0>, index<size_v<T>>);
+    static_assert(I0 <= kumi::size_v<T>, "[KUMI] - Invalid index");
+    constexpr auto proj = kumi::function::splitter(kumi::index<I0>, kumi::index<kumi::size_v<T>>);
 
     auto select = [&]<std::size_t... I>(std::index_sequence<I...>) {
       using type = builder_make_t<T, element_t<I, T>...>;
@@ -117,24 +117,24 @@ namespace kumi
 
   namespace result
   {
-    template<concepts::product_type T, std::size_t I0, std::size_t I1 = std::size_t(-1)> struct extract
+    template<kumi::concepts::product_type T, std::size_t I0, std::size_t I1 = std::size_t(-1)> struct extract
     {
       using type = decltype(kumi::extract(std::declval<T>(), kumi::index_t<I0>{}, kumi::index_t<I1>{}));
     };
 
-    template<concepts::product_type T, std::size_t I0> struct extract<T, I0>
+    template<kumi::concepts::product_type T, std::size_t I0> struct extract<T, I0>
     {
       using type = decltype(kumi::extract(std::declval<T>(), kumi::index_t<I0>{}));
     };
 
-    template<concepts::product_type T, std::size_t I0> struct split
+    template<kumi::concepts::product_type T, std::size_t I0> struct split
     {
       using type = decltype(kumi::split(std::declval<T>(), kumi::index_t<I0>{}));
     };
 
-    template<concepts::product_type T, std::size_t I0, std::size_t I1 = std::size_t(-1)>
+    template<kumi::concepts::product_type T, std::size_t I0, std::size_t I1 = std::size_t(-1)>
     using extract_t = typename extract<T, I0, I1>::type;
 
-    template<concepts::product_type T, std::size_t I0> using split_t = typename split<T, I0>::type;
+    template<kumi::concepts::product_type T, std::size_t I0> using split_t = typename split<T, I0>::type;
   }
 }

--- a/include/kumi/algorithm/extract.hpp
+++ b/include/kumi/algorithm/extract.hpp
@@ -108,7 +108,7 @@ namespace kumi
     constexpr auto proj = kumi::function::splitter(kumi::index<I0>, kumi::index<kumi::size_v<T>>);
 
     auto select = [&]<std::size_t... I>(std::index_sequence<I...>) {
-      using type = builder_make_t<T, element_t<I, T>...>;
+      using type = builder_make_t<T, kumi::element_t<I, T>...>;
       return type{get<I>(KUMI_FWD(t))...};
     };
 
@@ -133,8 +133,8 @@ namespace kumi
     };
 
     template<kumi::concepts::product_type T, std::size_t I0, std::size_t I1 = std::size_t(-1)>
-    using extract_t = typename extract<T, I0, I1>::type;
+    using extract_t = typename kumi::result::extract<T, I0, I1>::type;
 
-    template<kumi::concepts::product_type T, std::size_t I0> using split_t = typename split<T, I0>::type;
+    template<kumi::concepts::product_type T, std::size_t I0> using split_t = typename kumi::result::split<T, I0>::type;
   }
 }

--- a/include/kumi/algorithm/find.hpp
+++ b/include/kumi/algorithm/find.hpp
@@ -28,16 +28,17 @@ namespace kumi
     @include doc/record/algo/locate.cpp
   **/
   //====================================================================================================================
-  template<typename Pred, concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto locate(T&& t, Pred p) noexcept
+  template<typename Pred, kumi::concepts::product_type T>
+  [[nodiscard]] KUMI_ABI constexpr auto locate(T&& t, Pred p) noexcept
   {
-    if constexpr (concepts::empty_product_type<T>) return 0;
-    else if constexpr (concepts::record_type<T>) return locate(values_of(KUMI_FWD(t)), p);
+    if constexpr (kumi::concepts::empty_product_type<T>) return 0;
+    else if constexpr (kumi::concepts::record_type<T>) return kumi::locate(kumi::values_of(KUMI_FWD(t)), p);
     else
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        bool checks[] = {invoke(p, get<I>(KUMI_FWD(t)))...};
-        for (std::size_t i = 0; i < size_v<T>; ++i)
+        bool checks[] = {kumi::invoke(p, get<I>(KUMI_FWD(t)))...};
+        for (std::size_t i = 0; i < kumi::size_v<T>; ++i)
           if (checks[i]) return i;
-        return size_v<T>;
-      }(std::make_index_sequence<size_v<T>>{});
+        return kumi::size_v<T>;
+      }(std::make_index_sequence<kumi::size_v<T>>{});
   }
 }

--- a/include/kumi/algorithm/flatten.hpp
+++ b/include/kumi/algorithm/flatten.hpp
@@ -56,7 +56,7 @@ namespace kumi
         if constexpr (kumi::concepts::record_type<FV> && kumi::concepts::record_type<T>)
         {
           constexpr auto curr_name = kumi::label_of<V>();
-          constexpr auto new_name = kumi::concatenate_str<curr_name, kumi::label_of<element_t<J, FV>>()>();
+          constexpr auto new_name = kumi::concatenate_str<curr_name, kumi::label_of<kumi::element_t<J, FV>>()>();
           return (
             kumi::capture_field<name<new_name>{}>(kumi::field_value_of(get<J>(kumi::field_value_of(KUMI_FWD(v))))));
         }
@@ -210,11 +210,11 @@ namespace kumi
       using type = decltype(kumi::as_flat_ptr(std::declval<T>()));
     };
 
-    template<kumi::concepts::product_type T> using flatten_t = typename flatten<T>::type;
+    template<kumi::concepts::product_type T> using flatten_t = typename kumi::result::flatten<T>::type;
 
     template<kumi::concepts::product_type T, typename Func = void>
-    using flatten_all_t = typename flatten_all<T, Func>::type;
+    using flatten_all_t = typename kumi::result::flatten_all<T, Func>::type;
 
-    template<kumi::concepts::product_type T> using as_flat_ptr_t = typename as_flat_ptr<T>::type;
+    template<kumi::concepts::product_type T> using as_flat_ptr_t = typename kumi::result::as_flat_ptr<T>::type;
   }
 }

--- a/include/kumi/algorithm/flatten.hpp
+++ b/include/kumi/algorithm/flatten.hpp
@@ -41,29 +41,31 @@ namespace kumi
     @include doc/record/algo/flatten.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto flatten(T&& t)
+  template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto flatten(T&& t)
   {
-    if constexpr (concepts::empty_product_type<T>) return t;
+    if constexpr (kumi::concepts::empty_product_type<T>) return t;
     else
     {
       constexpr auto proj = [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return function::concatenater(std::index_sequence<function::size_or_v<stored_element_t<I, T>, 1>...>{});
-      }(std::make_index_sequence<size_v<T>>{});
+        return kumi::function::concatenater(
+          std::index_sequence<kumi::function::size_or_v<kumi::stored_element_t<I, T>, 1>...>{});
+      }(std::make_index_sequence<kumi::size_v<T>>{});
 
       auto process = [&]<typename V>(auto J, V&& v) {
-        using FV = result::field_value_of_t<V>;
-        if constexpr (concepts::record_type<FV> && concepts::record_type<T>)
+        using FV = kumi::result::field_value_of_t<V>;
+        if constexpr (kumi::concepts::record_type<FV> && kumi::concepts::record_type<T>)
         {
-          constexpr auto curr_name = label_of<V>();
-          constexpr auto new_name = concatenate_str<curr_name, label_of<element_t<J, FV>>()>();
-          return (capture_field<name<new_name>{}>(field_value_of(get<J>(field_value_of(KUMI_FWD(v))))));
+          constexpr auto curr_name = kumi::label_of<V>();
+          constexpr auto new_name = kumi::concatenate_str<curr_name, kumi::label_of<element_t<J, FV>>()>();
+          return (
+            kumi::capture_field<name<new_name>{}>(kumi::field_value_of(get<J>(kumi::field_value_of(KUMI_FWD(v))))));
         }
-        else if constexpr (concepts::follows_same_semantic<T, V>) return get<J>(KUMI_FWD(v));
+        else if constexpr (kumi::concepts::follows_same_semantic<T, V>) return get<J>(KUMI_FWD(v));
         else return KUMI_FWD(v);
       };
 
       return [&]<std::size_t... J, std::size_t... I>(std::index_sequence<J...>, std::index_sequence<I...>) {
-        return builder<T>::make(process(index<J>, get<I>(KUMI_FWD(t)))...);
+        return builder<T>::make(process(kumi::index<J>, get<I>(KUMI_FWD(t)))...);
       }(get<1>(proj), get<0>(proj));
     }
   }
@@ -107,44 +109,45 @@ namespace kumi
     @include doc/record/algo/flatten_all.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T, typename Func> [[nodiscard]] KUMI_ABI constexpr auto flatten_all(T&& t, Func f)
+  template<kumi::concepts::product_type T, typename Func>
+  [[nodiscard]] KUMI_ABI constexpr auto flatten_all(T&& t, Func f)
   {
-    if constexpr (concepts::empty_product_type<T>) return t;
+    if constexpr (kumi::concepts::empty_product_type<T>) return t;
     else
     {
       auto process = [&]<typename V>(V&& v) {
-        using FV = result::field_value_of_t<V>;
-        if constexpr (concepts::record_type<FV> && concepts::record_type<T>)
-          return capture_field<identifier_of<V>()>(flatten_all(field_value_of(KUMI_FWD(v)), f));
-        else if constexpr (concepts::follows_same_semantic<T, V>) return flatten_all(KUMI_FWD(v), f);
-        else if constexpr (concepts::record_type<T> && concepts::field<V>)
-          return capture_field<identifier_of<V>()>(invoke(f, field_value_of(v)));
-        else return invoke(f, v);
+        using FV = kumi::result::field_value_of_t<V>;
+        if constexpr (kumi::concepts::record_type<FV> && kumi::concepts::record_type<T>)
+          return kumi::capture_field<kumi::identifier_of<V>()>(kumi::flatten_all(kumi::field_value_of(KUMI_FWD(v)), f));
+        else if constexpr (kumi::concepts::follows_same_semantic<T, V>) return kumi::flatten_all(KUMI_FWD(v), f);
+        else if constexpr (kumi::concepts::record_type<T> && kumi::concepts::field<V>)
+          return kumi::capture_field<kumi::identifier_of<V>()>(kumi::invoke(f, kumi::field_value_of(v)));
+        else return kumi::invoke(f, v);
       };
 
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return flatten(builder<T>::make(process(get<I>(KUMI_FWD(t)))...));
-      }(std::make_index_sequence<size_v<T>>{});
+        return kumi::flatten(builder<T>::make(process(get<I>(KUMI_FWD(t)))...));
+      }(std::make_index_sequence<kumi::size_v<T>>{});
     }
   }
 
   /// @overload
-  template<concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto flatten_all(T&& t)
+  template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto flatten_all(T&& t)
   {
-    if constexpr (concepts::empty_product_type<T>) return KUMI_FWD(t);
+    if constexpr (kumi::concepts::empty_product_type<T>) return KUMI_FWD(t);
     else
     {
       auto process = [&]<typename V>(V&& v) {
-        using FV = result::field_value_of_t<V>;
-        if constexpr (concepts::record_type<FV> && concepts::record_type<T>)
-          return capture_field<identifier_of<V>()>(flatten_all(field_value_of(KUMI_FWD(v))));
-        else if constexpr (concepts::follows_same_semantic<T, V>) return flatten_all(KUMI_FWD(v));
+        using FV = kumi::result::field_value_of_t<V>;
+        if constexpr (kumi::concepts::record_type<FV> && concepts::record_type<T>)
+          return kumi::capture_field<kumi::identifier_of<V>()>(kumi::flatten_all(kumi::field_value_of(KUMI_FWD(v))));
+        else if constexpr (kumi::concepts::follows_same_semantic<T, V>) return kumi::flatten_all(KUMI_FWD(v));
         else return KUMI_FWD(v);
       };
 
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return flatten(builder<T>::make(process(get<I>(KUMI_FWD(t)))...));
-      }(std::make_index_sequence<size_v<T>>{});
+        return kumi::flatten(builder<T>::make(process(get<I>(KUMI_FWD(t)))...));
+      }(std::make_index_sequence<kumi::size_v<T>>{});
     }
   }
 
@@ -180,37 +183,38 @@ namespace kumi
     @include doc/record/algo/as_flat_ptr.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T> [[nodiscard]] KUMI_ABI auto as_flat_ptr(T&& t) noexcept
+  template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI auto as_flat_ptr(T&& t) noexcept
   {
     return kumi::flatten_all(KUMI_FWD(t), [](auto& m) { return &m; });
   }
 
   namespace result
   {
-    template<concepts::product_type T> struct flatten
+    template<kumi::concepts::product_type T> struct flatten
     {
       using type = decltype(kumi::flatten(std::declval<T>()));
     };
 
-    template<concepts::product_type T, typename Func = void> struct flatten_all
+    template<kumi::concepts::product_type T, typename Func = void> struct flatten_all
     {
       using type = decltype(kumi::flatten_all(std::declval<T>(), std::declval<Func>()));
     };
 
-    template<concepts::product_type T> struct flatten_all<T>
+    template<kumi::concepts::product_type T> struct flatten_all<T>
     {
       using type = decltype(kumi::flatten_all(std::declval<T>()));
     };
 
-    template<concepts::product_type T> struct as_flat_ptr
+    template<kumi::concepts::product_type T> struct as_flat_ptr
     {
       using type = decltype(kumi::as_flat_ptr(std::declval<T>()));
     };
 
-    template<concepts::product_type T> using flatten_t = typename flatten<T>::type;
+    template<kumi::concepts::product_type T> using flatten_t = typename flatten<T>::type;
 
-    template<concepts::product_type T, typename Func = void> using flatten_all_t = typename flatten_all<T, Func>::type;
+    template<kumi::concepts::product_type T, typename Func = void>
+    using flatten_all_t = typename flatten_all<T, Func>::type;
 
-    template<concepts::product_type T> using as_flat_ptr_t = typename as_flat_ptr<T>::type;
+    template<kumi::concepts::product_type T> using as_flat_ptr_t = typename as_flat_ptr<T>::type;
   }
 }

--- a/include/kumi/algorithm/fold.hpp
+++ b/include/kumi/algorithm/fold.hpp
@@ -41,15 +41,15 @@ namespace kumi
     @include doc/record/algo/fold_left.cpp
   **/
   //====================================================================================================================
-  template<typename Function, concepts::product_type T, typename Value>
+  template<typename Function, kumi::concepts::product_type T, typename Value>
   [[nodiscard]] KUMI_ABI constexpr auto fold_left(Function f, T&& t, Value init)
   {
-    if constexpr (concepts::record_type<T>) return fold_left(f, values_of(KUMI_FWD(t)), init);
-    else if constexpr (concepts::empty_product_type<T>) return init;
+    if constexpr (kumi::concepts::record_type<T>) return kumi::fold_left(f, kumi::values_of(KUMI_FWD(t)), init);
+    else if constexpr (kumi::concepts::empty_product_type<T>) return init;
     else
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return (function::foldable{init} >> ... >> bind_back(f, get<I>(KUMI_FWD(t))))();
-      }(std::make_index_sequence<size_v<T>>());
+        return (kumi::function::foldable{init} >> ... >> kumi::bind_back(f, get<I>(KUMI_FWD(t))))();
+      }(std::make_index_sequence<kumi::size_v<T>>());
   }
 
   //====================================================================================================================
@@ -83,15 +83,15 @@ namespace kumi
     @include doc/record/algo/fold_left.cpp
   **/
   //====================================================================================================================
-  template<typename Function, concepts::non_empty_product_type T>
+  template<typename Function, kumi::concepts::non_empty_product_type T>
   [[nodiscard]] KUMI_ABI constexpr auto fold_left(Function f, T&& t)
   {
-    if constexpr (concepts::record_type<T>) return fold_left(f, values_of(KUMI_FWD(t)));
-    else if constexpr (concepts::sized_product_type<T, 1>) return get<0>(KUMI_FWD(t));
+    if constexpr (kumi::concepts::record_type<T>) return fold_left(f, kumi::values_of(KUMI_FWD(t)));
+    else if constexpr (kumi::concepts::sized_product_type<T, 1>) return get<0>(KUMI_FWD(t));
     else
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return (function::foldable{get<0>(KUMI_FWD(t))} >> ... >> bind_back(f, get<I + 1>(KUMI_FWD(t))))();
-      }(std::make_index_sequence<size_v<T> - 1>{});
+        return (kumi::function::foldable{get<0>(KUMI_FWD(t))} >> ... >> kumi::bind_back(f, get<I + 1>(KUMI_FWD(t))))();
+      }(std::make_index_sequence<kumi::size_v<T> - 1>{});
   }
 
   //====================================================================================================================
@@ -126,15 +126,15 @@ namespace kumi
     @include doc/record/algo/fold_right.cpp
   **/
   //====================================================================================================================
-  template<typename Function, concepts::product_type T, typename Value>
+  template<typename Function, kumi::concepts::product_type T, typename Value>
   [[nodiscard]] KUMI_ABI constexpr auto fold_right(Function f, T&& t, Value init)
   {
-    if constexpr (concepts::record_type<T>) return fold_right(f, values_of(KUMI_FWD(t)), init);
-    else if constexpr (concepts::empty_product_type<T>) return init;
+    if constexpr (kumi::concepts::record_type<T>) return kumi::fold_right(f, kumi::values_of(KUMI_FWD(t)), init);
+    else if constexpr (kumi::concepts::empty_product_type<T>) return init;
     else
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return (bind_front(f, get<I>(KUMI_FWD(t))) << ... << function::foldable{init})();
-      }(std::make_index_sequence<size_v<T>>());
+        return (kumi::bind_front(f, get<I>(KUMI_FWD(t))) << ... << kumi::function::foldable{init})();
+      }(std::make_index_sequence<kumi::size_v<T>>());
   }
 
   //====================================================================================================================
@@ -168,43 +168,43 @@ namespace kumi
     @include doc/record/algo/fold_right.cpp
   **/
   //====================================================================================================================
-  template<typename Function, concepts::non_empty_product_type T>
+  template<typename Function, kumi::concepts::non_empty_product_type T>
   [[nodiscard]] KUMI_ABI constexpr auto fold_right(Function f, T&& t)
   {
-    if constexpr (concepts::record_type<T>) return fold_right(f, values_of(KUMI_FWD(t)));
-    else if constexpr (concepts::sized_product_type<T, 1>) return get<0>(KUMI_FWD(t));
+    if constexpr (kumi::concepts::record_type<T>) return kumi::fold_right(f, kumi::values_of(KUMI_FWD(t)));
+    else if constexpr (kumi::concepts::sized_product_type<T, 1>) return get<0>(KUMI_FWD(t));
     else
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return (bind_front(f, get<I + 1>(KUMI_FWD(t))) << ... << function::foldable{get<0>(KUMI_FWD(t))})();
-      }(std::make_index_sequence<size_v<T> - 1>());
+        return (kumi::bind_front(f, get<I + 1>(KUMI_FWD(t))) << ... << kumi::function::foldable{get<0>(KUMI_FWD(t))})();
+      }(std::make_index_sequence<kumi::size_v<T> - 1>());
   }
 
   namespace result
   {
-    template<typename Function, concepts::product_type T, typename Value = void> struct fold_right
+    template<typename Function, kumi::concepts::product_type T, typename Value = void> struct fold_right
     {
       using type = decltype(kumi::fold_right(std::declval<Function>(), std::declval<T>(), std::declval<Value>()));
     };
 
-    template<typename Function, concepts::product_type T> struct fold_right<Function, T>
+    template<typename Function, kumi::concepts::product_type T> struct fold_right<Function, T>
     {
       using type = decltype(kumi::fold_right(std::declval<Function>(), std::declval<T>()));
     };
 
-    template<typename Function, concepts::product_type T, typename Value = void> struct fold_left
+    template<typename Function, kumi::concepts::product_type T, typename Value = void> struct fold_left
     {
       using type = decltype(kumi::fold_left(std::declval<Function>(), std::declval<T>(), std::declval<Value>()));
     };
 
-    template<typename Function, concepts::product_type T> struct fold_left<Function, T>
+    template<typename Function, kumi::concepts::product_type T> struct fold_left<Function, T>
     {
       using type = decltype(kumi::fold_left(std::declval<Function>(), std::declval<T>()));
     };
 
-    template<typename Function, concepts::product_type T, typename Value = void>
+    template<typename Function, kumi::concepts::product_type T, typename Value = void>
     using fold_right_t = typename fold_right<Function, T, Value>::type;
 
-    template<typename Function, concepts::product_type T, typename Value = void>
+    template<typename Function, kumi::concepts::product_type T, typename Value = void>
     using fold_left_t = typename fold_left<Function, T, Value>::type;
   }
 }

--- a/include/kumi/algorithm/fold.hpp
+++ b/include/kumi/algorithm/fold.hpp
@@ -202,9 +202,9 @@ namespace kumi
     };
 
     template<typename Function, kumi::concepts::product_type T, typename Value = void>
-    using fold_right_t = typename fold_right<Function, T, Value>::type;
+    using fold_right_t = typename kumi::result::fold_right<Function, T, Value>::type;
 
     template<typename Function, kumi::concepts::product_type T, typename Value = void>
-    using fold_left_t = typename fold_left<Function, T, Value>::type;
+    using fold_left_t = typename kumi::result::fold_left<Function, T, Value>::type;
   }
 }

--- a/include/kumi/algorithm/for_each.hpp
+++ b/include/kumi/algorithm/for_each.hpp
@@ -45,7 +45,7 @@ namespace kumi
       auto const invoker{[&](auto const I) {
         if constexpr (kumi::concepts::record_type<T>)
         {
-          constexpr auto field = kumi::identifier_of<element_t<I, T>>();
+          constexpr auto field = kumi::identifier_of<kumi::element_t<I, T>>();
           kumi::invoke(f, get<field>(KUMI_FWD(t)), get<field>(KUMI_FWD(ts))...);
         }
         else kumi::invoke(f, get<I>(KUMI_FWD(t)), get<I>(KUMI_FWD(ts))...);

--- a/include/kumi/algorithm/for_each.hpp
+++ b/include/kumi/algorithm/for_each.hpp
@@ -32,28 +32,28 @@ namespace kumi
     @include doc/record/algo/for_each.cpp
   **/
   //====================================================================================================================
-  template<typename Function, concepts::product_type T, concepts::product_type... Ts>
+  template<typename Function, kumi::concepts::product_type T, kumi::concepts::product_type... Ts>
   KUMI_ABI constexpr void for_each(Function f, T&& t, Ts&&... ts)
-  requires(concepts::compatible_product_types<T, Ts...>)
+  requires(kumi::concepts::compatible_product_types<T, Ts...>)
 #ifndef KUMI_DOXYGEN_INVOKED
-          && (_::supports_call<Function&, T, Ts...>)
+          && (kumi::_::supports_call<Function&, T, Ts...>)
 #endif
   {
-    if constexpr (concepts::empty_product_type<T>) return;
+    if constexpr (kumi::concepts::empty_product_type<T>) return;
     else
     {
       auto const invoker{[&](auto const I) {
-        if constexpr (concepts::record_type<T>)
+        if constexpr (kumi::concepts::record_type<T>)
         {
-          constexpr auto field = identifier_of<element_t<I, T>>();
-          invoke(f, get<field>(KUMI_FWD(t)), get<field>(KUMI_FWD(ts))...);
+          constexpr auto field = kumi::identifier_of<element_t<I, T>>();
+          kumi::invoke(f, get<field>(KUMI_FWD(t)), get<field>(KUMI_FWD(ts))...);
         }
-        else invoke(f, get<I>(KUMI_FWD(t)), get<I>(KUMI_FWD(ts))...);
+        else kumi::invoke(f, get<I>(KUMI_FWD(t)), get<I>(KUMI_FWD(ts))...);
       }};
 
       [&]<std::size_t... I>(std::index_sequence<I...>) {
         (invoker(index<I>), ...);
-      }(std::make_index_sequence<size_v<T>>{});
+      }(std::make_index_sequence<kumi::size_v<T>>{});
     }
   }
 
@@ -77,18 +77,18 @@ namespace kumi
     @include doc/tuple/algo/for_each_index.cpp
   **/
   //====================================================================================================================
-  template<typename Function, concepts::product_type T, concepts::product_type... Ts>
+  template<typename Function, kumi::concepts::product_type T, kumi::concepts::product_type... Ts>
   KUMI_ABI constexpr void for_each_index(Function f, T&& t, Ts&&... ts)
-  requires(!concepts::record_type<T> && (!concepts::record_type<Ts> && ...))
+  requires(!kumi::concepts::record_type<T> && (!kumi::concepts::record_type<Ts> && ...))
   {
-    if constexpr (concepts::empty_product_type<T>) return;
+    if constexpr (kumi::concepts::empty_product_type<T>) return;
     else
     {
-      auto const invoker{[&](auto const I) { invoke(f, I, get<I>(KUMI_FWD(t)), get<I>(KUMI_FWD(ts))...); }};
+      auto const invoker{[&](auto const I) { kumi::invoke(f, I, get<I>(KUMI_FWD(t)), get<I>(KUMI_FWD(ts))...); }};
 
       [&]<std::size_t... I>(std::index_sequence<I...>) {
         (invoker(index<I>), ...);
-      }(std::make_index_sequence<size_v<T>>{});
+      }(std::make_index_sequence<kumi::size_v<T>>{});
     }
   }
 
@@ -115,22 +115,22 @@ namespace kumi
     @include doc/record/algo/for_each_field.cpp
   **/
   //====================================================================================================================
-  template<typename Function, concepts::record_type R, concepts::record_type... Rs>
+  template<typename Function, kumi::concepts::record_type R, kumi::concepts::record_type... Rs>
   KUMI_ABI constexpr void for_each_field(Function f, R&& r, Rs&&... rs)
-  requires(concepts::compatible_product_types<R, Rs...>)
+  requires(kumi::concepts::compatible_product_types<R, Rs...>)
   {
-    if constexpr (concepts::empty_product_type<R>) return;
+    if constexpr (kumi::concepts::empty_product_type<R>) return;
     else
     {
-      constexpr auto fields = members_of(as<R>{});
+      constexpr auto fields = kumi::members_of(as<R>{});
       auto const invoker = [&](auto const I) {
         constexpr auto field = get<I>(fields);
-        invoke(f, _::make_str(field), get<field>(KUMI_FWD(r)), get<field>(KUMI_FWD(rs))...);
+        kumi::invoke(f, kumi::_::make_str(field), get<field>(KUMI_FWD(r)), get<field>(KUMI_FWD(rs))...);
       };
 
       [&]<std::size_t... I>(std::index_sequence<I...>) {
         (invoker(index<I>), ...);
-      }(std::make_index_sequence<size_v<R>>{});
+      }(std::make_index_sequence<kumi::size_v<R>>{});
     }
   }
 }

--- a/include/kumi/algorithm/generate.hpp
+++ b/include/kumi/algorithm/generate.hpp
@@ -41,7 +41,7 @@ namespace kumi
     else
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
         auto eval = [](auto, auto const& vv) { return vv; };
-        return kumi::tuple{eval(index<I>, v)...};
+        return kumi::tuple{eval(kumi::index<I>, v)...};
       }(std::make_index_sequence<N>{});
   }
 
@@ -76,7 +76,7 @@ namespace kumi
     if constexpr (N == 0) return kumi::tuple{};
     else
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return kumi::tuple{invoke(f, index<I>)...};
+        return kumi::tuple{kumi::invoke(f, kumi::index<I>)...};
       }(std::make_index_sequence<N>{});
   }
 

--- a/include/kumi/algorithm/generate.hpp
+++ b/include/kumi/algorithm/generate.hpp
@@ -133,10 +133,10 @@ namespace kumi
       using type = decltype(kumi::iota<N>(std::declval<T>()));
     };
 
-    template<std::size_t N, typename T> using fill_t = typename fill<N, T>::type;
+    template<std::size_t N, typename T> using fill_t = typename kumi::result::fill<N, T>::type;
 
-    template<std::size_t N, typename Function> using generate_t = typename generate<N, Function>::type;
+    template<std::size_t N, typename Function> using generate_t = typename kumi::result::generate<N, Function>::type;
 
-    template<std::size_t N, typename T> using iota_t = typename iota<N, T>::type;
+    template<std::size_t N, typename T> using iota_t = typename kumi::result::iota<N, T>::type;
   }
 }

--- a/include/kumi/algorithm/inner_product.hpp
+++ b/include/kumi/algorithm/inner_product.hpp
@@ -61,58 +61,59 @@ namespace kumi
     @include doc/record/algo/inner_product.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type S1,
-           concepts::sized_product_type<size_v<S1>> S2,
+  template<kumi::concepts::product_type S1,
+           kumi::concepts::sized_product_type<kumi::size_v<S1>> S2,
            typename T,
            typename Sum,
            typename Prod>
   [[nodiscard]] KUMI_ABI constexpr auto inner_product(S1&& s1, S2&& s2, T init, Sum sum, Prod prod) noexcept
-  requires(concepts::compatible_product_types<S1, S2>)
+  requires(kumi::concepts::compatible_product_types<S1, S2>)
   {
-    if constexpr (concepts::empty_product_type<S1>) return init;
-    else if constexpr (concepts::record_type<S1>)
+    if constexpr (kumi::concepts::empty_product_type<S1>) return init;
+    else if constexpr (kumi::concepts::record_type<S1>)
     {
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return (function::foldable{init} >> ... >>
-                bind_back(sum, invoke(prod, get<identifier_of<element_t<I, S1>>()>(KUMI_FWD(s1)),
-                                      get<identifier_of<element_t<I, S1>>()>(KUMI_FWD(s2)))))();
-      }(std::make_index_sequence<size_v<S1>>());
+        return (
+          kumi::function::foldable{init} >> ... >>
+          kumi::bind_back(sum, kumi::invoke(prod, get<kumi::identifier_of<kumi::element_t<I, S1>>()>(KUMI_FWD(s1)),
+                                            get<kumi::identifier_of<kumi::element_t<I, S1>>()>(KUMI_FWD(s2)))))();
+      }(std::make_index_sequence<kumi::size_v<S1>>{});
     }
     else
     {
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return (function::foldable{init} >> ... >>
-                bind_back(sum, invoke(prod, get<I>(KUMI_FWD(s1)), get<I>(KUMI_FWD(s2)))))();
-      }(std::make_index_sequence<size_v<S1>>{});
+        return (kumi::function::foldable{init} >> ... >>
+                kumi::bind_back(sum, kumi::invoke(prod, get<I>(KUMI_FWD(s1)), get<I>(KUMI_FWD(s2)))))();
+      }(std::make_index_sequence<kumi::size_v<S1>>{});
     }
   }
 
   //! @overload
-  template<concepts::product_type S1, concepts::sized_product_type<size_v<S1>> S2, typename T>
+  template<kumi::concepts::product_type S1, kumi::concepts::sized_product_type<kumi::size_v<S1>> S2, typename T>
   [[nodiscard]] KUMI_ABI constexpr auto inner_product(S1&& s1, S2&& s2, T init) noexcept
-  requires(concepts::compatible_product_types<S1, S2>)
+  requires(kumi::concepts::compatible_product_types<S1, S2>)
   {
-    if constexpr (concepts::empty_product_type<S1>) return init;
-    else if constexpr (concepts::record_type<S1>)
+    if constexpr (kumi::concepts::empty_product_type<S1>) return init;
+    else if constexpr (kumi::concepts::record_type<S1>)
     {
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
         return (init + ... +
-                (get<identifier_of<element_t<I, S1>>()>(KUMI_FWD(s1)) *
-                 get<identifier_of<element_t<I, S1>>()>(KUMI_FWD(s2))));
-      }(std::make_index_sequence<size<S1>::value>());
+                (get<kumi::identifier_of<kumi::element_t<I, S1>>()>(KUMI_FWD(s1)) *
+                 get<kumi::identifier_of<kumi::element_t<I, S1>>()>(KUMI_FWD(s2))));
+      }(std::make_index_sequence<kumi::size_v<S1>>{});
     }
     else
     {
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
         return (init + ... + (get<I>(KUMI_FWD(s1)) * get<I>(KUMI_FWD(s2))));
-      }(std::make_index_sequence<size_v<S1>>{});
+      }(std::make_index_sequence<kumi::size_v<S1>>{});
     }
   }
 
   namespace result
   {
-    template<concepts::product_type S1,
-             concepts::sized_product_type<size_v<S1>> S2,
+    template<kumi::concepts::product_type S1,
+             kumi::concepts::sized_product_type<kumi::size_v<S1>> S2,
              typename T,
              typename Sum,
              typename Prod>
@@ -122,14 +123,14 @@ namespace kumi
         std::declval<S1>(), std::declval<S2>(), std::declval<T>(), std::declval<Sum>(), std::declval<Prod>()));
     };
 
-    template<concepts::product_type S1, concepts::sized_product_type<size_v<S1>> S2, typename T>
+    template<kumi::concepts::product_type S1, kumi::concepts::sized_product_type<kumi::size_v<S1>> S2, typename T>
     struct inner_product<S1, S2, T, void, void>
     {
       using type = decltype(kumi::inner_product(std::declval<S1>(), std::declval<S2>(), std::declval<T>()));
     };
 
-    template<concepts::product_type S1,
-             concepts::sized_product_type<size_v<S1>> S2,
+    template<kumi::concepts::product_type S1,
+             kumi::concepts::sized_product_type<kumi::size_v<S1>> S2,
              typename T,
              typename Sum = void,
              typename Prod = void>

--- a/include/kumi/algorithm/inner_product.hpp
+++ b/include/kumi/algorithm/inner_product.hpp
@@ -134,6 +134,6 @@ namespace kumi
              typename T,
              typename Sum = void,
              typename Prod = void>
-    using inner_product_t = typename inner_product<S1, S2, T, Sum, Prod>::type;
+    using inner_product_t = typename kumi::result::inner_product<S1, S2, T, Sum, Prod>::type;
   }
 }

--- a/include/kumi/algorithm/map.hpp
+++ b/include/kumi/algorithm/map.hpp
@@ -206,16 +206,16 @@ namespace kumi
     template<typename Function,
              kumi::concepts::product_type T,
              kumi::concepts::sized_product_type<kumi::size_v<T>>... Ts>
-    using map_t = typename map<Function, T, Ts...>::type;
+    using map_t = typename kumi::result::map<Function, T, Ts...>::type;
 
     template<typename Function,
              kumi::concepts::product_type T,
              kumi::concepts::sized_product_type<kumi::size_v<T>>... Ts>
-    using map_index_t = typename map_index<Function, T, Ts...>::type;
+    using map_index_t = typename kumi::result::map_index<Function, T, Ts...>::type;
 
     template<typename Function,
              kumi::concepts::record_type T,
              kumi::concepts::sized_product_type<kumi::size_v<T>>... Ts>
-    using map_field_t = typename map_field<Function, T, Ts...>::type;
+    using map_field_t = typename kumi::result::map_field<Function, T, Ts...>::type;
   }
 }

--- a/include/kumi/algorithm/map.hpp
+++ b/include/kumi/algorithm/map.hpp
@@ -47,28 +47,28 @@ namespace kumi
     @include doc/record/algo/map.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T, typename Function, concepts::sized_product_type<size_v<T>>... Ts>
+  template<kumi::concepts::product_type T, typename Function, kumi::concepts::sized_product_type<kumi::size_v<T>>... Ts>
   [[nodiscard]] KUMI_ABI constexpr auto map(Function f, T&& t0, Ts&&... others)
-  requires(concepts::compatible_product_types<T, Ts...>)
+  requires(kumi::concepts::compatible_product_types<T, Ts...>)
 #ifndef KUMI_DOXYGEN_INVOKED
-          && (_::supports_call<Function, T &&, Ts && ...>)
+          && (kumi::_::supports_call<Function, T &&, Ts && ...>)
 #endif
   {
-    if constexpr (concepts::empty_product_type<T>) return builder<T>::make();
+    if constexpr (kumi::concepts::empty_product_type<T>) return builder<T>::make();
     else
     {
       auto const call{[&](auto const N, auto&&... args) {
-        if constexpr (concepts::record_type<T>)
+        if constexpr (kumi::concepts::record_type<T>)
         {
-          constexpr auto field = identifier_of<element_t<N, T>>();
-          return capture_field<field>(invoke(f, get<field>(args)...));
+          constexpr auto field = kumi::identifier_of<kumi::element_t<N, T>>();
+          return kumi::capture_field<field>(kumi::invoke(f, get<field>(args)...));
         }
-        else return invoke(f, get<N>(KUMI_FWD(args))...);
+        else return kumi::invoke(f, get<N>(KUMI_FWD(args))...);
       }};
 
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return builder<T>::make(call(index<I>, KUMI_FWD(t0), KUMI_FWD(others)...)...);
-      }(std::make_index_sequence<size_v<T>>{});
+        return builder<T>::make(call(kumi::index<I>, KUMI_FWD(t0), KUMI_FWD(others)...)...);
+      }(std::make_index_sequence<kumi::size_v<T>>{});
     }
   }
 
@@ -108,18 +108,18 @@ namespace kumi
     @include doc/tuple/algo/map_index.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T, typename Function, concepts::sized_product_type<size_v<T>>... Ts>
+  template<kumi::concepts::product_type T, typename Function, kumi::concepts::sized_product_type<kumi::size_v<T>>... Ts>
   [[nodiscard]] KUMI_ABI constexpr auto map_index(Function f, T&& t0, Ts&&... others)
-  requires(!concepts::record_type<T> && (!concepts::record_type<Ts> && ...))
+  requires(!kumi::concepts::record_type<T> && (!kumi::concepts::record_type<Ts> && ...))
   {
-    if constexpr (concepts::empty_product_type<T>) return builder<T>::make();
+    if constexpr (kumi::concepts::empty_product_type<T>) return builder<T>::make();
     else
     {
-      auto const call{[&](auto const N, auto&&... args) { return invoke(f, N, get<N>(KUMI_FWD(args))...); }};
+      auto const call{[&](auto const N, auto&&... args) { return kumi::invoke(f, N, get<N>(KUMI_FWD(args))...); }};
 
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return builder<T>::make(call(index<I>, KUMI_FWD(t0), KUMI_FWD(others)...)...);
-      }(std::make_index_sequence<size_v<T>>{});
+        return builder<T>::make(call(kumi::index<I>, KUMI_FWD(t0), KUMI_FWD(others)...)...);
+      }(std::make_index_sequence<kumi::size_v<T>>{});
     }
   }
 
@@ -159,50 +159,63 @@ namespace kumi
     @include doc/record/algo/map_field.cpp
   **/
   //====================================================================================================================
-  template<concepts::record_type T, typename Function, concepts::sized_product_type<size_v<T>>... Ts>
+  template<kumi::concepts::record_type T, typename Function, kumi::concepts::sized_product_type<kumi::size_v<T>>... Ts>
   [[nodiscard]] KUMI_ABI constexpr auto map_field(Function f, T&& t0, Ts&&... others)
-  requires(concepts::compatible_product_types<T, Ts...>)
+  requires(kumi::concepts::compatible_product_types<T, Ts...>)
   {
-    if constexpr (concepts::empty_product_type<T>) return builder<T>::make();
+    if constexpr (kumi::concepts::empty_product_type<T>) return builder<T>::make();
     else
     {
       auto const call{[&](auto const N, auto&&... args) {
-        constexpr auto field = identifier_of<element_t<N, T>>();
-        return capture_field<field>(invoke(f, _::make_str(field), (get<field>(args))...));
+        constexpr auto field = kumi::identifier_of<kumi::element_t<N, T>>();
+        return kumi::capture_field<field>(kumi::invoke(f, kumi::_::make_str(field), (get<field>(args))...));
       }};
 
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return builder<T>::make(call(index<I>, KUMI_FWD(t0), KUMI_FWD(others)...)...);
-      }(std::make_index_sequence<size_v<T>>{});
+        return builder<T>::make(call(kumi::index<I>, KUMI_FWD(t0), KUMI_FWD(others)...)...);
+      }(std::make_index_sequence<kumi::size_v<T>>{});
     }
   }
 
   namespace result
   {
-    template<typename Function, concepts::product_type T, concepts::sized_product_type<size<T>::value>... Ts> struct map
+    template<typename Function,
+             kumi::concepts::product_type T,
+             kumi::concepts::sized_product_type<kumi::size_v<T>>... Ts>
+    struct map
     {
       using type = decltype(kumi::map(std::declval<Function>(), std::declval<T>(), std::declval<Ts>()...));
     };
 
-    template<typename Function, concepts::product_type T, concepts::sized_product_type<size<T>::value>... Ts>
+    template<typename Function,
+             kumi::concepts::product_type T,
+             kumi::concepts::sized_product_type<kumi::size_v<T>>... Ts>
     struct map_index
     {
       using type = decltype(kumi::map_index(std::declval<Function>(), std::declval<T>(), std::declval<Ts>()...));
     };
 
-    template<typename Function, concepts::record_type T, concepts::sized_product_type<size<T>::value>... Ts>
+    template<typename Function,
+             kumi::concepts::record_type T,
+             kumi::concepts::sized_product_type<kumi::size_v<T>>... Ts>
     struct map_field
     {
       using type = decltype(kumi::map_field(std::declval<Function>(), std::declval<T>(), std::declval<Ts>()...));
     };
 
-    template<typename Function, concepts::product_type T, concepts::sized_product_type<size<T>::value>... Ts>
+    template<typename Function,
+             kumi::concepts::product_type T,
+             kumi::concepts::sized_product_type<kumi::size_v<T>>... Ts>
     using map_t = typename map<Function, T, Ts...>::type;
 
-    template<typename Function, concepts::product_type T, concepts::sized_product_type<size<T>::value>... Ts>
+    template<typename Function,
+             kumi::concepts::product_type T,
+             kumi::concepts::sized_product_type<kumi::size_v<T>>... Ts>
     using map_index_t = typename map_index<Function, T, Ts...>::type;
 
-    template<typename Function, concepts::record_type T, concepts::sized_product_type<size<T>::value>... Ts>
+    template<typename Function,
+             kumi::concepts::record_type T,
+             kumi::concepts::sized_product_type<kumi::size_v<T>>... Ts>
     using map_field_t = typename map_field<Function, T, Ts...>::type;
   }
 }

--- a/include/kumi/algorithm/minmax.hpp
+++ b/include/kumi/algorithm/minmax.hpp
@@ -36,16 +36,16 @@ namespace kumi
     @include doc/record/algo/max.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto max(T&& t) noexcept
+  template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto max(T&& t) noexcept
   {
-    if constexpr (concepts::record_type<T>) return max(values_of(KUMI_FWD(t)));
-    else if constexpr (concepts::sized_product_type<T, 1>) return get<0>(KUMI_FWD(t));
+    if constexpr (kumi::concepts::record_type<T>) return kumi::max(kumi::values_of(KUMI_FWD(t)));
+    else if constexpr (kumi::concepts::sized_product_type<T, 1>) return get<0>(KUMI_FWD(t));
     else
     {
       auto const f = [](auto cur, auto u) { return cur > u ? cur : u; };
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return (function::foldable{get<0>(KUMI_FWD(t))} >> ... >> bind_back(f, get<I + 1>(KUMI_FWD(t))))();
-      }(std::make_index_sequence<size_v<T> - 1>{});
+        return (kumi::function::foldable{get<0>(KUMI_FWD(t))} >> ... >> kumi::bind_back(f, get<I + 1>(KUMI_FWD(t))))();
+      }(std::make_index_sequence<kumi::size_v<T> - 1>{});
     }
   }
 
@@ -77,16 +77,16 @@ namespace kumi
     @include doc/record/algo/max.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T, typename F> [[nodiscard]] KUMI_ABI constexpr auto max(T&& t, F f) noexcept
+  template<kumi::concepts::product_type T, typename F> [[nodiscard]] KUMI_ABI constexpr auto max(T&& t, F f) noexcept
   {
-    if constexpr (concepts::record_type<T>) return max(values_of(KUMI_FWD(t)), f);
-    else if constexpr (concepts::sized_product_type<T, 1>) return invoke(f, get<0>(KUMI_FWD(t)));
+    if constexpr (kumi::concepts::record_type<T>) return kumi::max(kumi::values_of(KUMI_FWD(t)), f);
+    else if constexpr (kumi::concepts::sized_product_type<T, 1>) return invoke(f, get<0>(KUMI_FWD(t)));
     else
     {
       auto const c = [f](auto cur, auto const& u) { return cur > invoke(f, u) ? cur : invoke(f, u); };
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
         return (function::foldable{invoke(f, get<0>(KUMI_FWD(t)))} >> ... >> bind_back(c, get<I + 1>(KUMI_FWD(t))))();
-      }(std::make_index_sequence<size_v<T> - 1>{});
+      }(std::make_index_sequence<kumi::size_v<T> - 1>{});
     }
   }
 
@@ -118,17 +118,18 @@ namespace kumi
     @include doc/record/algo/max_flat.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T, typename F> [[nodiscard]] KUMI_ABI constexpr auto max_flat(T&& t, F f) noexcept
+  template<kumi::concepts::product_type T, typename F>
+  [[nodiscard]] KUMI_ABI constexpr auto max_flat(T&& t, F f) noexcept
   {
-    if constexpr (concepts::empty_product_type<T>) return 0;
-    else if constexpr (concepts::record_type<T>) return max_flat(values_of(KUMI_FWD(t)), f);
+    if constexpr (kumi::concepts::empty_product_type<T>) return 0;
+    else if constexpr (kumi::concepts::record_type<T>) return kumi::max_flat(kumi::values_of(KUMI_FWD(t)), f);
     else
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return max(make_tuple([&]<typename V>(V&& v) {
-          if constexpr (concepts::product_type<V>) return max_flat(KUMI_FWD(v), f);
-          else return invoke(f, v);
+        return kumi::max(kumi::make_tuple([&]<typename V>(V&& v) {
+          if constexpr (kumi::concepts::product_type<V>) return kumi::max_flat(KUMI_FWD(v), f);
+          else return kumi::invoke(f, v);
         }(get<I>(KUMI_FWD(t)))...));
-      }(std::make_index_sequence<size_v<T>>{});
+      }(std::make_index_sequence<kumi::size_v<T>>{});
   }
 
   //====================================================================================================================
@@ -158,16 +159,16 @@ namespace kumi
     @include doc/record/algo/min.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto min(T&& t) noexcept
+  template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto min(T&& t) noexcept
   {
-    if constexpr (concepts::record_type<T>) return min(values_of(KUMI_FWD(t)));
-    else if constexpr (concepts::sized_product_type<T, 1>) return get<0>(KUMI_FWD(t));
+    if constexpr (kumi::concepts::record_type<T>) return kumi::min(kumi::values_of(KUMI_FWD(t)));
+    else if constexpr (kumi::concepts::sized_product_type<T, 1>) return get<0>(KUMI_FWD(t));
     else
     {
       auto const f = [](auto cur, auto u) { return cur < u ? cur : u; };
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return (function::foldable{get<0>(KUMI_FWD(t))} >> ... >> bind_back(f, get<I + 1>(KUMI_FWD(t))))();
-      }(std::make_index_sequence<size_v<T> - 1>{});
+        return (kumi::function::foldable{get<0>(KUMI_FWD(t))} >> ... >> kumi::bind_back(f, get<I + 1>(KUMI_FWD(t))))();
+      }(std::make_index_sequence<kumi::size_v<T> - 1>{});
     }
   }
 
@@ -199,16 +200,17 @@ namespace kumi
     @include doc/record/algo/min.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T, typename F> [[nodiscard]] KUMI_ABI constexpr auto min(T&& t, F f) noexcept
+  template<kumi::concepts::product_type T, typename F> [[nodiscard]] KUMI_ABI constexpr auto min(T&& t, F f) noexcept
   {
-    if constexpr (concepts::record_type<T>) return min(values_of(KUMI_FWD(t)), f);
-    else if constexpr (concepts::sized_product_type<T, 1>) return invoke(f, get<0>(KUMI_FWD(t)));
+    if constexpr (kumi::concepts::record_type<T>) return kumi::min(kumi::values_of(KUMI_FWD(t)), f);
+    else if constexpr (kumi::concepts::sized_product_type<T, 1>) return kumi::invoke(f, get<0>(KUMI_FWD(t)));
     else
     {
       auto const c = [f](auto cur, auto const& u) { return cur < invoke(f, u) ? cur : invoke(f, u); };
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return (function::foldable{invoke(f, get<0>(KUMI_FWD(t)))} >> ... >> bind_back(c, get<I + 1>(KUMI_FWD(t))))();
-      }(std::make_index_sequence<size_v<T> - 1>{});
+        return (function::foldable{kumi::invoke(f, get<0>(KUMI_FWD(t)))} >> ... >>
+                kumi::bind_back(c, get<I + 1>(KUMI_FWD(t))))();
+      }(std::make_index_sequence<kumi::size_v<T> - 1>{});
     }
   }
 
@@ -240,17 +242,18 @@ namespace kumi
     @include doc/record/algo/min_flat.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T, typename F> [[nodiscard]] KUMI_ABI constexpr auto min_flat(T&& t, F f) noexcept
+  template<kumi::concepts::product_type T, typename F>
+  [[nodiscard]] KUMI_ABI constexpr auto min_flat(T&& t, F f) noexcept
   {
-    if constexpr (concepts::empty_product_type<T>) return 0;
-    else if constexpr (concepts::record_type<T>) return min_flat(values_of(KUMI_FWD(t)), f);
+    if constexpr (kumi::concepts::empty_product_type<T>) return 0;
+    else if constexpr (kumi::concepts::record_type<T>) return kumi::min_flat(kumi::values_of(KUMI_FWD(t)), f);
     else
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return min(make_tuple([&]<typename V>(V&& v) {
-          if constexpr (concepts::product_type<V>) return min_flat(KUMI_FWD(v), f);
-          else return invoke(f, v);
+        return kumi::min(kumi::make_tuple([&]<typename V>(V&& v) {
+          if constexpr (kumi::concepts::product_type<V>) return kumi::min_flat(KUMI_FWD(v), f);
+          else return kumi::invoke(f, v);
         }(get<I>(KUMI_FWD(t)))...));
-      }(std::make_index_sequence<size_v<T>>{});
+      }(std::make_index_sequence<kumi::size_v<T>>{});
   }
 
   namespace result

--- a/include/kumi/algorithm/minmax.hpp
+++ b/include/kumi/algorithm/minmax.hpp
@@ -289,10 +289,10 @@ namespace kumi
       using type = decltype(kumi::min_flat(std::declval<T>(), std::declval<F>()));
     };
 
-    template<typename T, typename F = void> using max_t = typename max<T, F>::type;
-    template<typename T, typename F> using max_flat_t = typename max_flat<T, F>::type;
+    template<typename T, typename F = void> using max_t = typename kumi::result::max<T, F>::type;
+    template<typename T, typename F> using max_flat_t = typename kumi::result::max_flat<T, F>::type;
 
-    template<typename T, typename F = void> using min_t = typename min<T, F>::type;
-    template<typename T, typename F> using min_flat_t = typename min_flat<T, F>::type;
+    template<typename T, typename F = void> using min_t = typename kumi::result::min<T, F>::type;
+    template<typename T, typename F> using min_flat_t = typename kumi::result::min_flat<T, F>::type;
   }
 }

--- a/include/kumi/algorithm/partition.hpp
+++ b/include/kumi/algorithm/partition.hpp
@@ -40,23 +40,23 @@ namespace kumi
     @include doc/record/algo/partition.cpp
   **/
   //====================================================================================================================
-  template<template<typename> typename Pred, concepts::product_type T>
+  template<template<typename> typename Pred, kumi::concepts::product_type T>
   [[nodiscard]] KUMI_ABI constexpr auto partition(T&& t) noexcept
   {
-    if constexpr (concepts::empty_product_type<T>) return tuple{builder<T>::make(), builder<T>::make()};
+    if constexpr (kumi::concepts::empty_product_type<T>) return kumi::tuple{builder<T>::make(), builder<T>::make()};
     else
     {
       constexpr auto pos = []<std::size_t... I>(std::index_sequence<I...>) {
-        return function::selector(std::bool_constant<Pred<stored_element_t<I, T>>::value>{}...);
-      }(std::make_index_sequence<size_v<T>>{});
+        return kumi::function::selector(std::bool_constant<Pred<kumi::stored_element_t<I, T>>::value>{}...);
+      }(std::make_index_sequence<kumi::size_v<T>>{});
 
       auto select = [&]<typename O, std::size_t... I>(O, std::index_sequence<I...>) {
-        using type = builder_make_t<T, element_t<pos.t[O::value + I], T>...>;
+        using type = builder_make_t<T, kumi::element_t<pos.t[O::value + I], T>...>;
         return type{get<pos.t[O::value + I]>(KUMI_FWD(t))...};
       };
 
       return kumi::tuple{select(kumi::index<0>, std::make_index_sequence<pos.cut>{}),
-                         select(kumi::index<pos.cut>, std::make_index_sequence<size_v<T> - pos.cut>{})};
+                         select(kumi::index<pos.cut>, std::make_index_sequence<kumi::size_v<T> - pos.cut>{})};
     }
   }
 
@@ -90,18 +90,18 @@ namespace kumi
     @include doc/record/algo/filter.cpp
   **/
   //====================================================================================================================
-  template<template<typename> typename Pred, concepts::product_type T>
+  template<template<typename> typename Pred, kumi::concepts::product_type T>
   [[nodiscard]] KUMI_ABI constexpr auto filter(T&& t) noexcept
   {
-    if constexpr (concepts::empty_product_type<T>) return builder<T>::make();
+    if constexpr (kumi::concepts::empty_product_type<T>) return builder<T>::make();
     else
     {
       constexpr auto pos = []<std::size_t... I>(std::index_sequence<I...>) {
-        return function::selector(std::bool_constant<Pred<stored_element_t<I, T>>::value>{}...);
-      }(std::make_index_sequence<size_v<T>>{});
+        return kumi::function::selector(std::bool_constant<Pred<kumi::stored_element_t<I, T>>::value>{}...);
+      }(std::make_index_sequence<kumi::size_v<T>>{});
 
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        using type = builder_make_t<T, element_t<pos.t[I], T>...>;
+        using type = builder_make_t<T, kumi::element_t<pos.t[I], T>...>;
         return type{get<pos.t[I]>(KUMI_FWD(t))...};
       }(std::make_index_sequence<pos.cut>{});
     }
@@ -137,20 +137,20 @@ namespace kumi
     @include doc/record/algo/filter_not.cpp
   **/
   //====================================================================================================================
-  template<template<typename> typename Pred, concepts::product_type T>
+  template<template<typename> typename Pred, kumi::concepts::product_type T>
   [[nodiscard]] KUMI_ABI constexpr auto filter_not(T&& t) noexcept
   {
-    if constexpr (concepts::empty_product_type<T>) return builder<T>::make();
+    if constexpr (kumi::concepts::empty_product_type<T>) return builder<T>::make();
     else
     {
       constexpr auto pos = []<std::size_t... I>(std::index_sequence<I...>) {
-        return function::selector(std::bool_constant<Pred<stored_element_t<I, T>>::value>{}...);
-      }(std::make_index_sequence<size_v<T>>{});
+        return function::selector(std::bool_constant<Pred<kumi::stored_element_t<I, T>>::value>{}...);
+      }(std::make_index_sequence<kumi::size_v<T>>{});
 
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        using type = builder_make_t<T, element_t<pos.t[pos.cut + I], T>...>;
+        using type = builder_make_t<T, kumi::element_t<pos.t[pos.cut + I], T>...>;
         return type{get<pos.t[pos.cut + I]>(KUMI_FWD(t))...};
-      }(std::make_index_sequence<size_v<T> - pos.cut>{});
+      }(std::make_index_sequence<kumi::size_v<T> - pos.cut>{});
     }
   }
 

--- a/include/kumi/algorithm/partition.hpp
+++ b/include/kumi/algorithm/partition.hpp
@@ -172,12 +172,12 @@ namespace kumi
     };
 
     template<template<typename> typename Pred, kumi::concepts::product_type T>
-    using partition_t = typename partition<Pred, T>::type;
+    using partition_t = typename kumi::result::partition<Pred, T>::type;
 
     template<template<typename> typename Pred, kumi::concepts::product_type T>
-    using filter_t = typename filter<Pred, T>::type;
+    using filter_t = typename kumi::result::filter<Pred, T>::type;
 
     template<template<typename> typename Pred, kumi::concepts::product_type T>
-    using filter_not_t = typename filter_not<Pred, T>::type;
+    using filter_not_t = typename kumi::result::filter_not<Pred, T>::type;
   }
 }

--- a/include/kumi/algorithm/predicates.hpp
+++ b/include/kumi/algorithm/predicates.hpp
@@ -26,15 +26,16 @@ namespace kumi
     @include doc/record/algo/all_of.cpp
   **/
   //====================================================================================================================
-  template<typename Pred, concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto all_of(T&& t, Pred p) noexcept
+  template<typename Pred, kumi::concepts::product_type T>
+  [[nodiscard]] KUMI_ABI constexpr auto all_of(T&& t, Pred p) noexcept
   {
-    if constexpr (concepts::empty_product_type<T>) return true;
-    else if constexpr (concepts::record_type<T>) return all_of(values_of(KUMI_FWD(t)), p);
-    else if constexpr (concepts::sized_product_type<T, 1>) return invoke(p, get<0>(KUMI_FWD(t)));
+    if constexpr (kumi::concepts::empty_product_type<T>) return true;
+    else if constexpr (kumi::concepts::record_type<T>) return kumi::all_of(kumi::values_of(KUMI_FWD(t)), p);
+    else if constexpr (kumi::concepts::sized_product_type<T, 1>) return kumi::invoke(p, get<0>(KUMI_FWD(t)));
     else
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return (invoke(p, get<I>(KUMI_FWD(t))) && ...);
-      }(std::make_index_sequence<size_v<T>>{});
+        return (kumi::invoke(p, get<I>(KUMI_FWD(t))) && ...);
+      }(std::make_index_sequence<kumi::size_v<T>>{});
   }
 
   //====================================================================================================================
@@ -53,15 +54,15 @@ namespace kumi
     @include doc/record/algo/all_of.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto all_of(T&& t) noexcept
+  template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto all_of(T&& t) noexcept
   {
-    if constexpr (concepts::empty_product_type<T>) return true;
-    else if constexpr (concepts::record_type<T>) return all_of(values_of(KUMI_FWD(t)));
-    else if constexpr (concepts::sized_product_type<T, 1>) return !!get<0>(KUMI_FWD(t));
+    if constexpr (kumi::concepts::empty_product_type<T>) return true;
+    else if constexpr (kumi::concepts::record_type<T>) return kumi::all_of(kumi::values_of(KUMI_FWD(t)));
+    else if constexpr (kumi::concepts::sized_product_type<T, 1>) return !!get<0>(KUMI_FWD(t));
     else
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
         return (get<I>(KUMI_FWD(t)) && ...);
-      }(std::make_index_sequence<size_v<T>>{});
+      }(std::make_index_sequence<kumi::size_v<T>>{});
   }
 
   //====================================================================================================================
@@ -81,15 +82,16 @@ namespace kumi
     @include doc/record/algo/any_of.cpp
   **/
   //====================================================================================================================
-  template<typename Pred, concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto any_of(T&& t, Pred p) noexcept
+  template<typename Pred, kumi::concepts::product_type T>
+  [[nodiscard]] KUMI_ABI constexpr auto any_of(T&& t, Pred p) noexcept
   {
-    if constexpr (concepts::empty_product_type<T>) return true;
-    else if constexpr (concepts::record_type<T>) return any_of(values_of(KUMI_FWD(t)), p);
-    else if constexpr (concepts::sized_product_type<T, 1>) return invoke(p, get<0>(KUMI_FWD(t)));
+    if constexpr (kumi::concepts::empty_product_type<T>) return true;
+    else if constexpr (kumi::concepts::record_type<T>) return kumi::any_of(kumi::values_of(KUMI_FWD(t)), p);
+    else if constexpr (kumi::concepts::sized_product_type<T, 1>) return kumi::invoke(p, get<0>(KUMI_FWD(t)));
     else
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return (invoke(p, get<I>(KUMI_FWD(t))) || ...);
-      }(std::make_index_sequence<size_v<T>>{});
+        return (kumi::invoke(p, get<I>(KUMI_FWD(t))) || ...);
+      }(std::make_index_sequence<kumi::size_v<T>>{});
   }
 
   //====================================================================================================================
@@ -108,15 +110,15 @@ namespace kumi
     @include doc/record/algo/any_of.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto any_of(T&& t) noexcept
+  template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto any_of(T&& t) noexcept
   {
-    if constexpr (concepts::empty_product_type<T>) return false;
-    else if constexpr (concepts::record_type<T>) return any_of(values_of(KUMI_FWD(t)));
-    else if constexpr (concepts::sized_product_type<T, 1>) return !!get<0>(KUMI_FWD(t));
+    if constexpr (kumi::concepts::empty_product_type<T>) return false;
+    else if constexpr (kumi::concepts::record_type<T>) return kumi::any_of(kumi::values_of(KUMI_FWD(t)));
+    else if constexpr (kumi::concepts::sized_product_type<T, 1>) return !!get<0>(KUMI_FWD(t));
     else
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
         return (get<I>(KUMI_FWD(t)) || ...);
-      }(std::make_index_sequence<size_v<T>>{});
+      }(std::make_index_sequence<kumi::size_v<T>>{});
   }
 
   //====================================================================================================================
@@ -136,10 +138,10 @@ namespace kumi
     @include doc/record/algo/none_of.cpp
   **/
   //====================================================================================================================
-  template<typename Pred, concepts::product_type T>
+  template<typename Pred, kumi::concepts::product_type T>
   [[nodiscard]] KUMI_ABI constexpr bool none_of(T&& t, Pred p) noexcept
   {
-    return !any_of(KUMI_FWD(t), p);
+    return !kumi::any_of(KUMI_FWD(t), p);
   }
 
   //====================================================================================================================
@@ -158,9 +160,9 @@ namespace kumi
     @include doc/record/algo/none_of.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr bool none_of(T&& t) noexcept
+  template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr bool none_of(T&& t) noexcept
   {
-    return !any_of(KUMI_FWD(t));
+    return !kumi::any_of(KUMI_FWD(t));
   }
 
   //====================================================================================================================
@@ -180,17 +182,17 @@ namespace kumi
     @include doc/record/algo/count_if.cpp
   **/
   //====================================================================================================================
-  template<typename Pred, concepts::product_type T>
+  template<typename Pred, kumi::concepts::product_type T>
   [[nodiscard]] KUMI_ABI constexpr std::size_t count_if(T&& t, Pred p) noexcept
   {
     constexpr std::size_t o = 1ULL;
     constexpr std::size_t z = 0ULL;
-    if constexpr (concepts::empty_product_type<T>) return z;
-    else if constexpr (concepts::record_type<T>) return count_if(values_of(KUMI_FWD(t)), p);
+    if constexpr (kumi::concepts::empty_product_type<T>) return z;
+    else if constexpr (kumi::concepts::record_type<T>) return kumi::count_if(values_of(KUMI_FWD(t)), p);
     else
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return ((invoke(p, get<I>(KUMI_FWD(t))) ? o : z) + ... + z);
-      }(std::make_index_sequence<size_v<T>>{});
+        return ((kumi::invoke(p, get<I>(KUMI_FWD(t))) ? o : z) + ... + z);
+      }(std::make_index_sequence<kumi::size_v<T>>{});
   }
 
   //====================================================================================================================
@@ -209,8 +211,8 @@ namespace kumi
     @include doc/record/algo/count.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr std::size_t count(T&& t) noexcept
+  template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr std::size_t count(T&& t) noexcept
   {
-    return count_if(KUMI_FWD(t), [](auto const& m) { return static_cast<bool>(m); });
+    return kumi::count_if(KUMI_FWD(t), [](auto const& m) { return static_cast<bool>(m); });
   }
 }

--- a/include/kumi/algorithm/push_pop.hpp
+++ b/include/kumi/algorithm/push_pop.hpp
@@ -41,11 +41,11 @@ namespace kumi
     @include doc/record/algo/push_front.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T, typename V> [[nodiscard]] KUMI_ABI constexpr auto push_front(T&& t, V&& v)
+  template<kumi::concepts::product_type T, typename V> [[nodiscard]] KUMI_ABI constexpr auto push_front(T&& t, V&& v)
   {
     return [&]<std::size_t... I>(std::index_sequence<I...>) {
       return builder<T>::make(KUMI_FWD(v), get<I>(KUMI_FWD(t))...);
-    }(std::make_index_sequence<size_v<T>>{});
+    }(std::make_index_sequence<kumi::size_v<T>>{});
   }
 
   //====================================================================================================================
@@ -79,13 +79,13 @@ namespace kumi
     @include doc/record/algo/pop_front.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto pop_front(T&& t)
+  template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto pop_front(T&& t)
   {
-    if constexpr (concepts::empty_product_type<T>) return builder<T>::make();
+    if constexpr (kumi::concepts::empty_product_type<T>) return builder<T>::make();
     else
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
         return builder<T>::make(get<I + 1>(KUMI_FWD(t))...);
-      }(std::make_index_sequence<size_v<T> - 1>{});
+      }(std::make_index_sequence<kumi::size_v<T> - 1>{});
   }
 
   //====================================================================================================================
@@ -120,11 +120,11 @@ namespace kumi
     @include doc/record/algo/push_back.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T, typename V> [[nodiscard]] KUMI_ABI constexpr auto push_back(T&& t, V&& v)
+  template<kumi::concepts::product_type T, typename V> [[nodiscard]] KUMI_ABI constexpr auto push_back(T&& t, V&& v)
   {
     return [&]<std::size_t... I>(std::index_sequence<I...>) {
       return builder<T>::make(get<I>(KUMI_FWD(t))..., KUMI_FWD(v));
-    }(std::make_index_sequence<size_v<T>>());
+    }(std::make_index_sequence<kumi::size_v<T>>());
   }
 
   //====================================================================================================================
@@ -158,43 +158,43 @@ namespace kumi
     @include doc/record/algo/pop_back.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto pop_back(T&& t)
+  template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto pop_back(T&& t)
   {
-    if constexpr (concepts::empty_product_type<T>) return builder<T>::make();
+    if constexpr (kumi::concepts::empty_product_type<T>) return builder<T>::make();
     else
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
         return builder<T>::make(get<I>(KUMI_FWD(t))...);
-      }(std::make_index_sequence<size_v<T> - 1>{});
+      }(std::make_index_sequence<kumi::size_v<T> - 1>{});
   }
 
   namespace result
   {
-    template<concepts::product_type T, typename V> struct push_front
+    template<kumi::concepts::product_type T, typename V> struct push_front
     {
       using type = decltype(kumi::push_front(std::declval<T>(), std::declval<V>()));
     };
 
-    template<concepts::product_type T> struct pop_front
+    template<kumi::concepts::product_type T> struct pop_front
     {
       using type = decltype(kumi::pop_front(std::declval<T>()));
     };
 
-    template<concepts::product_type T, typename V> struct push_back
+    template<kumi::concepts::product_type T, typename V> struct push_back
     {
       using type = decltype(kumi::push_back(std::declval<T>(), std::declval<V>()));
     };
 
-    template<concepts::product_type T> struct pop_back
+    template<kumi::concepts::product_type T> struct pop_back
     {
       using type = decltype(kumi::pop_back(std::declval<T>()));
     };
 
-    template<concepts::product_type T, typename V> using push_front_t = typename push_front<T, V>::type;
+    template<kumi::concepts::product_type T, typename V> using push_front_t = typename push_front<T, V>::type;
 
-    template<concepts::product_type T> using pop_front_t = typename pop_front<T>::type;
+    template<kumi::concepts::product_type T> using pop_front_t = typename pop_front<T>::type;
 
-    template<concepts::product_type T, typename V> using push_back_t = typename push_back<T, V>::type;
+    template<kumi::concepts::product_type T, typename V> using push_back_t = typename push_back<T, V>::type;
 
-    template<concepts::product_type T> using pop_back_t = typename pop_back<T>::type;
+    template<kumi::concepts::product_type T> using pop_back_t = typename pop_back<T>::type;
   }
 }

--- a/include/kumi/algorithm/push_pop.hpp
+++ b/include/kumi/algorithm/push_pop.hpp
@@ -189,12 +189,14 @@ namespace kumi
       using type = decltype(kumi::pop_back(std::declval<T>()));
     };
 
-    template<kumi::concepts::product_type T, typename V> using push_front_t = typename push_front<T, V>::type;
+    template<kumi::concepts::product_type T, typename V>
+    using push_front_t = typename kumi::result::push_front<T, V>::type;
 
-    template<kumi::concepts::product_type T> using pop_front_t = typename pop_front<T>::type;
+    template<kumi::concepts::product_type T> using pop_front_t = typename kumi::result::pop_front<T>::type;
 
-    template<kumi::concepts::product_type T, typename V> using push_back_t = typename push_back<T, V>::type;
+    template<kumi::concepts::product_type T, typename V>
+    using push_back_t = typename kumi::result::push_back<T, V>::type;
 
-    template<kumi::concepts::product_type T> using pop_back_t = typename pop_back<T>::type;
+    template<kumi::concepts::product_type T> using pop_back_t = typename kumi::result::pop_back<T>::type;
   }
 }

--- a/include/kumi/algorithm/reduce.hpp
+++ b/include/kumi/algorithm/reduce.hpp
@@ -43,20 +43,24 @@ namespace kumi
     @include doc/record/algo/reduce.cpp
   **/
   //====================================================================================================================
-  template<concepts::monoid M, concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto reduce(M&& m, T&& t)
+  template<kumi::concepts::monoid M, kumi::concepts::product_type T>
+  [[nodiscard]] KUMI_ABI constexpr auto reduce(M&& m, T&& t)
   {
-    if constexpr (concepts::empty_product_type<T>) return m.identity;
-    else if constexpr (concepts::record_type<T>) return reduce(KUMI_FWD(m), values_of(KUMI_FWD(t)));
-    else if constexpr (concepts::sized_product_type<T, 1>) return get<0>(KUMI_FWD(t));
+    if constexpr (kumi::concepts::empty_product_type<T>) return m.identity;
+    else if constexpr (kumi::concepts::record_type<T>) return kumi::reduce(KUMI_FWD(m), kumi::values_of(KUMI_FWD(t)));
+    else if constexpr (kumi::concepts::sized_product_type<T, 1>) return get<0>(KUMI_FWD(t));
     else
     {
-      constexpr auto pos = function::reducer(index<size_v<T>>);
+      constexpr auto pos = kumi::function::reducer(index<kumi::size_v<T>>);
 
       return [&]<std::size_t... F, std::size_t... S>(std::index_sequence<F...>, std::index_sequence<S...>) {
         if constexpr (get<2>(pos) == 1)
-          return reduce(KUMI_FWD(m), tuple{invoke(KUMI_FWD(m), get<F>(KUMI_FWD(t)), get<S>(KUMI_FWD(t)))...,
-                                           get<size_v<T> - 1>(KUMI_FWD(t))});
-        else return reduce(KUMI_FWD(m), tuple{invoke(KUMI_FWD(m), get<F>(KUMI_FWD(t)), get<S>(KUMI_FWD(t)))...});
+          return kumi::reduce(KUMI_FWD(m),
+                              kumi::tuple{kumi::invoke(KUMI_FWD(m), get<F>(KUMI_FWD(t)), get<S>(KUMI_FWD(t)))...,
+                                          get<kumi::size_v<T> - 1>(KUMI_FWD(t))});
+        else
+          return kumi::reduce(KUMI_FWD(m),
+                              kumi::tuple{invoke(KUMI_FWD(m), get<F>(KUMI_FWD(t)), get<S>(KUMI_FWD(t)))...});
       }(get<0>(pos), get<1>(pos));
     }
   }
@@ -96,11 +100,11 @@ namespace kumi
     @include doc/record/algo/reduce.cpp
   **/
   //====================================================================================================================
-  template<concepts::monoid M, concepts::product_type T, typename Value>
+  template<kumi::concepts::monoid M, kumi::concepts::product_type T, typename Value>
   [[nodiscard]] KUMI_ABI constexpr auto reduce(M&& m, T&& t, Value init)
   {
-    if constexpr (concepts::empty_product_type<T>) return init;
-    else return KUMI_FWD(m)(init, reduce(KUMI_FWD(m), KUMI_FWD(t)));
+    if constexpr (kumi::concepts::empty_product_type<T>) return init;
+    else return KUMI_FWD(m)(init, kumi::reduce(KUMI_FWD(m), KUMI_FWD(t)));
   }
 
   //====================================================================================================================
@@ -140,24 +144,25 @@ namespace kumi
     @include doc/record/algo/map_reduce.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T, concepts::monoid M, typename Function>
+  template<kumi::concepts::product_type T, kumi::concepts::monoid M, typename Function>
   [[nodiscard]] KUMI_ABI constexpr auto map_reduce(Function f, M&& m, T&& t)
   {
-    if constexpr (concepts::empty_product_type<T>) return m.identity;
-    else if constexpr (concepts::record_type<T>) return map_reduce(f, KUMI_FWD(m), values_of(KUMI_FWD(t)));
-    else if constexpr (concepts::sized_product_type<T, 1>) return invoke(f, get<0>(KUMI_FWD(t)));
+    if constexpr (kumi::concepts::empty_product_type<T>) return m.identity;
+    else if constexpr (kumi::concepts::record_type<T>)
+      return kumi::map_reduce(f, KUMI_FWD(m), kumi::values_of(KUMI_FWD(t)));
+    else if constexpr (kumi::concepts::sized_product_type<T, 1>) return kumi::invoke(f, get<0>(KUMI_FWD(t)));
     else
     {
-      constexpr auto pos = function::reducer(index<size_v<T>>);
+      constexpr auto pos = kumi::function::reducer(index<kumi::size_v<T>>);
 
       return [&]<std::size_t... F, std::size_t... S>(std::index_sequence<F...>, std::index_sequence<S...>) {
         if constexpr (get<2>(pos) == 1)
-          return reduce(KUMI_FWD(m),
-                        tuple{invoke(KUMI_FWD(m), invoke(f, get<F>(KUMI_FWD(t))), invoke(f, get<S>(KUMI_FWD(t))))...,
-                              invoke(f, get<size_v<T> - 1>(KUMI_FWD(t)))});
+          return kumi::reduce(KUMI_FWD(m), kumi::tuple{kumi::invoke(KUMI_FWD(m), kumi::invoke(f, get<F>(KUMI_FWD(t))),
+                                                                    kumi::invoke(f, get<S>(KUMI_FWD(t))))...,
+                                                       kumi::invoke(f, get<kumi::size_v<T> - 1>(KUMI_FWD(t)))});
         else
-          return reduce(KUMI_FWD(m),
-                        tuple{invoke(KUMI_FWD(m), invoke(f, get<F>(KUMI_FWD(t))), invoke(f, get<S>(KUMI_FWD(t))))...});
+          return kumi::reduce(KUMI_FWD(m), kumi::tuple{kumi::invoke(KUMI_FWD(m), kumi::invoke(f, get<F>(KUMI_FWD(t))),
+                                                                    kumi::invoke(f, get<S>(KUMI_FWD(t))))...});
       }(get<0>(pos), get<1>(pos));
     }
   }
@@ -200,11 +205,11 @@ namespace kumi
     @include doc/record/algo/map_reduce.cpp
   **/
   //====================================================================================================================
-  template<concepts::monoid M, concepts::product_type T, typename Function, typename Value>
+  template<kumi::concepts::monoid M, kumi::concepts::product_type T, typename Function, typename Value>
   [[nodiscard]] KUMI_ABI constexpr auto map_reduce(Function f, M&& m, T&& t, Value init)
   {
-    if constexpr (concepts::empty_product_type<T>) return invoke(f, init);
-    else return KUMI_FWD(m)(invoke(f, init), map_reduce(f, KUMI_FWD(m), KUMI_FWD(t)));
+    if constexpr (kumi::concepts::empty_product_type<T>) return kumi::invoke(f, init);
+    else return KUMI_FWD(m)(kumi::invoke(f, init), kumi::map_reduce(f, KUMI_FWD(m), KUMI_FWD(t)));
   }
 
   //====================================================================================================================
@@ -238,9 +243,9 @@ namespace kumi
     @include doc/record/algo/sum.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T, typename Value> [[nodiscard]] KUMI_ABI constexpr auto sum(T&& t, Value init)
+  template<kumi::concepts::product_type T, typename Value> [[nodiscard]] KUMI_ABI constexpr auto sum(T&& t, Value init)
   {
-    return reduce(function::plus, KUMI_FWD(t), init);
+    return kumi::reduce(kumi::function::plus, KUMI_FWD(t), init);
   }
 
   //====================================================================================================================
@@ -273,9 +278,9 @@ namespace kumi
     @include doc/record/algo/sum.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto sum(T&& t)
+  template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto sum(T&& t)
   {
-    return reduce(function::plus, KUMI_FWD(t));
+    return kumi::reduce(kumi::function::plus, KUMI_FWD(t));
   }
 
   //====================================================================================================================
@@ -309,9 +314,9 @@ namespace kumi
     @include doc/record/algo/prod.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T, typename Value> [[nodiscard]] KUMI_ABI constexpr auto prod(T&& t, Value init)
+  template<kumi::concepts::product_type T, typename Value> [[nodiscard]] KUMI_ABI constexpr auto prod(T&& t, Value init)
   {
-    return reduce(function::multiplies, KUMI_FWD(t), init);
+    return kumi::reduce(kumi::function::multiplies, KUMI_FWD(t), init);
   }
 
   //====================================================================================================================
@@ -344,9 +349,9 @@ namespace kumi
     @include doc/record/algo/prod.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto prod(T&& t)
+  template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto prod(T&& t)
   {
-    return reduce(function::multiplies, KUMI_FWD(t));
+    return kumi::reduce(kumi::function::multiplies, KUMI_FWD(t));
   }
 
   //====================================================================================================================
@@ -380,9 +385,10 @@ namespace kumi
     @include doc/record/algo/bit_and.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T, typename Value> [[nodiscard]] KUMI_ABI constexpr auto bit_and(T&& t, Value init)
+  template<kumi::concepts::product_type T, typename Value>
+  [[nodiscard]] KUMI_ABI constexpr auto bit_and(T&& t, Value init)
   {
-    return reduce(function::bit_and, KUMI_FWD(t), init);
+    return kumi::reduce(kumi::function::bit_and, KUMI_FWD(t), init);
   }
 
   //====================================================================================================================
@@ -415,9 +421,9 @@ namespace kumi
     @include doc/record/algo/bit_and.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto bit_and(T&& t)
+  template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto bit_and(T&& t)
   {
-    return reduce(function::bit_and, KUMI_FWD(t));
+    return kumi::reduce(kumi::function::bit_and, KUMI_FWD(t));
   }
 
   //====================================================================================================================
@@ -451,9 +457,10 @@ namespace kumi
     @include doc/record/algo/bit_or.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T, typename Value> [[nodiscard]] KUMI_ABI constexpr auto bit_or(T&& t, Value init)
+  template<kumi::concepts::product_type T, typename Value>
+  [[nodiscard]] KUMI_ABI constexpr auto bit_or(T&& t, Value init)
   {
-    return reduce(function::bit_or, KUMI_FWD(t), init);
+    return kumi::reduce(kumi::function::bit_or, KUMI_FWD(t), init);
   }
 
   //====================================================================================================================
@@ -486,9 +493,9 @@ namespace kumi
     @include doc/record/algo/bit_or.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto bit_or(T&& t)
+  template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto bit_or(T&& t)
   {
-    return reduce(function::bit_or, KUMI_FWD(t));
+    return kumi::reduce(kumi::function::bit_or, KUMI_FWD(t));
   }
 
   //====================================================================================================================
@@ -522,9 +529,10 @@ namespace kumi
     @include doc/record/algo/bit_xor.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T, typename Value> [[nodiscard]] KUMI_ABI constexpr auto bit_xor(T&& t, Value init)
+  template<kumi::concepts::product_type T, typename Value>
+  [[nodiscard]] KUMI_ABI constexpr auto bit_xor(T&& t, Value init)
   {
-    return reduce(function::bit_xor, KUMI_FWD(t), init);
+    return kumi::reduce(kumi::function::bit_xor, KUMI_FWD(t), init);
   }
 
   //====================================================================================================================
@@ -557,98 +565,99 @@ namespace kumi
     @include doc/record/algo/bit_xor.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto bit_xor(T&& t)
+  template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto bit_xor(T&& t)
   {
-    return reduce(function::bit_xor, KUMI_FWD(t));
+    return kumi::reduce(kumi::function::bit_xor, KUMI_FWD(t));
   }
 
   namespace result
   {
-    template<concepts::monoid M, concepts::product_type T, typename Value = void> struct reduce
+    template<kumi::concepts::monoid M, kumi::concepts::product_type T, typename Value = void> struct reduce
     {
       using type = decltype(kumi::reduce(std::declval<M>(), std::declval<T>(), std::declval<Value>()));
     };
 
-    template<concepts::monoid M, concepts::product_type T> struct reduce<M, T>
+    template<kumi::concepts::monoid M, kumi::concepts::product_type T> struct reduce<M, T>
     {
       using type = decltype(kumi::reduce(std::declval<M>(), std::declval<T>()));
     };
 
-    template<typename F, concepts::monoid M, concepts::product_type T, typename Value = void> struct map_reduce
+    template<typename F, kumi::concepts::monoid M, kumi::concepts::product_type T, typename Value = void>
+    struct map_reduce
     {
       using type =
         decltype(kumi::map_reduce(std::declval<F>(), std::declval<M>(), std::declval<T>(), std::declval<Value>()));
     };
 
-    template<typename F, concepts::monoid M, concepts::product_type T> struct map_reduce<F, M, T>
+    template<typename F, kumi::concepts::monoid M, kumi::concepts::product_type T> struct map_reduce<F, M, T>
     {
       using type = decltype(kumi::map_reduce(std::declval<F>(), std::declval<M>(), std::declval<T>()));
     };
 
-    template<concepts::product_type T, typename Value = void> struct sum
+    template<kumi::concepts::product_type T, typename Value = void> struct sum
     {
       using type = decltype(kumi::sum(std::declval<T>(), std::declval<Value>()));
     };
 
-    template<concepts::product_type T> struct sum<T>
+    template<kumi::concepts::product_type T> struct sum<T>
     {
       using type = decltype(kumi::sum(std::declval<T>()));
     };
 
-    template<concepts::product_type T, typename Value = void> struct prod
+    template<kumi::concepts::product_type T, typename Value = void> struct prod
     {
       using type = decltype(kumi::prod(std::declval<T>(), std::declval<Value>()));
     };
 
-    template<concepts::product_type T> struct prod<T>
+    template<kumi::concepts::product_type T> struct prod<T>
     {
       using type = decltype(kumi::prod(std::declval<T>()));
     };
 
-    template<concepts::product_type T, typename Value = void> struct bit_and
+    template<kumi::concepts::product_type T, typename Value = void> struct bit_and
     {
       using type = decltype(kumi::bit_and(std::declval<T>(), std::declval<Value>()));
     };
 
-    template<concepts::product_type T> struct bit_and<T>
+    template<kumi::concepts::product_type T> struct bit_and<T>
     {
       using type = decltype(kumi::bit_and(std::declval<T>()));
     };
 
-    template<concepts::product_type T, typename Value = void> struct bit_or
+    template<kumi::concepts::product_type T, typename Value = void> struct bit_or
     {
       using type = decltype(kumi::bit_or(std::declval<T>(), std::declval<Value>()));
     };
 
-    template<concepts::product_type T> struct bit_or<T>
+    template<kumi::concepts::product_type T> struct bit_or<T>
     {
       using type = decltype(kumi::bit_or(std::declval<T>()));
     };
 
-    template<concepts::product_type T, typename Value = void> struct bit_xor
+    template<kumi::concepts::product_type T, typename Value = void> struct bit_xor
     {
       using type = decltype(kumi::bit_xor(std::declval<T>(), std::declval<Value>()));
     };
 
-    template<concepts::product_type T> struct bit_xor<T>
+    template<kumi::concepts::product_type T> struct bit_xor<T>
     {
       using type = decltype(kumi::bit_xor(std::declval<T>()));
     };
 
-    template<concepts::monoid M, concepts::product_type T, typename Value = void>
+    template<kumi::concepts::monoid M, kumi::concepts::product_type T, typename Value = void>
     using reduce_t = typename reduce<M, T, Value>::type;
 
-    template<typename F, concepts::monoid M, concepts::product_type T, typename Value = void>
+    template<typename F, kumi::concepts::monoid M, kumi::concepts::product_type T, typename Value = void>
     using map_reduce_t = typename map_reduce<F, M, T, Value>::type;
 
-    template<concepts::product_type T, typename Value = void> using sum_t = typename sum<T, Value>::type;
+    template<kumi::concepts::product_type T, typename Value = void> using sum_t = typename sum<T, Value>::type;
 
-    template<concepts::product_type T, typename Value = void> using prod_t = typename prod<T, Value>::type;
+    template<kumi::concepts::product_type T, typename Value = void> using prod_t = typename prod<T, Value>::type;
 
-    template<concepts::product_type T, typename Value = void> using bit_and_t = typename bit_and<T, Value>::type;
+    template<kumi::concepts::product_type T, typename Value = void> using bit_and_t = typename bit_and<T, Value>::type;
 
-    template<concepts::product_type T, typename Value = void> using bit_or_t = typename bit_or<T, Value>::type;
+    template<kumi::concepts::product_type T, typename Value = void> using bit_or_t = typename bit_or<T, Value>::type;
 
-    template<concepts::product_type T, typename Value = void> using bit_xor_t = typename bit_xor<T, Value>::type;
+    template<kumi::concepts::product_type T, typename Value = void> using bit_xor_t = typename bit_xor<T, Value>::type;
   }
 }

--- a/include/kumi/algorithm/reduce.hpp
+++ b/include/kumi/algorithm/reduce.hpp
@@ -645,19 +645,24 @@ namespace kumi
     };
 
     template<kumi::concepts::monoid M, kumi::concepts::product_type T, typename Value = void>
-    using reduce_t = typename reduce<M, T, Value>::type;
+    using reduce_t = typename kumi::result::reduce<M, T, Value>::type;
 
     template<typename F, kumi::concepts::monoid M, kumi::concepts::product_type T, typename Value = void>
-    using map_reduce_t = typename map_reduce<F, M, T, Value>::type;
+    using map_reduce_t = typename kumi::result::map_reduce<F, M, T, Value>::type;
 
-    template<kumi::concepts::product_type T, typename Value = void> using sum_t = typename sum<T, Value>::type;
+    template<kumi::concepts::product_type T, typename Value = void>
+    using sum_t = typename kumi::result::sum<T, Value>::type;
 
-    template<kumi::concepts::product_type T, typename Value = void> using prod_t = typename prod<T, Value>::type;
+    template<kumi::concepts::product_type T, typename Value = void>
+    using prod_t = typename kumi::result::prod<T, Value>::type;
 
-    template<kumi::concepts::product_type T, typename Value = void> using bit_and_t = typename bit_and<T, Value>::type;
+    template<kumi::concepts::product_type T, typename Value = void>
+    using bit_and_t = typename kumi::result::bit_and<T, Value>::type;
 
-    template<kumi::concepts::product_type T, typename Value = void> using bit_or_t = typename bit_or<T, Value>::type;
+    template<kumi::concepts::product_type T, typename Value = void>
+    using bit_or_t = typename kumi::result::bit_or<T, Value>::type;
 
-    template<kumi::concepts::product_type T, typename Value = void> using bit_xor_t = typename bit_xor<T, Value>::type;
+    template<kumi::concepts::product_type T, typename Value = void>
+    using bit_xor_t = typename kumi::result::bit_xor<T, Value>::type;
   }
 }

--- a/include/kumi/algorithm/reorder.hpp
+++ b/include/kumi/algorithm/reorder.hpp
@@ -171,12 +171,13 @@ namespace kumi
       using type = decltype(kumi::reindex<Indexes>(std::declval<T>()));
     };
 
-    template<kumi::concepts::product_type T, std::size_t... Idx> using reorder_t = typename reorder<T, Idx...>::type;
+    template<kumi::concepts::product_type T, std::size_t... Idx>
+    using reorder_t = typename kumi::result::reorder<T, Idx...>::type;
 
     template<kumi::concepts::product_type Tuple, kumi::concepts::identifier auto... Name>
-    using reorder_fields_t = typename reorder_fields<Tuple, Name...>::type;
+    using reorder_fields_t = typename kumi::result::reorder_fields<Tuple, Name...>::type;
 
     template<kumi::concepts::product_type T, kumi::concepts::projection_map auto Indexes>
-    using reindex_t = typename reindex<T, Indexes>::type;
+    using reindex_t = typename kumi::result::reindex<T, Indexes>::type;
   }
 }

--- a/include/kumi/algorithm/reorder.hpp
+++ b/include/kumi/algorithm/reorder.hpp
@@ -48,9 +48,9 @@ namespace kumi
     @include doc/record/algo/reorder.cpp
   **/
   //====================================================================================================================
-  template<std::size_t... Idx, concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto reorder(T&& t)
+  template<std::size_t... Idx, kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto reorder(T&& t)
   {
-    static_assert(((Idx < size_v<T>) && ...), "[KUMI] - Index out of bounds");
+    static_assert(((Idx < kumi::size_v<T>) && ...), "[KUMI] - Index out of bounds");
     return builder<T>::make(get<Idx>(KUMI_FWD(t))...);
   }
 
@@ -88,7 +88,7 @@ namespace kumi
     @include doc/record/algo/reorder_fields.cpp
   **/
   //====================================================================================================================
-  template<concepts::identifier auto... Name, concepts::product_type Tuple>
+  template<kumi::concepts::identifier auto... Name, kumi::concepts::product_type Tuple>
   [[nodiscard]] KUMI_ABI constexpr auto reorder_fields(Tuple&& t)
   {
     static_assert((requires { get<Name>(std::declval<Tuple>()); } && ...),
@@ -133,12 +133,12 @@ namespace kumi
     @include doc/record/algo/reindex.cpp
   **/
   //====================================================================================================================
-  template<concepts::projection_map auto Projections, concepts::product_type T>
+  template<kumi::concepts::projection_map auto Projections, kumi::concepts::product_type T>
   [[nodiscard]] KUMI_ABI constexpr auto reindex(T&& t)
   {
     using proj_t = std::remove_cvref_t<decltype(Projections)>;
-    auto mk = [&]<concepts::projection auto proj>() -> decltype(auto) {
-      if constexpr (concepts::projection_map<decltype(proj)>) return reindex<proj>(KUMI_FWD(t));
+    auto mk = [&]<kumi::concepts::projection auto proj>() -> decltype(auto) {
+      if constexpr (kumi::concepts::projection_map<decltype(proj)>) return kumi::reindex<proj>(KUMI_FWD(t));
       else
       {
         static_assert(requires { get<proj>(std::declval<T>()); }, "[KUMI] - Invalid projection for input type");
@@ -146,7 +146,7 @@ namespace kumi
       }
     };
 
-    if constexpr (concepts::empty_product_type<T>) return builder<T>::make();
+    if constexpr (kumi::concepts::empty_product_type<T>) return builder<T>::make();
     else if constexpr (proj_t::size() == 0) return builder<T>::make();
     else
       return [&]<auto... E>(kumi::projection_map<E...>) {
@@ -156,27 +156,27 @@ namespace kumi
 
   namespace result
   {
-    template<concepts::product_type T, std::size_t... Idx> struct reorder
+    template<kumi::concepts::product_type T, std::size_t... Idx> struct reorder
     {
       using type = decltype(kumi::reorder<Idx...>(std::declval<T>()));
     };
 
-    template<concepts::product_type Tuple, concepts::identifier auto... Name> struct reorder_fields
+    template<kumi::concepts::product_type Tuple, kumi::concepts::identifier auto... Name> struct reorder_fields
     {
       using type = decltype(kumi::reorder_fields<Name...>(std::declval<Tuple>()));
     };
 
-    template<concepts::product_type T, concepts::projection_map auto Indexes> struct reindex
+    template<kumi::concepts::product_type T, kumi::concepts::projection_map auto Indexes> struct reindex
     {
       using type = decltype(kumi::reindex<Indexes>(std::declval<T>()));
     };
 
-    template<concepts::product_type T, std::size_t... Idx> using reorder_t = typename reorder<T, Idx...>::type;
+    template<kumi::concepts::product_type T, std::size_t... Idx> using reorder_t = typename reorder<T, Idx...>::type;
 
-    template<concepts::product_type Tuple, concepts::identifier auto... Name>
+    template<kumi::concepts::product_type Tuple, kumi::concepts::identifier auto... Name>
     using reorder_fields_t = typename reorder_fields<Tuple, Name...>::type;
 
-    template<concepts::product_type T, concepts::projection_map auto Indexes>
+    template<kumi::concepts::product_type T, kumi::concepts::projection_map auto Indexes>
     using reindex_t = typename reindex<T, Indexes>::type;
   }
 }

--- a/include/kumi/algorithm/reverse.hpp
+++ b/include/kumi/algorithm/reverse.hpp
@@ -40,24 +40,24 @@ namespace kumi
     @include doc/record/algo/reverse.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto reverse(T&& t)
+  template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto reverse(T&& t)
   {
-    if constexpr (concepts::empty_product_type<T>) return builder<T>::make();
+    if constexpr (kumi::concepts::empty_product_type<T>) return builder<T>::make();
     else
     {
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return builder<T>::make(get<(size_v<T> - 1 - I)>(KUMI_FWD(t))...);
-      }(std::make_index_sequence<size<T>::value>());
+        return builder<T>::make(get<(kumi::size_v<T> - 1 - I)>(KUMI_FWD(t))...);
+      }(std::make_index_sequence<kumi::size_v<T>>{});
     }
   }
 
   namespace result
   {
-    template<concepts::product_type T> struct reverse
+    template<kumi::concepts::product_type T> struct reverse
     {
       using type = decltype(kumi::reverse(std::declval<T>()));
     };
 
-    template<concepts::product_type T> using reverse_t = typename reverse<T>::type;
+    template<kumi::concepts::product_type T> using reverse_t = typename reverse<T>::type;
   }
 }

--- a/include/kumi/algorithm/reverse.hpp
+++ b/include/kumi/algorithm/reverse.hpp
@@ -58,6 +58,6 @@ namespace kumi
       using type = decltype(kumi::reverse(std::declval<T>()));
     };
 
-    template<kumi::concepts::product_type T> using reverse_t = typename reverse<T>::type;
+    template<kumi::concepts::product_type T> using reverse_t = typename kumi::result::reverse<T>::type;
   }
 }

--- a/include/kumi/algorithm/rotate.hpp
+++ b/include/kumi/algorithm/rotate.hpp
@@ -116,8 +116,10 @@ namespace kumi
       using type = decltype(kumi::rotate_right<R>(std::declval<T>()));
     };
 
-    template<std::size_t R, kumi::concepts::product_type T> using rotate_left_t = typename rotate_left<R, T>::type;
+    template<std::size_t R, kumi::concepts::product_type T>
+    using rotate_left_t = typename kumi::result::rotate_left<R, T>::type;
 
-    template<std::size_t R, kumi::concepts::product_type T> using rotate_right_t = typename rotate_right<R, T>::type;
+    template<std::size_t R, kumi::concepts::product_type T>
+    using rotate_right_t = typename kumi::result::rotate_right<R, T>::type;
   }
 }

--- a/include/kumi/algorithm/rotate.hpp
+++ b/include/kumi/algorithm/rotate.hpp
@@ -42,15 +42,15 @@ namespace kumi
     @include doc/record/algo/rotate_left.cpp
   **/
   //====================================================================================================================
-  template<std::size_t R, concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto rotate_left(T&& t)
+  template<std::size_t R, kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto rotate_left(T&& t)
   {
-    if constexpr (concepts::empty_product_type<T>) return KUMI_FWD(t);
-    else if constexpr ((R % size_v<T>) == 0) return KUMI_FWD(t);
+    if constexpr (kumi::concepts::empty_product_type<T>) return KUMI_FWD(t);
+    else if constexpr ((R % kumi::size_v<T>) == 0) return KUMI_FWD(t);
     else
     {
-      constexpr auto idxs = function::rotater(index<size_v<T>>, index<(R % size_v<T>)>);
+      constexpr auto idxs = kumi::function::rotater(kumi::index<kumi::size_v<T>>, kumi::index<(R % kumi::size_v<T>)>);
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        using type = builder_make_t<T, element_t<I, T>...>;
+        using type = builder_make_t<T, kumi::element_t<I, T>...>;
         return type{get<I>(KUMI_FWD(t))...};
       }(idxs);
     }
@@ -89,16 +89,16 @@ namespace kumi
     @include doc/record/algo/rotate_right.cpp
   **/
   //====================================================================================================================
-  template<std::size_t R, concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto rotate_right(T&& t)
+  template<std::size_t R, kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto rotate_right(T&& t)
   {
-    if constexpr (concepts::empty_product_type<T>) return KUMI_FWD(t);
-    else if constexpr ((R % size_v<T>) == 0) return KUMI_FWD(t);
+    if constexpr (kumi::concepts::empty_product_type<T>) return KUMI_FWD(t);
+    else if constexpr ((R % kumi::size_v<T>) == 0) return KUMI_FWD(t);
     else
     {
-      constexpr auto F = R % size_v<T>;
-      constexpr auto idxs = function::rotater(index<size_v<T>>, index<(size_v<T> - F)>);
+      constexpr auto F = R % kumi::size_v<T>;
+      constexpr auto idxs = kumi::function::rotater(kumi::index<kumi::size_v<T>>, kumi::index<(kumi::size_v<T> - F)>);
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        using type = builder_make_t<T, element_t<I, T>...>;
+        using type = builder_make_t<T, kumi::element_t<I, T>...>;
         return type{get<I>(KUMI_FWD(t))...};
       }(idxs);
     }
@@ -106,18 +106,18 @@ namespace kumi
 
   namespace result
   {
-    template<std::size_t R, concepts::product_type T> struct rotate_left
+    template<std::size_t R, kumi::concepts::product_type T> struct rotate_left
     {
       using type = decltype(kumi::rotate_left<R>(std::declval<T>()));
     };
 
-    template<std::size_t R, concepts::product_type T> struct rotate_right
+    template<std::size_t R, kumi::concepts::product_type T> struct rotate_right
     {
       using type = decltype(kumi::rotate_right<R>(std::declval<T>()));
     };
 
-    template<std::size_t R, concepts::product_type T> using rotate_left_t = typename rotate_left<R, T>::type;
+    template<std::size_t R, kumi::concepts::product_type T> using rotate_left_t = typename rotate_left<R, T>::type;
 
-    template<std::size_t R, concepts::product_type T> using rotate_right_t = typename rotate_right<R, T>::type;
+    template<std::size_t R, kumi::concepts::product_type T> using rotate_right_t = typename rotate_right<R, T>::type;
   }
 }

--- a/include/kumi/algorithm/scan.hpp
+++ b/include/kumi/algorithm/scan.hpp
@@ -435,15 +435,15 @@ namespace kumi
     };
 
     template<typename Function, kumi::concepts::product_type T, typename Value = void>
-    using inclusive_scan_right_t = typename inclusive_scan_right<Function, T, Value>::type;
+    using inclusive_scan_right_t = typename kumi::result::inclusive_scan_right<Function, T, Value>::type;
 
     template<typename Function, kumi::concepts::product_type T, typename Value = void>
-    using exclusive_scan_right_t = typename exclusive_scan_right<Function, T, Value>::type;
+    using exclusive_scan_right_t = typename kumi::result::exclusive_scan_right<Function, T, Value>::type;
 
     template<typename Function, kumi::concepts::product_type T, typename Value = void>
-    using inclusive_scan_left_t = typename inclusive_scan_left<Function, T, Value>::type;
+    using inclusive_scan_left_t = typename kumi::result::inclusive_scan_left<Function, T, Value>::type;
 
     template<typename Function, kumi::concepts::product_type T, typename Value = void>
-    using exclusive_scan_left_t = typename exclusive_scan_left<Function, T, Value>::type;
+    using exclusive_scan_left_t = typename kumi::result::exclusive_scan_left<Function, T, Value>::type;
   }
 }

--- a/include/kumi/algorithm/scan.hpp
+++ b/include/kumi/algorithm/scan.hpp
@@ -45,18 +45,19 @@ namespace kumi
     @include doc/record/algo/inclusive_scan_left.cpp
   **/
   //====================================================================================================================
-  template<typename Function, concepts::product_type T, typename Value>
+  template<typename Function, kumi::concepts::product_type T, typename Value>
   [[nodiscard]] KUMI_ABI constexpr auto inclusive_scan_left(Function f, T&& t, Value init)
   {
-    if constexpr (concepts::record_type<T>) return inclusive_scan_left(f, values_of(KUMI_FWD(t)), init);
-    else if constexpr (concepts::empty_product_type<T>) return tuple{};
+    if constexpr (kumi::concepts::record_type<T>)
+      return kumi::inclusive_scan_left(f, kumi::values_of(KUMI_FWD(t)), init);
+    else if constexpr (kumi::concepts::empty_product_type<T>) return kumi::tuple{};
     else
     {
       auto op = [](auto&&... xs) { return kumi::make_tuple(KUMI_FWD(xs)...); };
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return (function::scannable{op, invoke(f, init, get<0>(KUMI_FWD(t)))} >> ... >>
-                bind_back(f, get<I + 1>(KUMI_FWD(t))))();
-      }(std::make_index_sequence<size_v<T> - 1>{});
+        return (kumi::function::scannable{op, kumi::invoke(f, init, get<0>(KUMI_FWD(t)))} >> ... >>
+                kumi::bind_back(f, get<I + 1>(KUMI_FWD(t))))();
+      }(std::make_index_sequence<kumi::size_v<T> - 1>{});
     }
   }
 
@@ -95,12 +96,13 @@ namespace kumi
     @include doc/record/algo/inclusive_scan_left.cpp
   **/
   //====================================================================================================================
-  template<concepts::monoid M, concepts::sized_product_type_or_more<1> T>
+  template<kumi::concepts::monoid M, kumi::concepts::sized_product_type_or_more<1> T>
   [[nodiscard]] KUMI_ABI constexpr auto inclusive_scan_left(M&& m, T&& t)
   {
-    if constexpr (concepts::record_type<T>) return inclusive_scan_left(KUMI_FWD(m), values_of(KUMI_FWD(t)));
-    else if constexpr (concepts::sized_product_type<T, 1>) return KUMI_FWD(t);
-    else return inclusive_scan_left(KUMI_FWD(m), KUMI_FWD(t), m.identity);
+    if constexpr (kumi::concepts::record_type<T>)
+      return kumi::inclusive_scan_left(KUMI_FWD(m), kumi::values_of(KUMI_FWD(t)));
+    else if constexpr (kumi::concepts::sized_product_type<T, 1>) return KUMI_FWD(t);
+    else return kumi::inclusive_scan_left(KUMI_FWD(m), KUMI_FWD(t), m.identity);
   }
 
   //====================================================================================================================
@@ -138,17 +140,18 @@ namespace kumi
     @include doc/record/algo/exclusive_scan_left.cpp
   **/
   //====================================================================================================================
-  template<typename Function, concepts::product_type T, typename Value>
+  template<typename Function, kumi::concepts::product_type T, typename Value>
   [[nodiscard]] KUMI_ABI constexpr auto exclusive_scan_left(Function f, T&& t, Value init)
   {
-    if constexpr (concepts::record_type<T>) return exclusive_scan_left(f, values_of(KUMI_FWD(t)), init);
-    else if constexpr (concepts::empty_product_type<T>) return tuple{init};
+    if constexpr (kumi::concepts::record_type<T>)
+      return kumi::exclusive_scan_left(f, kumi::values_of(KUMI_FWD(t)), init);
+    else if constexpr (kumi::concepts::empty_product_type<T>) return kumi::tuple{init};
     else
     {
       auto op = [](auto&&... xs) { return kumi::make_tuple(KUMI_FWD(xs)...); };
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return (function::scannable{op, init} >> ... >> bind_back(f, get<I>(KUMI_FWD(t))))();
-      }(std::make_index_sequence<size_v<T> - 1>{});
+        return (kumi::function::scannable{op, init} >> ... >> kumi::bind_back(f, get<I>(KUMI_FWD(t))))();
+      }(std::make_index_sequence<kumi::size_v<T> - 1>{});
     }
   }
 
@@ -186,12 +189,13 @@ namespace kumi
     @include doc/record/algo/exclusive_scan_left.cpp
   **/
   //====================================================================================================================
-  template<concepts::monoid M, concepts::sized_product_type_or_more<1> T>
+  template<kumi::concepts::monoid M, kumi::concepts::sized_product_type_or_more<1> T>
   [[nodiscard]] KUMI_ABI constexpr auto exclusive_scan_left(M&& m, T&& t)
   {
-    if constexpr (concepts::record_type<T>) return exclusive_scan_left(KUMI_FWD(m), values_of(KUMI_FWD(t)));
-    else if constexpr (concepts::sized_product_type<T, 1>) return tuple(m.identity, get<0>(KUMI_FWD(t)));
-    else return exclusive_scan_left(KUMI_FWD(m), KUMI_FWD(t), m.identity);
+    if constexpr (kumi::concepts::record_type<T>)
+      return kumi::exclusive_scan_left(KUMI_FWD(m), kumi::values_of(KUMI_FWD(t)));
+    else if constexpr (kumi::concepts::sized_product_type<T, 1>) return kumi::tuple(m.identity, get<0>(KUMI_FWD(t)));
+    else return kumi::exclusive_scan_left(KUMI_FWD(m), KUMI_FWD(t), m.identity);
   }
 
   //====================================================================================================================
@@ -230,18 +234,20 @@ namespace kumi
     @include doc/record/algo/inclusive_scan_right.cpp
   **/
   //====================================================================================================================
-  template<typename Function, concepts::product_type T, typename Value>
+  template<typename Function, kumi::concepts::product_type T, typename Value>
   [[nodiscard]] KUMI_ABI constexpr auto inclusive_scan_right(Function f, T&& t, Value init)
   {
-    if constexpr (concepts::record_type<T>) return inclusive_scan_right(KUMI_FWD(f), values_of(KUMI_FWD(t)), init);
-    else if constexpr (concepts::empty_product_type<T>) return tuple{};
+    if constexpr (kumi::concepts::record_type<T>)
+      return kumi::inclusive_scan_right(KUMI_FWD(f), kumi::values_of(KUMI_FWD(t)), init);
+    else if constexpr (kumi::concepts::empty_product_type<T>) return kumi::tuple{};
     else
     {
       auto op = [](auto&&... xs) { return kumi::make_tuple(KUMI_FWD(xs)...); };
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return (bind_front(f, get<I>(KUMI_FWD(t)))
-                << ... << function::scannable{op, invoke(f, get<size_v<T> - 1>(KUMI_FWD(t)), init)})();
-      }(std::make_index_sequence<size_v<T> - 1>{});
+        return (kumi::bind_front(f, get<I>(KUMI_FWD(t)))
+                << ...
+                << kumi::function::scannable{op, kumi::invoke(f, get<kumi::size_v<T> - 1>(KUMI_FWD(t)), init)})();
+      }(std::make_index_sequence<kumi::size_v<T> - 1>{});
     }
   }
 
@@ -280,12 +286,13 @@ namespace kumi
     @include doc/record/algo/inclusive_scan_right.cpp
   **/
   //====================================================================================================================
-  template<concepts::monoid M, concepts::sized_product_type_or_more<1> T>
+  template<kumi::concepts::monoid M, kumi::concepts::sized_product_type_or_more<1> T>
   [[nodiscard]] KUMI_ABI constexpr auto inclusive_scan_right(M&& m, T&& t)
   {
-    if constexpr (concepts::record_type<T>) return inclusive_scan_right(KUMI_FWD(m), values_of(KUMI_FWD(t)));
-    else if constexpr (concepts::sized_product_type<T, 1>) return KUMI_FWD(t);
-    else return inclusive_scan_right(KUMI_FWD(m), KUMI_FWD(t), m.identity);
+    if constexpr (kumi::concepts::record_type<T>)
+      return kumi::inclusive_scan_right(KUMI_FWD(m), kumi::values_of(KUMI_FWD(t)));
+    else if constexpr (kumi::concepts::sized_product_type<T, 1>) return KUMI_FWD(t);
+    else return kumi::inclusive_scan_right(KUMI_FWD(m), KUMI_FWD(t), m.identity);
   }
 
   //====================================================================================================================
@@ -323,17 +330,18 @@ namespace kumi
     @include doc/record/algo/exclusive_scan_right.cpp
   **/
   //====================================================================================================================
-  template<typename Function, concepts::product_type T, typename Value>
+  template<typename Function, kumi::concepts::product_type T, typename Value>
   [[nodiscard]] KUMI_ABI constexpr auto exclusive_scan_right(Function f, T&& t, Value init)
   {
-    if constexpr (concepts::record_type<T>) return exclusive_scan_right(KUMI_FWD(f), values_of(KUMI_FWD(t)), init);
-    else if constexpr (concepts::empty_product_type<T>) return tuple{init};
+    if constexpr (kumi::concepts::record_type<T>)
+      return kumi::exclusive_scan_right(KUMI_FWD(f), kumi::values_of(KUMI_FWD(t)), init);
+    else if constexpr (kumi::concepts::empty_product_type<T>) return kumi::tuple{init};
     else
     {
       auto op = [](auto&&... xs) { return kumi::make_tuple(KUMI_FWD(xs)...); };
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return (bind_front(f, get<I + 1>(KUMI_FWD(t))) << ... << function::scannable{op, init})();
-      }(std::make_index_sequence<size_v<T> - 1>{});
+        return (kumi::bind_front(f, get<I + 1>(KUMI_FWD(t))) << ... << kumi::function::scannable{op, init})();
+      }(std::make_index_sequence<kumi::size_v<T> - 1>{});
     }
   }
 
@@ -371,70 +379,71 @@ namespace kumi
     @include doc/record/algo/exclusive_scan_right.cpp
   **/
   //====================================================================================================================
-  template<concepts::monoid M, concepts::sized_product_type_or_more<1> T>
+  template<kumi::concepts::monoid M, kumi::concepts::sized_product_type_or_more<1> T>
   [[nodiscard]] KUMI_ABI constexpr auto exclusive_scan_right(M&& m, T&& t)
   {
-    if constexpr (concepts::record_type<T>) return exclusive_scan_right(KUMI_FWD(m), values_of(KUMI_FWD(t)));
-    else if constexpr (concepts::sized_product_type<T, 1>) return tuple{get<0>(KUMI_FWD(t)), m.identity};
+    if constexpr (kumi::concepts::record_type<T>)
+      return kumi::exclusive_scan_right(KUMI_FWD(m), kumi::values_of(KUMI_FWD(t)));
+    else if constexpr (kumi::concepts::sized_product_type<T, 1>) return kumi::tuple{get<0>(KUMI_FWD(t)), m.identity};
     else return kumi::exclusive_scan_right(KUMI_FWD(m), KUMI_FWD(t), m.identity);
   }
 
   namespace result
   {
-    template<typename Function, concepts::product_type T, typename Value = void> struct inclusive_scan_right
+    template<typename Function, kumi::concepts::product_type T, typename Value = void> struct inclusive_scan_right
     {
       using type =
         decltype(kumi::inclusive_scan_right(std::declval<Function>(), std::declval<T>(), std::declval<Value>()));
     };
 
-    template<typename Function, concepts::product_type T> struct inclusive_scan_right<Function, T>
+    template<typename Function, kumi::concepts::product_type T> struct inclusive_scan_right<Function, T>
     {
       using type = decltype(kumi::inclusive_scan_right(std::declval<Function>(), std::declval<T>()));
     };
 
-    template<typename Function, concepts::product_type T, typename Value = void> struct exclusive_scan_right
+    template<typename Function, kumi::concepts::product_type T, typename Value = void> struct exclusive_scan_right
     {
       using type =
         decltype(kumi::exclusive_scan_right(std::declval<Function>(), std::declval<T>(), std::declval<Value>()));
     };
 
-    template<typename Function, concepts::product_type T> struct exclusive_scan_right<Function, T>
+    template<typename Function, kumi::concepts::product_type T> struct exclusive_scan_right<Function, T>
     {
       using type = decltype(kumi::exclusive_scan_right(std::declval<Function>(), std::declval<T>()));
     };
 
-    template<typename Function, concepts::product_type T, typename Value = void> struct inclusive_scan_left
+    template<typename Function, kumi::concepts::product_type T, typename Value = void> struct inclusive_scan_left
     {
       using type =
         decltype(kumi::inclusive_scan_left(std::declval<Function>(), std::declval<T>(), std::declval<Value>()));
     };
 
-    template<typename Function, concepts::product_type T> struct inclusive_scan_left<Function, T>
+    template<typename Function, kumi::concepts::product_type T> struct inclusive_scan_left<Function, T>
     {
       using type = decltype(kumi::inclusive_scan_left(std::declval<Function>(), std::declval<T>()));
     };
 
-    template<typename Function, concepts::product_type T, typename Value = void> struct exclusive_scan_left
+    template<typename Function, kumi::concepts::product_type T, typename Value = void> struct exclusive_scan_left
     {
       using type =
         decltype(kumi::exclusive_scan_left(std::declval<Function>(), std::declval<T>(), std::declval<Value>()));
     };
 
-    template<typename Function, concepts::product_type T> struct exclusive_scan_left<Function, T>
+    template<typename Function, kumi::concepts::product_type T> struct exclusive_scan_left<Function, T>
     {
       using type = decltype(kumi::exclusive_scan_left(std::declval<Function>(), std::declval<T>()));
     };
 
-    template<typename Function, concepts::product_type T, typename Value = void>
+    template<typename Function, kumi::concepts::product_type T, typename Value = void>
     using inclusive_scan_right_t = typename inclusive_scan_right<Function, T, Value>::type;
 
-    template<typename Function, concepts::product_type T, typename Value = void>
+    template<typename Function, kumi::concepts::product_type T, typename Value = void>
     using exclusive_scan_right_t = typename exclusive_scan_right<Function, T, Value>::type;
 
-    template<typename Function, concepts::product_type T, typename Value = void>
+    template<typename Function, kumi::concepts::product_type T, typename Value = void>
     using inclusive_scan_left_t = typename inclusive_scan_left<Function, T, Value>::type;
 
-    template<typename Function, concepts::product_type T, typename Value = void>
+    template<typename Function, kumi::concepts::product_type T, typename Value = void>
     using exclusive_scan_left_t = typename exclusive_scan_left<Function, T, Value>::type;
   }
 }

--- a/include/kumi/algorithm/tiler.hpp
+++ b/include/kumi/algorithm/tiler.hpp
@@ -47,21 +47,22 @@ namespace kumi
     @include doc/record/algo/tiles.cpp
   **/
   //====================================================================================================================
-  template<std::size_t N, std::size_t O, concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto tiles(T&& t)
+  template<std::size_t N, std::size_t O, kumi::concepts::product_type T>
+  [[nodiscard]] KUMI_ABI constexpr auto tiles(T&& t)
   {
-    static_assert(N > 0 && N <= size_v<T>, "[KUMI] - Invalid tile size");
+    static_assert(N > 0 && N <= kumi::size_v<T>, "[KUMI] - Invalid tile size");
 
-    if constexpr (N == size_v<T>) return kumi::make_tuple(t);
+    if constexpr (N == kumi::size_v<T>) return kumi::make_tuple(t);
     else
     {
-      constexpr auto proj = function::tiler(index<size_v<T>>, index<N>, index<O>);
+      constexpr auto proj = kumi::function::tiler(kumi::index<kumi::size_v<T>>, kumi::index<N>, kumi::index<O>);
       auto const build = [&]<std::size_t... J>(auto Off, std::index_sequence<J...>) {
-        using type = builder_make_t<T, element_t<Off + J, T>...>;
+        using type = builder_make_t<T, kumi::element_t<Off + J, T>...>;
         return type{get<Off + J>(KUMI_FWD(t))...};
       };
 
       return [&]<std::size_t... B, std::size_t... E>(std::index_sequence<B...>, std::index_sequence<E...>) {
-        return tuple{build(index<E>, std::make_index_sequence<B>{})...};
+        return kumi::tuple{build(kumi::index<E>, std::make_index_sequence<B>{})...};
       }(get<0>(proj), get<1>(proj));
     }
   }
@@ -102,20 +103,20 @@ namespace kumi
     @include doc/record/algo/windows.cpp
   **/
   //====================================================================================================================
-  template<std::size_t N, concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto windows(T&& t)
+  template<std::size_t N, kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto windows(T&& t)
   {
-    static_assert(N > 0 && N <= size_v<T>, "[KUMI] - Invalid tile size");
-    if constexpr (N == size_v<T>) return kumi::make_tuple(t);
+    static_assert(N > 0 && N <= kumi::size_v<T>, "[KUMI] - Invalid tile size");
+    if constexpr (N == kumi::size_v<T>) return kumi::make_tuple(t);
     else
     {
-      constexpr auto proj = function::tiler(index<size_v<T>>, index<N>, index<1>);
+      constexpr auto proj = kumi::function::tiler(kumi::index<kumi::size_v<T>>, kumi::index<N>, kumi::index<1>);
       auto const build = [&]<std::size_t... J>(auto O, std::index_sequence<J...>) {
-        using type = builder_make_t<T, element_t<O + J, T>...>;
+        using type = builder_make_t<T, kumi::element_t<O + J, T>...>;
         return type{get<O + J>(KUMI_FWD(t))...};
       };
 
       return [&]<std::size_t... B, std::size_t... E>(std::index_sequence<B...>, std::index_sequence<E...>) {
-        return tuple{build(index<E>, std::make_index_sequence<B>{})...};
+        return kumi::tuple{build(kumi::index<E>, std::make_index_sequence<B>{})...};
       }(get<0>(proj), get<1>(proj));
     }
   }
@@ -157,21 +158,21 @@ namespace kumi
     @include doc/record/algo/chunks.cpp
   **/
   //====================================================================================================================
-  template<std::size_t N, concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto chunks(T&& t)
+  template<std::size_t N, kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto chunks(T&& t)
   {
-    static_assert(N > 0 && N <= size_v<T>, "[KUMI] - Invalid tile size");
+    static_assert(N > 0 && N <= kumi::size_v<T>, "[KUMI] - Invalid tile size");
 
-    if constexpr (N == size_v<T>) return kumi::make_tuple(t);
+    if constexpr (N == kumi::size_v<T>) return kumi::make_tuple(t);
     else
     {
-      constexpr auto proj = function::tiler(index<size_v<T>>, index<N>, index<N>);
+      constexpr auto proj = function::tiler(kumi::index<kumi::size_v<T>>, kumi::index<N>, kumi::index<N>);
       auto const build = [&]<std::size_t... J>(auto O, std::index_sequence<J...>) {
-        using type = builder_make_t<T, element_t<O + J, T>...>;
+        using type = builder_make_t<T, kumi::element_t<O + J, T>...>;
         return type{get<O + J>(KUMI_FWD(t))...};
       };
 
       return [&]<std::size_t... B, std::size_t... E>(std::index_sequence<B...>, std::index_sequence<E...>) {
-        return tuple{build(index<E>, std::make_index_sequence<B>{})...};
+        return kumi::tuple{build(kumi::index<E>, std::make_index_sequence<B>{})...};
       }(get<0>(proj), get<1>(proj));
     }
   }

--- a/include/kumi/algorithm/tiler.hpp
+++ b/include/kumi/algorithm/tiler.hpp
@@ -195,10 +195,11 @@ namespace kumi
     };
 
     template<std::size_t N, std::size_t O, kumi::concepts::product_type T>
-    using tiles_t = typename tiles<N, O, T>::type;
+    using tiles_t = typename kumi::result::tiles<N, O, T>::type;
 
-    template<std::size_t N, kumi::concepts::product_type T> using windows_t = typename windows<N, T>::type;
+    template<std::size_t N, kumi::concepts::product_type T>
+    using windows_t = typename kumi::result::windows<N, T>::type;
 
-    template<std::size_t N, kumi::concepts::product_type T> using chunks_t = typename chunks<N, T>::type;
+    template<std::size_t N, kumi::concepts::product_type T> using chunks_t = typename kumi::result::chunks<N, T>::type;
   }
 }

--- a/include/kumi/algorithm/transpose.hpp
+++ b/include/kumi/algorithm/transpose.hpp
@@ -71,6 +71,6 @@ namespace kumi
       using type = decltype(kumi::transpose(std::declval<T>()));
     };
 
-    template<kumi::concepts::product_type T> using transpose_t = typename transpose<T>::type;
+    template<kumi::concepts::product_type T> using transpose_t = typename kumi::result::transpose<T>::type;
   }
 }

--- a/include/kumi/algorithm/transpose.hpp
+++ b/include/kumi/algorithm/transpose.hpp
@@ -41,35 +41,36 @@ namespace kumi
     @include doc/record/algo/transpose.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto transpose(T&& t)
+  template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto transpose(T&& t)
   {
     static_assert(_::supports_transpose<T>, "[KUMI] - Cannot transpose given product type");
-    if constexpr (concepts::empty_product_type<T>) return tuple{};
-    else if constexpr (concepts::record_type<T>) return transpose(values_of(KUMI_FWD(t)));
+    if constexpr (kumi::concepts::empty_product_type<T>) return kumi::tuple{};
+    else if constexpr (kumi::concepts::record_type<T>) return kumi::transpose(kumi::values_of(KUMI_FWD(t)));
     else
     {
-      constexpr std::size_t count = size_v<T>;
-      constexpr std::size_t size = size_v<element_t<0, T>>;
-      constexpr auto pos = function::zipper(index<count>, index<size>);
+      constexpr std::size_t count = kumi::size_v<T>;
+      constexpr std::size_t size = kumi::size_v<kumi::element_t<0, T>>;
+      constexpr auto pos = kumi::function::zipper(kumi::index<count>, kumi::index<size>);
 
       auto maps = [&]<std::size_t... I>(auto k, std::index_sequence<I...>) {
-        using type = builder_make_t<element_t<0, T>, element_t<k, std::remove_cvref_t<element_t<I, T>>>...>;
+        using type =
+          builder_make_t<kumi::element_t<0, T>, kumi::element_t<k, std::remove_cvref_t<kumi::element_t<I, T>>>...>;
         return type{get<k>(get<I>(KUMI_FWD(t)))...};
       };
 
       return [&]<std::size_t... N>(std::index_sequence<N...>) {
-        return kumi::make_tuple(maps(index<N>, get<0>(pos))...);
+        return kumi::make_tuple(maps(kumi::index<N>, get<0>(pos))...);
       }(get<1>(pos));
     }
   }
 
   namespace result
   {
-    template<concepts::product_type T> struct transpose
+    template<kumi::concepts::product_type T> struct transpose
     {
       using type = decltype(kumi::transpose(std::declval<T>()));
     };
 
-    template<concepts::product_type T> using transpose_t = typename transpose<T>::type;
+    template<kumi::concepts::product_type T> using transpose_t = typename transpose<T>::type;
   }
 }

--- a/include/kumi/algorithm/unique.hpp
+++ b/include/kumi/algorithm/unique.hpp
@@ -38,9 +38,9 @@ namespace kumi
     @include doc/record/algo/unique.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto unique(T&& t)
+  template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto unique(T&& t)
   {
-    if constexpr (concepts::empty_product_type<T>) return KUMI_FWD(t);
+    if constexpr (kumi::concepts::empty_product_type<T>) return KUMI_FWD(t);
     else
     {
       constexpr auto pos = function::uniqued(as<T>{});
@@ -81,17 +81,17 @@ namespace kumi
     @include doc/record/algo/all_unique.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto all_unique(T&& t)
+  template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto all_unique(T&& t)
   {
-    if constexpr (concepts::empty_product_type<T>) return t;
+    if constexpr (kumi::concepts::empty_product_type<T>) return t;
     else
     {
       constexpr auto proj = [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return function::uniquer(std::type_identity<stored_element_t<I, T>>{}...);
-      }(std::make_index_sequence<size_v<T>>{});
+        return kumi::function::uniquer(std::type_identity<kumi::stored_element_t<I, T>>{}...);
+      }(std::make_index_sequence<kumi::size_v<T>>{});
 
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        using type = builder_make_t<T, element_t<proj.e[I], T>...>;
+        using type = builder_make_t<T, kumi::element_t<proj.e[I], T>...>;
         return type{get<proj.e[I]>(KUMI_FWD(t))...};
       }(std::make_index_sequence<proj.count>{});
     }
@@ -99,18 +99,18 @@ namespace kumi
 
   namespace result
   {
-    template<concepts::product_type T> struct unique
+    template<kumi::concepts::product_type T> struct unique
     {
       using type = decltype(kumi::unique(std::declval<T>()));
     };
 
-    template<concepts::product_type T> struct all_unique
+    template<kumi::concepts::product_type T> struct all_unique
     {
       using type = decltype(kumi::all_unique(std::declval<T>()));
     };
 
-    template<concepts::product_type T> using unique_t = typename unique<T>::type;
+    template<kumi::concepts::product_type T> using unique_t = typename unique<T>::type;
 
-    template<concepts::product_type T> using all_unique_t = typename all_unique<T>::type;
+    template<kumi::concepts::product_type T> using all_unique_t = typename all_unique<T>::type;
   }
 }

--- a/include/kumi/algorithm/unique.hpp
+++ b/include/kumi/algorithm/unique.hpp
@@ -45,7 +45,7 @@ namespace kumi
     {
       constexpr auto pos = function::uniqued(as<T>{});
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        using ret_t = builder_make_t<T, element_t<pos.t[I], T>...>;
+        using ret_t = builder_make_t<T, kumi::element_t<pos.t[I], T>...>;
         return ret_t{get<pos.t[I]>(KUMI_FWD(t))...};
       }(std::make_index_sequence<pos.count>{});
     }
@@ -109,8 +109,8 @@ namespace kumi
       using type = decltype(kumi::all_unique(std::declval<T>()));
     };
 
-    template<kumi::concepts::product_type T> using unique_t = typename unique<T>::type;
+    template<kumi::concepts::product_type T> using unique_t = typename kumi::result::unique<T>::type;
 
-    template<kumi::concepts::product_type T> using all_unique_t = typename all_unique<T>::type;
+    template<kumi::concepts::product_type T> using all_unique_t = typename kumi::result::all_unique<T>::type;
   }
 }

--- a/include/kumi/algorithm/zip.hpp
+++ b/include/kumi/algorithm/zip.hpp
@@ -47,25 +47,25 @@ namespace kumi
     @include doc/record/algo/zip.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T0, concepts::sized_product_type<size_v<T0>>... Ts>
+  template<kumi::concepts::product_type T0, kumi::concepts::sized_product_type<kumi::size_v<T0>>... Ts>
   [[nodiscard]] KUMI_ABI constexpr auto zip(T0&& t0, Ts&&... ts)
-  requires(concepts::follows_same_semantic<T0, Ts...>)
+  requires(kumi::concepts::follows_same_semantic<T0, Ts...>)
   {
-    if constexpr (concepts::sized_product_type<T0, 0>) return tuple{};
+    if constexpr (kumi::concepts::sized_product_type<T0, 0>) return kumi::tuple{};
     else
     {
       constexpr auto count = 1 + sizeof...(Ts);
-      constexpr auto pos = function::zipper(index<count>, index<size_v<T0>>);
-      using res_type = common_product_type_t<std::remove_cvref_t<T0>, std::remove_cvref_t<Ts>...>;
+      constexpr auto pos = kumi::function::zipper(kumi::index<count>, kumi::index<kumi::size_v<T0>>);
+      using res_type = kumi::common_product_type_t<std::remove_cvref_t<T0>, std::remove_cvref_t<Ts>...>;
 
       auto maps = [&]<std::size_t... I>(auto k, std::index_sequence<I...>) {
         auto tps = kumi::forward_as_tuple(KUMI_FWD(t0), KUMI_FWD(ts)...);
-        using type = builder_make_t<res_type, element_t<k, element_t<I, decltype(tps)>>...>;
+        using type = builder_make_t<res_type, kumi::element_t<k, kumi::element_t<I, decltype(tps)>>...>;
         return type{get<k>(get<I>(KUMI_FWD(tps)))...};
       };
 
       return [&]<std::size_t... N>(std::index_sequence<N...>) {
-        return kumi::make_tuple(maps(index<N>, get<0>(pos))...);
+        return kumi::make_tuple(maps(kumi::index<N>, get<0>(pos))...);
       }(get<1>(pos));
     }
   }
@@ -110,27 +110,27 @@ namespace kumi
     @include doc/record/algo/zip_min.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T0, concepts::product_type... Ts>
+  template<kumi::concepts::product_type T0, kumi::concepts::product_type... Ts>
   [[nodiscard]] KUMI_ABI constexpr auto zip_min(T0&& t0, Ts&&... ts)
-  requires(concepts::follows_same_semantic<T0, Ts...>)
+  requires(kumi::concepts::follows_same_semantic<T0, Ts...>)
   {
-    constexpr std::size_t min = _::min(size_v<T0>, size_v<Ts>...);
-    if constexpr (min == 0) return tuple{};
+    constexpr std::size_t min = kumi::_::min(kumi::size_v<T0>, kumi::size_v<Ts>...);
+    if constexpr (min == 0) return kumi::tuple{};
     else
     {
       constexpr std::size_t count = 1 + sizeof...(Ts);
-      constexpr auto pos = function::zipper(index<count>, index<min>);
+      constexpr auto pos = kumi::function::zipper(kumi::index<count>, kumi::index<min>);
 
-      using res_type = common_product_type_t<std::remove_cvref_t<T0>, std::remove_cvref_t<Ts>...>;
+      using res_type = kumi::common_product_type_t<std::remove_cvref_t<T0>, std::remove_cvref_t<Ts>...>;
 
       auto maps = [&]<std::size_t... I>(auto E, std::index_sequence<I...>) {
         auto tps = kumi::forward_as_tuple(KUMI_FWD(t0), KUMI_FWD(ts)...);
-        using type = builder_make_t<res_type, element_t<E, element_t<I, decltype(tps)>>...>;
+        using type = builder_make_t<res_type, kumi::element_t<E, kumi::element_t<I, decltype(tps)>>...>;
         return type{get<E>(get<I>(KUMI_FWD(tps)))...};
       };
 
       return [&]<std::size_t... N>(std::index_sequence<N...>) {
-        return kumi::make_tuple(maps(index<N>, get<0>(pos))...);
+        return kumi::make_tuple(maps(kumi::index<N>, get<0>(pos))...);
       }(get<1>(pos));
     }
   }
@@ -172,55 +172,57 @@ namespace kumi
     @include doc/tuple/algo/zip_max.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T0, concepts::product_type... Ts>
+  template<kumi::concepts::product_type T0, kumi::concepts::product_type... Ts>
   [[nodiscard]] KUMI_ABI constexpr auto zip_max(T0&& t0, Ts&&... ts)
-  requires(concepts::follows_same_semantic<T0, Ts...>)
+  requires(kumi::concepts::follows_same_semantic<T0, Ts...>)
   {
-    constexpr std::size_t max = _::max(size_v<T0>, size_v<Ts>...);
-    if constexpr (max == 0) return tuple{};
+    constexpr std::size_t max = kumi::_::max(kumi::size_v<T0>, kumi::size_v<Ts>...);
+    if constexpr (max == 0) return kumi::tuple{};
     else
     {
       constexpr std::size_t count = 1 + sizeof...(Ts);
-      constexpr auto pos = function::zipper(index<count>, index<max>);
-      using res_type = common_product_type_t<std::remove_cvref_t<T0>, std::remove_cvref_t<Ts>...>;
+      constexpr auto pos = kumi::function::zipper(kumi::index<count>, kumi::index<max>);
+      using res_type = kumi::common_product_type_t<std::remove_cvref_t<T0>, std::remove_cvref_t<Ts>...>;
 
       auto maps = [&]<std::size_t... I>(auto k, std::index_sequence<I...>) {
         auto tps = kumi::forward_as_tuple(KUMI_FWD(t0), KUMI_FWD(ts)...);
 
-        using type = builder_make_t<res_type, function::element_or_t<k, element_t<I, decltype(tps)>, kumi::unit>...>;
+        using type =
+          builder_make_t<res_type, kumi::function::element_or_t<k, kumi::element_t<I, decltype(tps)>, kumi::unit>...>;
 
-        return type{function::get_or<k>(get<I>(KUMI_FWD(tps)), kumi::none)...};
+        return type{kumi::function::get_or<k>(get<I>(KUMI_FWD(tps)), kumi::none)...};
       };
 
       return [&]<std::size_t... N>(std::index_sequence<N...>) {
-        return kumi::make_tuple(maps(index<N>, get<0>(pos))...);
+        return kumi::make_tuple(maps(kumi::index<N>, get<0>(pos))...);
       }(get<1>(pos));
     }
   }
 
   namespace result
   {
-    template<concepts::product_type T0, concepts::sized_product_type<size_v<T0>>... Ts> struct zip
+    template<kumi::concepts::product_type T0, kumi::concepts::sized_product_type<kumi::size_v<T0>>... Ts> struct zip
     {
       using type = decltype(kumi::zip(std::declval<T0>(), std::declval<Ts>()...));
     };
 
-    template<concepts::product_type T0, concepts::product_type... Ts> struct zip_min
+    template<kumi::concepts::product_type T0, kumi::concepts::product_type... Ts> struct zip_min
     {
       using type = decltype(kumi::zip_min(std::declval<T0>(), std::declval<Ts>()...));
     };
 
-    template<concepts::product_type T0, concepts::product_type... Ts> struct zip_max
+    template<kumi::concepts::product_type T0, kumi::concepts::product_type... Ts> struct zip_max
     {
       using type = decltype(kumi::zip_max(std::declval<T0>(), std::declval<Ts>()...));
     };
 
-    template<concepts::product_type T0, concepts::product_type... Ts> using zip_t = typename zip<T0, Ts...>::type;
+    template<kumi::concepts::product_type T0, kumi::concepts::product_type... Ts>
+    using zip_t = typename zip<T0, Ts...>::type;
 
-    template<concepts::product_type T0, concepts::product_type... Ts>
+    template<kumi::concepts::product_type T0, kumi::concepts::product_type... Ts>
     using zip_min_t = typename zip_min<T0, Ts...>::type;
 
-    template<concepts::product_type T0, concepts::product_type... Ts>
+    template<kumi::concepts::product_type T0, kumi::concepts::product_type... Ts>
     using zip_max_t = typename zip_max<T0, Ts...>::type;
   }
 }

--- a/include/kumi/algorithm/zip.hpp
+++ b/include/kumi/algorithm/zip.hpp
@@ -217,12 +217,12 @@ namespace kumi
     };
 
     template<kumi::concepts::product_type T0, kumi::concepts::product_type... Ts>
-    using zip_t = typename zip<T0, Ts...>::type;
+    using zip_t = typename kumi::result::zip<T0, Ts...>::type;
 
     template<kumi::concepts::product_type T0, kumi::concepts::product_type... Ts>
-    using zip_min_t = typename zip_min<T0, Ts...>::type;
+    using zip_min_t = typename kumi::result::zip_min<T0, Ts...>::type;
 
     template<kumi::concepts::product_type T0, kumi::concepts::product_type... Ts>
-    using zip_max_t = typename zip_max<T0, Ts...>::type;
+    using zip_max_t = typename kumi::result::zip_max<T0, Ts...>::type;
   }
 }

--- a/include/kumi/detail/binder.hpp
+++ b/include/kumi/detail/binder.hpp
@@ -37,7 +37,7 @@ namespace kumi::_
 
   // Empty Base Optimization
   template<int N, typename T>
-  requires(std::is_empty_v<T> && (!field<T>))
+  requires(std::is_empty_v<T> && (!kumi::_::field<T>))
   struct leaf<N, T> : T
   {
     using index = std::integral_constant<std::size_t, N>;
@@ -60,12 +60,12 @@ namespace kumi::_
     KUMI_ABI constexpr T const& operator()(inner_type) const& noexcept { return *this; }
   };
 
-  template<int N, field T> struct leaf<N, T> : T
+  template<int N, kumi::_::field T> struct leaf<N, T> : T
   {
     using T::operator();
     using index = std::integral_constant<std::size_t, N>;
-    using key = identifier_of_t<T>;
-    using inner_type = type_of_t<T>;
+    using key = kumi::_::identifier_of_t<T>;
+    using inner_type = kumi::_::type_of_t<T>;
 
     KUMI_ABI constexpr T& operator()(index) & noexcept { return *this; }
 
@@ -79,19 +79,19 @@ namespace kumi::_
   template<typename ISeq, typename... Ts> struct binder;
 
   // General N-case
-  template<int... Is, typename... Ts> struct binder<std::integer_sequence<int, Is...>, Ts...> : leaf<Is, Ts>...
+  template<int... Is, typename... Ts> struct binder<std::integer_sequence<int, Is...>, Ts...> : kumi::_::leaf<Is, Ts>...
   {
     static constexpr bool is_homogeneous = false;
-    using leaf<Is, Ts>::operator()...;
+    using kumi::_::leaf<Is, Ts>::operator()...;
   };
 
   // Specializable binder type constructor
   template<typename ISeq, typename... Ts> struct make_binder
   {
-    using type = binder<ISeq, Ts...>;
+    using type = kumi::_::binder<ISeq, Ts...>;
   };
 
-  template<typename ISeq, typename... Ts> using make_binder_t = typename make_binder<ISeq, Ts...>::type;
+  template<typename ISeq, typename... Ts> using make_binder_t = typename kumi::_::make_binder<ISeq, Ts...>::type;
 
   // Record binder, a record is unordered which implies no need for leaf tagging with integers. All types are also
   // necessarily unique.
@@ -103,8 +103,8 @@ namespace kumi::_
   // Specializable set type constructor
   template<typename... Ts> struct make_set
   {
-    using type = set<Ts...>;
+    using type = kumi::_::set<Ts...>;
   };
 
-  template<typename... Ts> using make_set_t = typename make_set<Ts...>::type;
+  template<typename... Ts> using make_set_t = typename kumi::_::make_set<Ts...>::type;
 }

--- a/include/kumi/detail/concepts.hpp
+++ b/include/kumi/detail/concepts.hpp
@@ -33,8 +33,9 @@ namespace kumi::_
   // To be displayed an identifier need to be constructible via T{}, and either expose a constexpr to_str() or
   // nothing, in which case the typer will be used (see typename.hpp). The name that is displayed is called the label.
   template<typename T>
-  concept valid_label = implicit_constructible<T> &&
-                        (!requires { to_str(T{}); } || std::same_as<typename value<to_str(T{})>::type, kumi::str>);
+  concept valid_label =
+    kumi::_::implicit_constructible<T> &&
+    (!requires { to_str(T{}); } || std::same_as<typename kumi::_::value<to_str(T{})>::type, kumi::str>);
 
   //====================================================================================================================
   // Helper concepts for custom label
@@ -57,24 +58,24 @@ namespace kumi::_
     { std::remove_cvref_t<O>::label() };
   };
 
-  template<field T> struct identifier_of
+  template<kumi::_::field T> struct identifier_of
   {
     using type = typename std::remove_cvref_t<T>::identifier_type;
   };
 
-  template<field T> struct type_of
+  template<kumi::_::field T> struct type_of
   {
     using type = typename std::remove_cvref_t<T>::type;
   };
 
-  template<field T> struct label_of
+  template<kumi::_::field T> struct label_of
   {
     using type = typename std::remove_cvref_t<T>::label_type;
   };
 
-  template<field T> using identifier_of_t = typename identifier_of<std::remove_cvref_t<T>>::type;
-  template<field T> using type_of_t = typename type_of<std::remove_cvref_t<T>>::type;
-  template<field T> using label_of_t = typename label_of<std::remove_cvref_t<T>>::type;
+  template<kumi::_::field T> using identifier_of_t = typename kumi::_::identifier_of<std::remove_cvref_t<T>>::type;
+  template<kumi::_::field T> using type_of_t = typename kumi::_::type_of<std::remove_cvref_t<T>>::type;
+  template<kumi::_::field T> using label_of_t = typename kumi::_::label_of<std::remove_cvref_t<T>>::type;
 
   //====================================================================================================================
   // Helper concepts for custom identifier
@@ -82,12 +83,12 @@ namespace kumi::_
   template<typename T>
   concept identifier = requires(T const& t) { typename std::remove_cvref_t<T>::type; };
 
-  template<identifier T> struct tag_of
+  template<kumi::_::identifier T> struct tag_of
   {
     using type = typename std::remove_cvref_t<T>::type;
   };
 
-  template<identifier T> using tag_of_t = typename tag_of<std::remove_cvref_t<T>>::type;
+  template<kumi::_::identifier T> using tag_of_t = typename kumi::_::tag_of<std::remove_cvref_t<T>>::type;
 
   //====================================================================================================================
   // Helper concepts for construction checks
@@ -137,17 +138,19 @@ namespace kumi::_
   };
 
   template<typename From, typename To>
-  concept piecewise_convertible = is_piecewise_convertible<std::remove_cvref_t<From>, std::remove_cvref_t<To>>::value;
+  concept piecewise_convertible =
+    kumi::_::is_piecewise_convertible<std::remove_cvref_t<From>, std::remove_cvref_t<To>>::value;
 
   template<typename From, typename To>
   concept piecewise_constructible =
-    is_piecewise_constructible<std::remove_cvref_t<From>, std::remove_cvref_t<To>>::value;
+    kumi::_::is_piecewise_constructible<std::remove_cvref_t<From>, std::remove_cvref_t<To>>::value;
 
   template<typename From, typename To>
-  concept piecewise_ordered = is_piecewise_ordered<std::remove_cvref_t<From>, std::remove_cvref_t<To>>::value;
+  concept piecewise_ordered = kumi::_::is_piecewise_ordered<std::remove_cvref_t<From>, std::remove_cvref_t<To>>::value;
 
   template<typename From, typename To>
-  concept piecewise_comparable = is_piecewise_comparable<std::remove_cvref_t<From>, std::remove_cvref_t<To>>::value;
+  concept piecewise_comparable =
+    kumi::_::is_piecewise_comparable<std::remove_cvref_t<From>, std::remove_cvref_t<To>>::value;
 
   //====================================================================================================================
   // Helper concepts for construction checks on records
@@ -157,11 +160,11 @@ namespace kumi::_
     static consteval void get(...);
   };
 
-  template<field F> struct check_value<F>
+  template<kumi::_::field F> struct check_value<F>
   {
-    template<field T>
-    requires(std::is_same_v<identifier_of_t<F>, identifier_of_t<T>>)
-    static consteval type_of_t<F> get(T);
+    template<kumi::_::field T>
+    requires(std::is_same_v<kumi::_::identifier_of_t<F>, kumi::_::identifier_of_t<T>>)
+    static consteval kumi::_::type_of_t<F> get(T);
   };
 
   template<typename... Ts> struct sort : std::true_type
@@ -174,24 +177,24 @@ namespace kumi::_
   {
     using check_value<Ts>::get...;
     using t_list = Box<decltype(get(std::declval<Us>()))...>;
-    using u_list = Box<type_of_t<Us>...>;
+    using u_list = Box<kumi::_::type_of_t<Us>...>;
 
-    using is_fieldwise_constructible = is_piecewise_constructible<t_list, u_list>;
-    using is_fieldwise_convertible = is_piecewise_convertible<t_list, u_list>;
-    using is_fieldwise_comparable = is_piecewise_comparable<t_list, u_list>;
+    using is_fieldwise_constructible = kumi::_::is_piecewise_constructible<t_list, u_list>;
+    using is_fieldwise_convertible = kumi::_::is_piecewise_convertible<t_list, u_list>;
+    using is_fieldwise_comparable = kumi::_::is_piecewise_comparable<t_list, u_list>;
   };
 
   template<typename From, typename To>
   concept fieldwise_convertible =
-    sort<std::remove_cvref_t<From>, std::remove_cvref_t<To>>::is_fieldwise_convertible::value;
+    kumi::_::sort<std::remove_cvref_t<From>, std::remove_cvref_t<To>>::is_fieldwise_convertible::value;
 
   template<typename From, typename To>
   concept fieldwise_constructible =
-    sort<std::remove_cvref_t<From>, std::remove_cvref_t<To>>::is_fieldwise_constructible::value;
+    kumi::_::sort<std::remove_cvref_t<From>, std::remove_cvref_t<To>>::is_fieldwise_constructible::value;
 
   template<typename From, typename To>
   concept fieldwise_comparable =
-    sort<std::remove_cvref_t<From>, std::remove_cvref_t<To>>::is_fieldwise_comparable::value;
+    kumi::_::sort<std::remove_cvref_t<From>, std::remove_cvref_t<To>>::is_fieldwise_comparable::value;
 
   //====================================================================================================================
   // Helper meta functions to access a field type via a meta function
@@ -199,13 +202,13 @@ namespace kumi::_
   struct find_failed
   {
     static consteval std::false_type get(...);
-    static consteval invalid get_index(...);
+    static consteval kumi::_::invalid get_index(...);
   };
 
   template<template<class, class> class Matcher, std::size_t I, typename Ref, typename Field> struct match_node
   {
     static consteval std::false_type get();
-    static consteval invalid get_index();
+    static consteval kumi::_::invalid get_index();
   };
 
   template<template<class, class> class Matcher, std::size_t I, typename Ref, typename Field>
@@ -220,13 +223,13 @@ namespace kumi::_
   template<template<class, class> class Matcher, typename Ref, typename Seq, typename... Fields> struct find_engine;
 
   template<template<class, class> class Matcher, typename Ref, std::size_t... I, typename... Fields>
-  struct find_engine<Matcher, Ref, std::index_sequence<I...>, Fields...> : find_failed,
-                                                                           match_node<Matcher, I, Ref, Fields>...
+  struct find_engine<Matcher, Ref, std::index_sequence<I...>, Fields...>
+    : find_failed, kumi::_::match_node<Matcher, I, Ref, Fields>...
   {
-    using find_failed::get;
-    using find_failed::get_index;
-    using match_node<Matcher, I, Ref, Fields>::get...;
-    using match_node<Matcher, I, Ref, Fields>::get_index...;
+    using kumi::_::find_failed::get;
+    using kumi::_::find_failed::get_index;
+    using kumi::_::match_node<Matcher, I, Ref, Fields>::get...;
+    using kumi::_::match_node<Matcher, I, Ref, Fields>::get_index...;
 
     using type = decltype(get(std::declval<Ref>()));
     static constexpr auto value = decltype(get_index(std::declval<Ref>()))::value;
@@ -240,15 +243,17 @@ namespace kumi::_
   };
 
   template<typename Ref, typename... Fields>
-  using find_by_type_t = find_engine<match_by_type, Ref, std::index_sequence_for<Fields...>, Fields...>;
-
-  template<typename Ref, typename... Fields> using get_field_by_type_t = typename find_by_type_t<Ref, Fields...>::type;
-
-  template<typename Ref, typename... Fields>
-  inline constexpr auto get_index_by_type_v = find_by_type_t<Ref, Fields...>::value;
+  using find_by_type_t =
+    kumi::_::find_engine<kumi::_::match_by_type, Ref, std::index_sequence_for<Fields...>, Fields...>;
 
   template<typename Ref, typename... Fields>
-  concept can_get_field_by_type = !std::is_same_v<get_field_by_type_t<Ref, Fields...>, std::false_type>;
+  using get_field_by_type_t = typename kumi::_::find_by_type_t<Ref, Fields...>::type;
+
+  template<typename Ref, typename... Fields>
+  inline constexpr auto get_index_by_type_v = kumi::_::find_by_type_t<Ref, Fields...>::value;
+
+  template<typename Ref, typename... Fields>
+  concept can_get_field_by_type = !std::is_same_v<kumi::_::get_field_by_type_t<Ref, Fields...>, std::false_type>;
 
   // ===================================================================================================================
   // By Value (Tag)
@@ -257,21 +262,22 @@ namespace kumi::_
   {
   };
 
-  template<identifier Ref, field Field>
-  struct match_by_tag<Ref, Field> : std::is_same<tag_of_t<Ref>, identifier_of_t<Field>>
+  template<kumi::_::identifier Ref, kumi::_::field Field>
+  struct match_by_tag<Ref, Field> : std::is_same<kumi::_::tag_of_t<Ref>, kumi::_::identifier_of_t<Field>>
   {
   };
 
   template<typename Ref, typename... Fields>
-  using find_by_tag_t = find_engine<match_by_tag, Ref, std::index_sequence_for<Fields...>, Fields...>;
-
-  template<typename Ref, typename... Fields> using get_field_by_value_t = typename find_by_tag_t<Ref, Fields...>::type;
+  using find_by_tag_t = kumi::_::find_engine<kumi::_::match_by_tag, Ref, std::index_sequence_for<Fields...>, Fields...>;
 
   template<typename Ref, typename... Fields>
-  inline constexpr auto get_index_by_value_v = find_by_tag_t<Ref, Fields...>::value;
+  using get_field_by_value_t = typename kumi::_::find_by_tag_t<Ref, Fields...>::type;
 
   template<typename Ref, typename... Fields>
-  concept can_get_field_by_value = !std::is_same_v<get_field_by_value_t<Ref, Fields...>, std::false_type>;
+  inline constexpr auto get_index_by_value_v = kumi::_::find_by_tag_t<Ref, Fields...>::value;
+
+  template<typename Ref, typename... Fields>
+  concept can_get_field_by_value = !std::is_same_v<kumi::_::get_field_by_value_t<Ref, Fields...>, std::false_type>;
 
   //====================================================================================================================
   // By label (displayed name)
@@ -280,19 +286,21 @@ namespace kumi::_
   {
   };
 
-  template<label Ref, field Field> struct match_by_label<Ref, Field> : std::bool_constant<Ref::value == Field::label()>
+  template<kumi::_::label Ref, kumi::_::field Field>
+  struct match_by_label<Ref, Field> : std::bool_constant<Ref::value == Field::label()>
   {
   };
 
   template<typename Ref, typename... Fields>
-  using find_by_label_t = find_engine<match_by_label, Ref, std::index_sequence_for<Fields...>, Fields...>;
+  using find_by_label_t =
+    kumi::_::find_engine<kumi::_::match_by_label, Ref, std::index_sequence_for<Fields...>, Fields...>;
 
   template<typename Ref, typename... Fields>
-  using get_field_by_label_t = typename find_by_label_t<Ref, Fields...>::type;
+  using get_field_by_label_t = typename kumi::_::find_by_label_t<Ref, Fields...>::type;
 
   template<typename Ref, typename... Fields>
-  inline constexpr auto get_index_by_label_v = find_by_label_t<Ref, Fields...>::value;
+  inline constexpr auto get_index_by_label_v = kumi::_::find_by_label_t<Ref, Fields...>::value;
 
   template<typename Ref, typename... Fields>
-  concept can_get_field_by_label = !std::is_same_v<get_field_by_label_t<Ref, Fields...>, std::false_type>;
+  concept can_get_field_by_label = !std::is_same_v<kumi::_::get_field_by_label_t<Ref, Fields...>, std::false_type>;
 }

--- a/include/kumi/detail/field.hpp
+++ b/include/kumi/detail/field.hpp
@@ -25,7 +25,7 @@ namespace kumi
   template<typename Id, typename T> struct field
   {
     /// Name associated to the field
-    static constexpr auto label() { return _::make_str(Id{}); }
+    static constexpr auto label() { return kumi::_::make_str(Id{}); }
 
     using type = T;
     using identifier_type = Id;
@@ -66,7 +66,7 @@ namespace kumi
     template<typename CharT, typename Traits>
     friend std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, Traits>& os, field const& w) noexcept
     {
-      return os << _::make_str(std::remove_cvref_t<Id>{}) << " : " << _::make_streamable(w.value);
+      return os << kumi::_::make_str(std::remove_cvref_t<Id>{}) << " : " << kumi::_::make_streamable(w.value);
     }
   };
 
@@ -76,7 +76,7 @@ namespace kumi
   struct field<Id, T> : T
   {
     /// Name associated to the field
-    static constexpr auto label() { return _::make_str(Id{}); }
+    static constexpr auto label() { return kumi::_::make_str(Id{}); }
 
     using type = T;
     using identifier_type = Id;
@@ -115,18 +115,18 @@ namespace kumi
     template<typename CharT, typename Traits>
     friend std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, Traits>& os, field const& w) noexcept
     {
-      return os << _::make_str(std::remove_cvref_t<Id>{}) << " : "
-                << _::make_streamable(w(_::identifier_of_t<decltype(w)>{}));
+      return os << kumi::_::make_str(std::remove_cvref_t<Id>{}) << " : "
+                << kumi::_::make_streamable(w(_::identifier_of_t<decltype(w)>{}));
     }
   };
 
   /// Specialisation to clearly indicate an error
   template<typename Id, typename T>
-  requires(!_::valid_label<Id>)
+  requires(!kumi::_::valid_label<Id>)
   struct field<Id, T>
   {
     field(T&&) = delete;
-    static_assert(_::valid_label<Id>, "User defined to_str(...) function is not constexpr");
+    static_assert(kumi::_::valid_label<Id>, "User defined to_str(...) function is not constexpr");
   };
 
   //====================================================================================================================
@@ -156,7 +156,7 @@ namespace kumi
   //====================================================================================================================
   template<typename T> [[nodiscard]] KUMI_ABI consteval auto identifier_of() noexcept
   {
-    if constexpr (_::field<T>) return _::identifier_of_t<T>{};
+    if constexpr (kumi::_::field<T>) return kumi::_::identifier_of_t<T>{};
     else return kumi::unknown{};
   }
 
@@ -187,7 +187,7 @@ namespace kumi
   //====================================================================================================================
   template<typename T> [[nodiscard]] KUMI_ABI consteval str label_of() noexcept
   {
-    if constexpr (_::field<T>) return _::label_of_t<T>{};
+    if constexpr (kumi::_::field<T>) return kumi::_::label_of_t<T>{};
     else return kumi::unknown{};
   }
 
@@ -219,7 +219,7 @@ namespace kumi
   //====================================================================================================================
   template<typename T> [[nodiscard]] KUMI_ABI constexpr decltype(auto) field_value_of(T&& t) noexcept
   {
-    if constexpr (_::field<T>) return (KUMI_FWD(t)(_::identifier_of_t<T>{}));
+    if constexpr (kumi::_::field<T>) return (KUMI_FWD(t)(kumi::_::identifier_of_t<T>{}));
     else return KUMI_FWD(t);
   }
 
@@ -252,7 +252,7 @@ namespace kumi
   template<_::identifier auto Name, typename T>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) capture_field(T&& t) noexcept
   {
-    return field<decltype(Name), T>{KUMI_FWD(t)};
+    return kumi::field<decltype(Name), T>{KUMI_FWD(t)};
   }
 
   //====================================================================================================================
@@ -285,11 +285,11 @@ namespace kumi
   //====================================================================================================================
   template<typename U, typename T> [[nodiscard]] KUMI_ABI constexpr decltype(auto) field_cast(T&& t) noexcept
   {
-    if constexpr (_::field<U>)
-      return field<_::identifier_of_t<T>, _::type_of_t<U>>{
-        static_cast<_::type_of_t<U>>(KUMI_FWD(t)(_::identifier_of_t<T>{}))};
-    else if constexpr (!_::field<T>) return static_cast<_::type_of_t<U>>(KUMI_FWD(t));
-    else return field<_::identifier_of_t<T>, U>{static_cast<U>(KUMI_FWD(t)(_::identifier_of_t<T>{}))};
+    if constexpr (kumi::_::field<U>)
+      return kumi::field<kumi::_::identifier_of_t<T>, kumi::_::type_of_t<U>>{
+        static_cast<kumi::_::type_of_t<U>>(KUMI_FWD(t)(kumi::_::identifier_of_t<T>{}))};
+    else if constexpr (!kumi::_::field<T>) return static_cast<kumi::_::type_of_t<U>>(KUMI_FWD(t));
+    else return kumi::field<kumi::_::identifier_of_t<T>, U>{static_cast<U>(KUMI_FWD(t)(kumi::_::identifier_of_t<T>{}))};
   }
 
   namespace result
@@ -309,7 +309,7 @@ namespace kumi
       using type = decltype(kumi::field_value_of(std::declval<T>()));
     };
 
-    template<_::identifier auto Name, typename T> struct capture_field
+    template<kumi::_::identifier auto Name, typename T> struct capture_field
     {
       using type = decltype(kumi::capture_field<Name>(std::declval<T>()));
     };
@@ -319,14 +319,15 @@ namespace kumi
       using type = decltype(kumi::field_cast<U, T>(std::declval<T>()));
     };
 
-    template<typename T> using identifier_of_t = typename identifier_of<T>::type;
+    template<typename T> using identifier_of_t = typename kumi::result::identifier_of<T>::type;
 
-    template<typename T> using label_of_t = typename label_of<T>::type;
+    template<typename T> using label_of_t = typename kumi::result::label_of<T>::type;
 
-    template<typename T> using field_value_of_t = typename field_value_of<T>::type;
+    template<typename T> using field_value_of_t = typename kumi::result::field_value_of<T>::type;
 
-    template<_::identifier auto Name, typename T> using capture_field_t = typename capture_field<Name, T>::type;
+    template<_::identifier auto Name, typename T>
+    using capture_field_t = typename kumi::result::capture_field<Name, T>::type;
 
-    template<typename U, typename T> using field_cast_t = typename field_cast<U, T>::type;
+    template<typename U, typename T> using field_cast_t = typename kumi::result::field_cast<U, T>::type;
   }
 }

--- a/include/kumi/detail/functors.hpp
+++ b/include/kumi/detail/functors.hpp
@@ -84,19 +84,20 @@ namespace kumi::_
     using type = T;
   };
 
-  template<typename T, auto I> using repeat_t = typename repeat<T, I>::type;
+  template<typename T, auto I> using repeat_t = typename kumi::_::repeat<T, I>::type;
 
   template<typename T, auto N> struct as_homogeneous
   {
-    template<std::size_t... I> static consteval auto homogeneify(std::index_sequence<I...>) -> tuple<repeat_t<T, I>...>;
+    template<std::size_t... I>
+    static consteval auto homogeneify(std::index_sequence<I...>) -> tuple<kumi::_::repeat_t<T, I>...>;
 
     using type = std::remove_cvref_t<decltype(homogeneify(std::make_index_sequence<N>{}))>;
   };
 
-  template<typename T, auto N> using as_homogeneous_t = typename as_homogeneous<T, N>::type;
+  template<typename T, auto N> using as_homogeneous_t = typename kumi::_::as_homogeneous<T, N>::type;
 
-  inline constexpr container_of_index_t container_of_index{};
-  inline constexpr element_of_index_t element_of_index{};
-  inline constexpr unflatten_index_t unflatten_index{};
-  inline constexpr digits_ digits{};
+  inline constexpr kumi::_::container_of_index_t container_of_index{};
+  inline constexpr kumi::_::element_of_index_t element_of_index{};
+  inline constexpr kumi::_::unflatten_index_t unflatten_index{};
+  inline constexpr kumi::_::digits_ digits{};
 }

--- a/include/kumi/detail/meta_helpers.hpp
+++ b/include/kumi/detail/meta_helpers.hpp
@@ -15,7 +15,7 @@ namespace kumi::_
   template<std::size_t I, typename T> consteval auto get_key()
   {
     using type = std::remove_cvref_t<T>;
-    if constexpr (_::field<T>) return typename type::identifier_type{};
+    if constexpr (kumi::_::field<T>) return typename type::identifier_type{};
     else return std::integral_constant<std::size_t, I>{};
   }
 
@@ -32,7 +32,7 @@ namespace kumi::_
   };
 
   /// Named variant of unique
-  template<std::size_t I, _::field T> struct unique_name<I, T>
+  template<std::size_t I, kumi::_::field T> struct unique_name<I, T>
   {
     operator typename std::remove_cvref_t<T>::identifier_type();
   };

--- a/include/kumi/detail/optimized.hpp
+++ b/include/kumi/detail/optimized.hpp
@@ -56,10 +56,11 @@ namespace kumi::_
   };
 
   template<int... Is, typename T0, typename T1, typename... Ts>
-  requires(all_the_same<T0, T1, Ts...> && no_references<T0, T1, Ts...> && no_empty<T0, T1, Ts...>)
+  requires(kumi::_::all_the_same<T0, T1, Ts...> && kumi::_::no_references<T0, T1, Ts...> &&
+           kumi::_::no_empty<T0, T1, Ts...>)
   struct make_binder<std::integer_sequence<int, Is...>, T0, T1, Ts...>
   {
-    using type = binder_n<T0, 2 + sizeof...(Ts)>;
+    using type = kumi::_::binder_n<T0, 2 + sizeof...(Ts)>;
   };
 
   //====================================================================================================================

--- a/include/kumi/detail/preprocessor.hpp
+++ b/include/kumi/detail/preprocessor.hpp
@@ -100,22 +100,24 @@
   if constexpr (std::same_as<T, T##N>) return static_cast<T##N const&&>(member##N);
 
 #define KUMI_GET_NAME_LVALUE(N, I)                                                                                     \
-  if constexpr (field<T##N> && requires { member##N(I{}); }) return member##N(identifier_of_t<T##N>{});
+  if constexpr (kumi::_::field<T##N> && requires { member##N(I{}); })                                                  \
+    return member##N(kumi::_::identifier_of_t<T##N>{});
 
 #define KUMI_GET_NAME_RVALUE(N, I)                                                                                     \
-  if constexpr (field<T##N> && requires { member##N(I{}); })                                                           \
-    return static_cast<T##N&&>(member##N)(identifier_of_t<T##N>{});
+  if constexpr (kumi::_::field<T##N> && requires { member##N(I{}); })                                                  \
+    return static_cast<T##N&&>(member##N)(kumi::_::identifier_of_t<T##N>{});
 
 #define KUMI_GET_NAME_CONST_RVALUE(N, I)                                                                               \
-  if constexpr (field<T##N> && requires { member##N(I{}); })                                                           \
-    return static_cast<T##N const&&>(member##N)(identifier_of_t<T##N>{});
+  if constexpr (kumi::_::field<T##N> && requires { member##N(I{}); })                                                  \
+    return static_cast<T##N const&&>(member##N)(kumi::_::identifier_of_t<T##N>{});
 
 //======================================================================================================================
 // Macro used to define the optimized inner structure of a product type
 //======================================================================================================================
 #define KUMI_BINDER(N)                                                                                                 \
   template<KUMI_PP_ENUM(N, KUMI_PP_TAC, typename T)>                                                                   \
-  requires(no_empty<KUMI_PP_ENUM(N, KUMI_PP_TAC, T)> && no_references<KUMI_PP_ENUM(N, KUMI_PP_TAC, T)>)                \
+  requires(kumi::_::no_empty<KUMI_PP_ENUM(N, KUMI_PP_TAC, T)> &&                                                       \
+           kumi::_::no_references<KUMI_PP_ENUM(N, KUMI_PP_TAC, T)>)                                                    \
   struct binder<std::integer_sequence<int, KUMI_PP_ENUM(N, KUMI_PP_IDENTITY, _)>, KUMI_PP_ENUM(N, KUMI_PP_TAC, T)>     \
   {                                                                                                                    \
     static constexpr bool is_homogeneous = (N == 1);                                                                   \
@@ -138,19 +140,19 @@
       KUMI_PP_REPEAT(N, KUMI_GET_TYPE_LVALUE, T)                                                                       \
     }                                                                                                                  \
                                                                                                                        \
-    template<identifier I> KUMI_ABI constexpr auto& operator()(I) & noexcept                                           \
+    template<kumi::_::identifier I> KUMI_ABI constexpr auto& operator()(I) & noexcept                                  \
     {                                                                                                                  \
       KUMI_PP_REPEAT(N, KUMI_GET_NAME_LVALUE, I)                                                                       \
     }                                                                                                                  \
-    template<identifier I> KUMI_ABI constexpr auto&& operator()(I) && noexcept                                         \
+    template<kumi::_::identifier I> KUMI_ABI constexpr auto&& operator()(I) && noexcept                                \
     {                                                                                                                  \
       KUMI_PP_REPEAT(N, KUMI_GET_NAME_RVALUE, I)                                                                       \
     }                                                                                                                  \
-    template<identifier I> KUMI_ABI constexpr auto const&& operator()(I) const&& noexcept                              \
+    template<kumi::_::identifier I> KUMI_ABI constexpr auto const&& operator()(I) const&& noexcept                     \
     {                                                                                                                  \
       KUMI_PP_REPEAT(N, KUMI_GET_NAME_CONST_RVALUE, I)                                                                 \
     }                                                                                                                  \
-    template<identifier I> KUMI_ABI constexpr auto const& operator()(I) const& noexcept                                \
+    template<kumi::_::identifier I> KUMI_ABI constexpr auto const& operator()(I) const& noexcept                       \
     {                                                                                                                  \
       KUMI_PP_REPEAT(N, KUMI_GET_NAME_LVALUE, I)                                                                       \
     }                                                                                                                  \

--- a/include/kumi/detail/str.hpp
+++ b/include/kumi/detail/str.hpp
@@ -87,7 +87,7 @@ namespace kumi
   //====================================================================================================================
   struct unknown
   {
-    constexpr inline operator str() const noexcept { return str{"kumi::unknown"}; }
+    constexpr inline operator kumi::str() const noexcept { return str{"kumi::unknown"}; }
 
     KUMI_ABI friend constexpr auto operator<=>(unknown const&, unknown const&) noexcept = default;
 

--- a/include/kumi/detail/streamable.hpp
+++ b/include/kumi/detail/streamable.hpp
@@ -55,9 +55,9 @@ namespace kumi::_
     else return kumi::unknown{};
   }
 
-  template<valid_label T> consteval str make_str(T const& t)
+  template<kumi::_::valid_label T> consteval str make_str(T const& t)
   {
     if constexpr (requires { to_str(t); }) return to_str(t);
-    else return typer<std::remove_cvref_t<T>>();
+    else return kumi::_::typer<std::remove_cvref_t<T>>();
   }
 }

--- a/include/kumi/functional/bind.hpp
+++ b/include/kumi/functional/bind.hpp
@@ -29,7 +29,7 @@ namespace kumi
   requires(std::is_move_constructible_v<std::decay_t<C>> && (std::is_move_constructible_v<std::decay_t<Ts>> && ...))
   {
     return [&]<typename... Args>(Args&&... call_args) -> decltype(auto) {
-      return invoke(KUMI_FWD(c), KUMI_FWD(ts)..., KUMI_FWD(call_args)...);
+      return kumi::invoke(KUMI_FWD(c), KUMI_FWD(ts)..., KUMI_FWD(call_args)...);
     };
   }
 
@@ -52,7 +52,7 @@ namespace kumi
   requires(std::is_move_constructible_v<std::decay_t<C>> && (std::is_move_constructible_v<std::decay_t<Ts>> && ...))
   {
     return [&]<typename... Args>(Args&&... call_args) -> decltype(auto) {
-      return invoke(KUMI_FWD(c), KUMI_FWD(call_args)..., KUMI_FWD(ts)...);
+      return kumi::invoke(KUMI_FWD(c), KUMI_FWD(call_args)..., KUMI_FWD(ts)...);
     };
   }
 
@@ -62,6 +62,6 @@ namespace kumi
              (std::is_nothrow_move_constructible_v<std::decay_t<Ts>> && ...))
   requires(std::is_move_constructible_v<std::decay_t<C>> && (std::is_move_constructible_v<std::decay_t<Ts>> && ...))
   {
-    return [&]() -> decltype(auto) { return invoke(KUMI_FWD(c), KUMI_FWD(ts)...); };
+    return [&]() -> decltype(auto) { return kumi::invoke(KUMI_FWD(c), KUMI_FWD(ts)...); };
   }
 }

--- a/include/kumi/functional/indexable.hpp
+++ b/include/kumi/functional/indexable.hpp
@@ -23,11 +23,12 @@ namespace kumi::function
   struct cartesian_product_t
   {
     template<std::size_t H, std::size_t... S>
-    KUMI_ABI consteval auto operator()(index_t<H>, index_t<S>...) const noexcept
+    KUMI_ABI consteval auto operator()(kumi::index_t<H>, kumi::index_t<S>...) const noexcept
     {
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return projection_map{_::digits(_::unflatten_index, std::integral_constant<std::size_t, sizeof...(S)>{},
-                                        std::index_sequence<I, S...>{})...};
+        return kumi::projection_map{kumi::_::digits(kumi::_::unflatten_index,
+                                                    std::integral_constant<std::size_t, sizeof...(S)>{},
+                                                    std::index_sequence<I, S...>{})...};
       }(std::make_index_sequence<H>{});
     }
   };
@@ -50,7 +51,8 @@ namespace kumi::function
       constexpr auto N = std::integral_constant<std::size_t, (Sizes + ... + 0ULL)>{};
       constexpr auto Ids = std::index_sequence<Sizes...>{};
 
-      return projection_map{_::digits(_::container_of_index, N, Ids), _::digits(_::element_of_index, N, Ids)};
+      return kumi::projection_map{kumi::_::digits(kumi::_::container_of_index, N, Ids),
+                                  kumi::_::digits(kumi::_::element_of_index, N, Ids)};
     }
   };
 
@@ -67,7 +69,8 @@ namespace kumi::function
   //====================================================================================================================
   struct rotate_t
   {
-    template<std::size_t S, std::size_t R> KUMI_ABI consteval auto operator()(index_t<S>, index_t<R>) const noexcept
+    template<std::size_t S, std::size_t R>
+    KUMI_ABI consteval auto operator()(kumi::index_t<S>, kumi::index_t<R>) const noexcept
     {
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
         return std::index_sequence<(I + R) % S...>{};
@@ -88,14 +91,14 @@ namespace kumi::function
   //====================================================================================================================
   struct reduce_t
   {
-    template<std::size_t N> KUMI_ABI consteval auto operator()(index_t<N>) const noexcept
+    template<std::size_t N> KUMI_ABI consteval auto operator()(kumi::index_t<N>) const noexcept
     {
       constexpr std::size_t half = N / 2;
       constexpr std::size_t remainder = N % 2;
 
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return projection_map{std::index_sequence<(2 * I)...>{}, std::index_sequence<(2 * I + 1)...>{},
-                              index<remainder>};
+        return kumi::projection_map{std::index_sequence<(2 * I)...>{}, std::index_sequence<(2 * I + 1)...>{},
+                                    kumi::index<remainder>};
       }(std::make_index_sequence<half>{});
     }
   };
@@ -113,10 +116,11 @@ namespace kumi::function
   //====================================================================================================================
   struct split_t
   {
-    template<std::size_t N, std::size_t Sz> KUMI_ABI consteval auto operator()(index_t<N>, index_t<Sz>) const noexcept
+    template<std::size_t N, std::size_t Sz>
+    KUMI_ABI consteval auto operator()(kumi::index_t<N>, kumi::index_t<Sz>) const noexcept
     {
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return projection_map{std::make_index_sequence<N>{}, std::index_sequence<(I + N)...>{}};
+        return kumi::projection_map{std::make_index_sequence<N>{}, std::index_sequence<(I + N)...>{}};
       }(std::make_index_sequence<Sz - N>{});
     }
   };
@@ -135,14 +139,14 @@ namespace kumi::function
   struct tile_t
   {
     template<std::size_t Sz, std::size_t Extent, std::size_t Stride>
-    KUMI_ABI consteval auto operator()(index_t<Sz>, index_t<Extent>, index_t<Stride>) const noexcept
+    KUMI_ABI consteval auto operator()(kumi::index_t<Sz>, kumi::index_t<Extent>, kumi::index_t<Stride>) const noexcept
     {
       constexpr std::size_t nb_blocks = (Sz <= Extent) ? 1 : (Sz - Extent + Stride - 1) / Stride + 1;
 
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        using blocks = std::index_sequence<_::block_size(I, Stride, Extent, Sz)...>;
+        using blocks = std::index_sequence<kumi::_::block_size(I, Stride, Extent, Sz)...>;
         using offsets = std::index_sequence<(I * Stride)...>;
-        return projection_map{blocks{}, offsets{}};
+        return kumi::projection_map{blocks{}, offsets{}};
       }(std::make_index_sequence<nb_blocks>{});
     }
   };
@@ -161,11 +165,11 @@ namespace kumi::function
   struct zip_t
   {
     template<std::size_t Count, std::size_t Size>
-    KUMI_ABI consteval auto operator()(index_t<Count>, index_t<Size>) const noexcept
+    KUMI_ABI consteval auto operator()(kumi::index_t<Count>, kumi::index_t<Size>) const noexcept
     {
       using tuples = std::make_index_sequence<Count>;
       using elements = std::make_index_sequence<Size>;
-      return projection_map{tuples{}, elements{}};
+      return kumi::projection_map{tuples{}, elements{}};
     }
   };
 
@@ -175,7 +179,7 @@ namespace kumi::function
     @brief  Callable object computing the index map associated to the cartesian product operation.
   **/
   //====================================================================================================================
-  inline constexpr cartesian_product_t cartesian_producer{};
+  inline constexpr kumi::function::cartesian_product_t cartesian_producer{};
 
   //====================================================================================================================
   /**
@@ -183,7 +187,7 @@ namespace kumi::function
     @brief  Callable object computing the index map associated to the concatenation operation.
   **/
   //====================================================================================================================
-  inline constexpr cat_t concatenater{};
+  inline constexpr kumi::function::cat_t concatenater{};
 
   //====================================================================================================================
   /**
@@ -191,7 +195,7 @@ namespace kumi::function
     @brief  Callable object computing the index map associated to the rotation operation.
   **/
   //====================================================================================================================
-  inline constexpr rotate_t rotater{};
+  inline constexpr kumi::function::rotate_t rotater{};
 
   //====================================================================================================================
   /**
@@ -199,7 +203,7 @@ namespace kumi::function
     @brief  Callable object computing the index map associated to the reduction operation.
   **/
   //====================================================================================================================
-  inline constexpr reduce_t reducer{};
+  inline constexpr kumi::function::reduce_t reducer{};
 
   //====================================================================================================================
   /**
@@ -207,7 +211,7 @@ namespace kumi::function
     @brief  Callable object computing the index map associated to the split operation.
   **/
   //====================================================================================================================
-  inline constexpr split_t splitter{};
+  inline constexpr kumi::function::split_t splitter{};
 
   //====================================================================================================================
   /**
@@ -215,7 +219,7 @@ namespace kumi::function
     @brief  Callable object computing the index map associated to the tiling operation.
   **/
   //====================================================================================================================
-  inline constexpr tile_t tiler{};
+  inline constexpr kumi::function::tile_t tiler{};
 
   //====================================================================================================================
   /**
@@ -223,5 +227,5 @@ namespace kumi::function
     @brief  Callable object computing the index map associated to the zip operation.
   **/
   //====================================================================================================================
-  inline constexpr zip_t zipper{};
+  inline constexpr kumi::function::zip_t zipper{};
 }

--- a/include/kumi/functional/invoke.hpp
+++ b/include/kumi/functional/invoke.hpp
@@ -21,7 +21,7 @@ namespace kumi
     {
       using callable_t = P C::*;
       auto&& ptr = []<typename T>(T&& obj) -> decltype(auto) {
-        if constexpr (_::is_reference_wrapper_v<std::remove_cvref_t<T>>) return obj.get();
+        if constexpr (kumi::_::is_reference_wrapper_v<std::remove_cvref_t<T>>) return obj.get();
         else if constexpr (std::is_pointer_v<std::remove_cvref_t<T>>) return *KUMI_FWD(obj);
         else return KUMI_FWD(obj);
       }(KUMI_FWD(o));
@@ -47,7 +47,7 @@ namespace kumi
   KUMI_ABI constexpr decltype(auto) invoke(C&& c, Ts&&... ts) noexcept(std::is_nothrow_invocable_v<C, Ts...>)
   requires(std::is_invocable_v<C, Ts...>)
   {
-    if constexpr (std::is_member_pointer_v<std::decay_t<C>>) return _::invoke_memptr(c, KUMI_FWD(ts)...);
+    if constexpr (std::is_member_pointer_v<std::decay_t<C>>) return kumi::_::invoke_memptr(c, KUMI_FWD(ts)...);
     else return KUMI_FWD(c)(KUMI_FWD(ts)...);
   }
 
@@ -68,7 +68,7 @@ namespace kumi
   KUMI_ABI constexpr R invoke_r(C&& c, Ts&&... ts) noexcept(std::is_nothrow_invocable_r_v<R, C, Ts...>)
   requires(std::is_invocable_r_v<R, C, Ts...>)
   {
-    if constexpr (std::is_void_v<R>) invoke(KUMI_FWD(c), KUMI_FWD(ts)...);
-    else return invoke(KUMI_FWD(c), KUMI_FWD(ts)...);
+    if constexpr (std::is_void_v<R>) kumi::invoke(KUMI_FWD(c), KUMI_FWD(ts)...);
+    else return kumi::invoke(KUMI_FWD(c), KUMI_FWD(ts)...);
   }
 }

--- a/include/kumi/functional/monadic.hpp
+++ b/include/kumi/functional/monadic.hpp
@@ -26,12 +26,12 @@ namespace kumi::function
   template<typename T, auto V> struct size_or
   {
     static constexpr auto value = [] {
-      if constexpr (concepts::product_type<T>) return size_v<T>;
+      if constexpr (kumi::concepts::product_type<T>) return kumi::size_v<T>;
       else return V;
     }();
   };
 
-  template<typename T, auto V> inline constexpr auto size_or_v = size_or<T, V>::value;
+  template<typename T, auto V> inline constexpr auto size_or_v = kumi::function::size_or<T, V>::value;
 
   //====================================================================================================================
   /**
@@ -54,12 +54,13 @@ namespace kumi::function
   template<std::size_t I, typename T, typename U> struct element_or
   {
     using type = typename decltype([] {
-      if constexpr (concepts::product_type<T> && I < size_v<T>) return element<I, T>{};
+      if constexpr (kumi::concepts::product_type<T> && I < kumi::size_v<T>) return kumi::element<I, T>{};
       else return std::type_identity<U>{};
     }())::type;
   };
 
-  template<std::size_t I, typename T, typename U> using element_or_t = typename element_or<I, T, U>::type;
+  template<std::size_t I, typename T, typename U>
+  using element_or_t = typename kumi::function::element_or<I, T, U>::type;
 
   //====================================================================================================================
   /**
@@ -75,7 +76,7 @@ namespace kumi::function
   //====================================================================================================================
   template<std::size_t I, typename T, typename V> [[nodiscard]] KUMI_ABI constexpr decltype(auto) get_or(T&& t, V&& v)
   {
-    if constexpr (concepts::product_type<T> && I < size_v<T>) return get<I>(KUMI_FWD(t));
+    if constexpr (kumi::concepts::product_type<T> && I < kumi::size_v<T>) return get<I>(KUMI_FWD(t));
     else return KUMI_FWD(v);
   }
 
@@ -108,7 +109,7 @@ namespace kumi::function
     //==================================================================================================================
     template<typename C> KUMI_ABI friend constexpr decltype(auto) operator>>(foldable&& f, C&& c)
     {
-      return function::foldable{invoke(c, f.value)};
+      return kumi::function::foldable{kumi::invoke(c, f.value)};
     }
 
     //==================================================================================================================
@@ -123,7 +124,7 @@ namespace kumi::function
     //==================================================================================================================
     template<typename C> KUMI_ABI friend constexpr decltype(auto) operator<<(C&& c, foldable&& f)
     {
-      return function::foldable{invoke(c, f.value)};
+      return kumi::function::foldable{kumi::invoke(c, f.value)};
     }
 
     //==================================================================================================================
@@ -166,8 +167,8 @@ namespace kumi::function
     //==================================================================================================================
     template<typename C> KUMI_ABI friend constexpr decltype(auto) operator>>(scannable&& s, C&& c)
     {
-      auto res = invoke(c, s.value);
-      return function::scannable{bind_front(std::move(s.func), std::move(s.value)), res};
+      auto res = kumi::invoke(c, s.value);
+      return kumi::function::scannable{kumi::bind_front(std::move(s.func), std::move(s.value)), res};
     }
 
     //==================================================================================================================
@@ -182,8 +183,8 @@ namespace kumi::function
     //==================================================================================================================
     template<typename C> KUMI_ABI friend constexpr decltype(auto) operator<<(C&& c, scannable&& s)
     {
-      auto res = invoke(c, s.value);
-      return function::scannable{bind_back(std::move(s.func), std::move(s.value)), res};
+      auto res = kumi::invoke(c, s.value);
+      return kumi::function::scannable{kumi::bind_back(std::move(s.func), std::move(s.value)), res};
     }
 
     //==================================================================================================================
@@ -193,7 +194,7 @@ namespace kumi::function
               Essentially marking the end of a computation.
     **/
     //==================================================================================================================
-    KUMI_ABI constexpr decltype(auto) operator()() const noexcept { return invoke(func, value); }
+    KUMI_ABI constexpr decltype(auto) operator()() const noexcept { return kumi::invoke(func, value); }
   };
 
   //====================================================================================================================

--- a/include/kumi/functional/monoid.hpp
+++ b/include/kumi/functional/monoid.hpp
@@ -131,7 +131,7 @@ namespace kumi::function
            addition.
   **/
   //==================================================================================================================
-  inline constexpr numeric_add plus{};
+  inline constexpr kumi::function::numeric_add plus{};
 
   //==================================================================================================================
   /**
@@ -140,7 +140,7 @@ namespace kumi::function
            multiplication.
   **/
   //==================================================================================================================
-  inline constexpr numeric_prod multiplies{};
+  inline constexpr kumi::function::numeric_prod multiplies{};
 
   //==================================================================================================================
   /**
@@ -149,7 +149,7 @@ namespace kumi::function
            logical and operation.
   **/
   //==================================================================================================================
-  inline constexpr boolean_and bit_and{};
+  inline constexpr kumi::function::boolean_and bit_and{};
 
   //==================================================================================================================
   /**
@@ -158,7 +158,7 @@ namespace kumi::function
            logical or operation.
   **/
   //==================================================================================================================
-  inline constexpr boolean_or bit_or{};
+  inline constexpr kumi::function::boolean_or bit_or{};
 
   //==================================================================================================================
   /**
@@ -167,5 +167,5 @@ namespace kumi::function
            logical xor operation.
   **/
   //==================================================================================================================
-  inline constexpr boolean_xor bit_xor{};
+  inline constexpr kumi::function::boolean_xor bit_xor{};
 }

--- a/include/kumi/functional/set.hpp
+++ b/include/kumi/functional/set.hpp
@@ -121,7 +121,7 @@ namespace kumi
       {
         struct
         {
-          std::size_t count{1}, t[size_v<T>];
+          std::size_t count{1}, t[kumi::size_v<T>];
         } that{};
 
         that.t[0] = 0;
@@ -131,7 +131,7 @@ namespace kumi
                     ? I
                     : (that.t[that.count++] = I + 1)),
            ...);
-        }(std::make_index_sequence<size_v<T> - 1>{});
+        }(std::make_index_sequence<kumi::size_v<T> - 1>{});
 
         return that;
       }

--- a/include/kumi/functional/set.hpp
+++ b/include/kumi/functional/set.hpp
@@ -23,22 +23,22 @@ namespace kumi
     };
 
     template<std::size_t I, std::size_t... Is, typename T, typename... Ts>
-    struct multiset<std::index_sequence<I, Is...>, T, Ts...> : multiset<std::index_sequence<Is...>, Ts...>
+    struct multiset<std::index_sequence<I, Is...>, T, Ts...> : kumi::_::multiset<std::index_sequence<Is...>, Ts...>
     {
       consteval auto operator()(std::type_identity<T>) const noexcept
       {
         return std::integral_constant<std::size_t, I>{};
       }
 
-      using multiset<std::index_sequence<Is...>, Ts...>::operator();
+      using kumi::_::multiset<std::index_sequence<Is...>, Ts...>::operator();
     };
 
     template<typename... Ts> struct make_multiset
     {
-      using type = multiset<Ts...>;
+      using type = kumi::_::multiset<Ts...>;
     };
 
-    template<typename... Ts> using make_multiset_t = typename make_multiset<Ts...>::type;
+    template<typename... Ts> using make_multiset_t = typename kumi::_::make_multiset<Ts...>::type;
   }
 
   namespace function
@@ -58,7 +58,7 @@ namespace kumi
     {
       template<typename... Ts> KUMI_ABI consteval auto operator()(std::type_identity<Ts>...) const noexcept
       {
-        using type = _::make_multiset_t<std::make_index_sequence<sizeof...(Ts)>, Ts...>;
+        using type = kumi::_::make_multiset_t<std::make_index_sequence<sizeof...(Ts)>, Ts...>;
         constexpr type impl{};
 
         struct
@@ -117,7 +117,7 @@ namespace kumi
     //==================================================================================================================
     struct adjacent_unicity_t
     {
-      template<concepts::product_type T> KUMI_ABI consteval auto operator()(as<T>) const noexcept
+      template<kumi::concepts::product_type T> KUMI_ABI consteval auto operator()(kumi::as<T>) const noexcept
       {
         struct
         {
@@ -127,7 +127,7 @@ namespace kumi
         that.t[0] = 0;
 
         [&]<std::size_t... I>(std::index_sequence<I...>) {
-          ((void)((std::is_same_v<stored_element_t<I, T>, stored_element_t<I + 1, T>>)
+          ((void)((std::is_same_v<kumi::stored_element_t<I, T>, kumi::stored_element_t<I + 1, T>>)
                     ? I
                     : (that.t[that.count++] = I + 1)),
            ...);
@@ -143,7 +143,7 @@ namespace kumi
       @brief    Callable object computing the index map associated to the adjactent unicity operation.
     **/
     //==================================================================================================================
-    inline constexpr adjacent_unicity_t uniqued{};
+    inline constexpr kumi::function::adjacent_unicity_t uniqued{};
 
     //==================================================================================================================
     /**
@@ -151,7 +151,7 @@ namespace kumi
       @brief    Callable object computing the index map associated to the deduplication operation.
     **/
     //==================================================================================================================
-    inline constexpr unique_t uniquer{};
+    inline constexpr kumi::function::unique_t uniquer{};
 
     //==================================================================================================================
     /**
@@ -159,6 +159,6 @@ namespace kumi
       @brief    Callable object computing the index map associated to the selection operation.
     **/
     //==================================================================================================================
-    inline constexpr select_t selector{};
+    inline constexpr kumi::function::select_t selector{};
   }
 }

--- a/include/kumi/product_types/record.hpp
+++ b/include/kumi/product_types/record.hpp
@@ -35,7 +35,7 @@ namespace kumi
   template<typename... Ts> struct record
   {
     using is_record_type = void;
-    using set_t = _::make_set_t<Ts...>;
+    using set_t = kumi::_::make_set_t<Ts...>;
 
     static constexpr bool is_homogeneous = false;
 
@@ -61,37 +61,37 @@ namespace kumi
     **/
     //==================================================================================================================
     template<std::size_t I>
-    KUMI_ABI constexpr decltype(auto) operator[]([[maybe_unused]] index_t<I> i) & noexcept
+    KUMI_ABI constexpr decltype(auto) operator[]([[maybe_unused]] kumi::index_t<I> i) & noexcept
     requires(I < sizeof...(Ts))
     {
-      using T = element_t<I, tuple<Ts...>>;
+      using T = kumi::element_t<I, tuple<Ts...>>;
       return static_cast<T&>(impl);
     }
 
     /// @overload
     template<std::size_t I>
-    KUMI_ABI constexpr decltype(auto) operator[](index_t<I>) && noexcept
+    KUMI_ABI constexpr decltype(auto) operator[](kumi::index_t<I>) && noexcept
     requires(I < sizeof...(Ts))
     {
-      using T = element_t<I, tuple<Ts...>>;
+      using T = kumi::element_t<I, tuple<Ts...>>;
       return static_cast<T&&>(static_cast<decltype(impl)&&>(impl));
     }
 
     /// @overload
     template<std::size_t I>
-    KUMI_ABI constexpr decltype(auto) operator[](index_t<I>) const&& noexcept
+    KUMI_ABI constexpr decltype(auto) operator[](kumi::index_t<I>) const&& noexcept
     requires(I < sizeof...(Ts))
     {
-      using T = element_t<I, tuple<Ts...>>;
+      using T = kumi::element_t<I, tuple<Ts...>>;
       return static_cast<T const&&>(static_cast<decltype(impl) const&&>(impl));
     }
 
     /// @overload
     template<std::size_t I>
-    KUMI_ABI constexpr decltype(auto) operator[](index_t<I>) const& noexcept
+    KUMI_ABI constexpr decltype(auto) operator[](kumi::index_t<I>) const& noexcept
     requires(I < sizeof...(Ts))
     {
-      using T = element_t<I, tuple<Ts...>>;
+      using T = kumi::element_t<I, tuple<Ts...>>;
       return static_cast<T const&>(impl);
     }
 
@@ -110,32 +110,36 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename T>
-    KUMI_ABI constexpr decltype(auto) operator[]([[maybe_unused]] as<T> type) & noexcept
-    requires(concepts::uniquely_typed<_::type_of_t<Ts>...> && concepts::contains_type<T, _::type_of_t<Ts>...>)
+    KUMI_ABI constexpr decltype(auto) operator[]([[maybe_unused]] kumi::as<T> type) & noexcept
+    requires(kumi::concepts::uniquely_typed<kumi::_::type_of_t<Ts>...> &&
+             kumi::concepts::contains_type<T, kumi::_::type_of_t<Ts>...>)
     {
       return impl(std::type_identity<T>{});
     }
 
     /// @overload
     template<typename T>
-    KUMI_ABI constexpr decltype(auto) operator[](as<T>) && noexcept
-    requires(concepts::uniquely_typed<_::type_of_t<Ts>...> && concepts::contains_type<T, _::type_of_t<Ts>...>)
+    KUMI_ABI constexpr decltype(auto) operator[](kumi::as<T>) && noexcept
+    requires(kumi::concepts::uniquely_typed<kumi::_::type_of_t<Ts>...> &&
+             kumi::concepts::contains_type<T, kumi::_::type_of_t<Ts>...>)
     {
       return static_cast<decltype(impl)&&>(impl)(std::type_identity<T>{});
     }
 
     /// @overload
     template<typename T>
-    KUMI_ABI constexpr decltype(auto) operator[](as<T>) const&& noexcept
-    requires(concepts::uniquely_typed<_::type_of_t<Ts>...> && concepts::contains_type<T, _::type_of_t<Ts>...>)
+    KUMI_ABI constexpr decltype(auto) operator[](kumi::as<T>) const&& noexcept
+    requires(kumi::concepts::uniquely_typed<kumi::_::type_of_t<Ts>...> &&
+             kumi::concepts::contains_type<T, kumi::_::type_of_t<Ts>...>)
     {
       return static_cast<decltype(impl) const&&>(impl)(std::type_identity<T>{});
     }
 
     /// @overload
     template<typename T>
-    KUMI_ABI constexpr decltype(auto) operator[](as<T>) const& noexcept
-    requires(concepts::uniquely_typed<_::type_of_t<Ts>...> && concepts::contains_type<T, _::type_of_t<Ts>...>)
+    KUMI_ABI constexpr decltype(auto) operator[](kumi::as<T>) const& noexcept
+    requires(kumi::concepts::uniquely_typed<kumi::_::type_of_t<Ts>...> &&
+             kumi::concepts::contains_type<T, kumi::_::type_of_t<Ts>...>)
     {
       return impl(std::type_identity<T>{});
     }
@@ -154,35 +158,35 @@ namespace kumi
     **/
     //==================================================================================================================
 
-    template<str Name>
-    KUMI_ABI constexpr decltype(auto) operator[]([[maybe_unused]] label_t<Name> l) & noexcept
-    requires(concepts::contains_label<label_t<Name>, Ts...>)
+    template<kumi::str Name>
+    KUMI_ABI constexpr decltype(auto) operator[]([[maybe_unused]] kumi::label_t<Name> l) & noexcept
+    requires(kumi::concepts::contains_label<kumi::label_t<Name>, Ts...>)
     {
-      return impl(std::integral_constant<str, Name>{});
+      return impl(std::integral_constant<kumi::str, Name>{});
     }
 
     /// @overload
-    template<str Name>
-    KUMI_ABI constexpr decltype(auto) operator[](label_t<Name>) && noexcept
-    requires(concepts::contains_label<label_t<Name>, Ts...>)
+    template<kumi::str Name>
+    KUMI_ABI constexpr decltype(auto) operator[](kumi::label_t<Name>) && noexcept
+    requires(kumi::concepts::contains_label<kumi::label_t<Name>, Ts...>)
     {
-      return static_cast<decltype(impl)&&>(impl)(std::integral_constant<str, Name>{});
+      return static_cast<decltype(impl)&&>(impl)(std::integral_constant<kumi::str, Name>{});
     }
 
     /// @overload
-    template<str Name>
-    KUMI_ABI constexpr decltype(auto) operator[](label_t<Name>) const&& noexcept
-    requires(concepts::contains_label<label_t<Name>, Ts...>)
+    template<kumi::str Name>
+    KUMI_ABI constexpr decltype(auto) operator[](kumi::label_t<Name>) const&& noexcept
+    requires(kumi::concepts::contains_label<kumi::label_t<Name>, Ts...>)
     {
-      return static_cast<decltype(impl) const&&>(impl)(std::integral_constant<str, Name>{});
+      return static_cast<decltype(impl) const&&>(impl)(std::integral_constant<kumi::str, Name>{});
     }
 
     /// @overload
-    template<str Name>
-    KUMI_ABI constexpr decltype(auto) operator[](label_t<Name>) const& noexcept
-    requires(concepts::contains_label<label_t<Name>, Ts...>)
+    template<kumi::str Name>
+    KUMI_ABI constexpr decltype(auto) operator[](kumi::label_t<Name>) const& noexcept
+    requires(kumi::concepts::contains_label<kumi::label_t<Name>, Ts...>)
     {
-      return impl(std::integral_constant<str, Name>{});
+      return impl(std::integral_constant<kumi::str, Name>{});
     }
 
     //==================================================================================================================
@@ -198,35 +202,35 @@ namespace kumi
       @include doc/record/api/named_subscript.cpp
     **/
     //==================================================================================================================
-    template<concepts::identifier Id>
+    template<kumi::concepts::identifier Id>
     KUMI_ABI constexpr decltype(auto) operator[](Id const&) & noexcept
-    requires(concepts::contains_identifier<Id, Ts...>)
+    requires(kumi::concepts::contains_identifier<Id, Ts...>)
     {
-      return impl(_::tag_of_t<Id>{});
+      return impl(kumi::_::tag_of_t<Id>{});
     }
 
     /// @overload
-    template<concepts::identifier Id>
+    template<kumi::concepts::identifier Id>
     KUMI_ABI constexpr decltype(auto) operator[](Id const&) && noexcept
-    requires(concepts::contains_identifier<Id, Ts...>)
+    requires(kumi::concepts::contains_identifier<Id, Ts...>)
     {
-      return static_cast<decltype(impl)&&>(impl)(_::tag_of_t<Id>{});
+      return static_cast<decltype(impl)&&>(impl)(kumi::_::tag_of_t<Id>{});
     }
 
     /// @overload
-    template<concepts::identifier Id>
+    template<kumi::concepts::identifier Id>
     KUMI_ABI constexpr decltype(auto) operator[](Id const&) const&& noexcept
-    requires(concepts::contains_identifier<Id, Ts...>)
+    requires(kumi::concepts::contains_identifier<Id, Ts...>)
     {
-      return static_cast<decltype(impl) const&&>(impl)(_::tag_of_t<Id>{});
+      return static_cast<decltype(impl) const&&>(impl)(kumi::_::tag_of_t<Id>{});
     }
 
     /// @overload
-    template<concepts::identifier Id>
+    template<kumi::concepts::identifier Id>
     KUMI_ABI constexpr decltype(auto) operator[](Id const&) const& noexcept
-    requires(concepts::contains_identifier<Id, Ts...>)
+    requires(kumi::concepts::contains_identifier<Id, Ts...>)
     {
-      return impl(_::tag_of_t<Id>{});
+      return impl(kumi::_::tag_of_t<Id>{});
     }
 
     //==================================================================================================================
@@ -247,16 +251,16 @@ namespace kumi
     [[nodiscard]] KUMI_ABI static constexpr bool empty() noexcept { return sizeof...(Ts) == 0; }
 
     /// Returns the identifiers associated to the elements of a kumi::record
-    [[nodiscard]] KUMI_ABI static constexpr auto identifiers() noexcept { return tuple{identifier_of<Ts>()...}; }
+    [[nodiscard]] KUMI_ABI static constexpr auto identifiers() noexcept { return tuple{kumi::identifier_of<Ts>()...}; }
 
     /// Returns the labels associated to the elements of a kumi::record
-    [[nodiscard]] KUMI_ABI static constexpr auto labels() noexcept { return tuple{label_of<Ts>()...}; }
+    [[nodiscard]] KUMI_ABI static constexpr auto labels() noexcept { return tuple{kumi::label_of<Ts>()...}; }
 
     /// Returns references to the values of the element in a kumi::record
     [[nodiscard]] KUMI_ABI constexpr auto values() noexcept
     {
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return tuple<stored_member_t<I, decltype(*this)>...>{field_value_of(get<I>(*this))...};
+        return tuple<stored_member_t<I, decltype(*this)>...>{kumi::field_value_of(get<I>(*this))...};
       }(std::make_index_sequence<sizeof...(Ts)>{});
     }
 
@@ -264,7 +268,7 @@ namespace kumi
     [[nodiscard]] KUMI_ABI constexpr auto values() const noexcept
     {
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return tuple<stored_member_t<I, decltype(*this)>...>{field_value_of(get<I>(*this))...};
+        return tuple<stored_member_t<I, decltype(*this)>...>{kumi::field_value_of(get<I>(*this))...};
       }(std::make_index_sequence<sizeof...(Ts)>{});
     }
 
@@ -284,24 +288,24 @@ namespace kumi
     //==================================================================================================================
     template<typename... Us>
     KUMI_ABI constexpr record& operator=(record<Us...> const& other)
-    requires(concepts::equivalent<record, record<Us...>>)
+    requires(kumi::concepts::equivalent<record, record<Us...>>)
 #ifndef KUMI_DOXYGEN_INVOKED
-            && (_::fieldwise_convertible<record, record<Us...>>)
+            && (kumi::_::fieldwise_convertible<record, record<Us...>>)
 #endif
     {
-      ((get<identifier_of<Ts>()>(*this) = get<identifier_of<Ts>()>(KUMI_FWD(other))), ...);
+      ((get<kumi::identifier_of<Ts>()>(*this) = get<kumi::identifier_of<Ts>()>(KUMI_FWD(other))), ...);
       return *this;
     }
 
     /// @overload
     template<typename... Us>
     KUMI_ABI constexpr record& operator=(record<Us...>&& other)
-    requires(concepts::equivalent<record, record<Us...>>)
+    requires(kumi::concepts::equivalent<record, record<Us...>>)
 #ifndef KUMI_DOXYGEN_INVOKED
-            && (_::fieldwise_convertible<record, record<Us...>>)
+            && (kumi::_::fieldwise_convertible<record, record<Us...>>)
 #endif
     {
-      ((get<identifier_of<Ts>()>(*this) = get<identifier_of<Ts>()>(KUMI_FWD(other))), ...);
+      ((get<kumi::identifier_of<Ts>()>(*this) = get<kumi::identifier_of<Ts>()>(KUMI_FWD(other))), ...);
       return *this;
     }
 
@@ -316,17 +320,17 @@ namespace kumi
     template<typename... Us>
     KUMI_ABI friend constexpr auto operator==(record const& self, record<Us...> const& other) noexcept
 #ifndef KUMI_DOXYGEN_INVOKED
-    requires(_::fieldwise_comparable<record, record<Us...>>)
+    requires(kumi::_::fieldwise_comparable<record, record<Us...>>)
 #endif
     {
-      return ((get<identifier_of<Ts>()>(self) == get<identifier_of<Ts>()>(other)) && ...);
+      return ((get<kumi::identifier_of<Ts>()>(self) == get<kumi::identifier_of<Ts>()>(other)) && ...);
     }
 
     /// @brief Compares a record with an other for inequality
     template<typename... Us>
     KUMI_ABI friend constexpr auto operator!=(record const& self, record<Us...> const& other) noexcept
 #ifndef KUMI_DOXYGEN_INVOKED
-    requires(_::fieldwise_comparable<record, record<Us...>>)
+    requires(kumi::_::fieldwise_comparable<record, record<Us...>>)
 #endif
     {
       return !(self == other);
@@ -349,8 +353,8 @@ namespace kumi
       os << "{ ";
       [&]<std::size_t... I>(std::index_sequence<I...>) {
         ((os << t[index<I>] << ", "), ...);
-      }(std::make_index_sequence<size_v<record> - 1>{});
-      os << t[index<size_v<record> - 1>] << " }";
+      }(std::make_index_sequence<kumi::size_v<record> - 1>{});
+      os << t[kumi::index<kumi::size_v<record> - 1>] << " }";
 
       return os;
     }
@@ -365,22 +369,22 @@ namespace kumi
 
     [[nodiscard]] KUMI_ABI static constexpr auto empty() noexcept { return true; }
 
-    [[nodiscard]] KUMI_ABI static constexpr auto names() noexcept { return tuple{}; }
+    [[nodiscard]] KUMI_ABI static constexpr auto names() noexcept { return kumi::tuple{}; }
 
-    [[nodiscard]] KUMI_ABI static constexpr auto values() noexcept { return tuple{}; }
+    [[nodiscard]] KUMI_ABI static constexpr auto values() noexcept { return kumi::tuple{}; }
 
     KUMI_ABI friend constexpr auto operator<=>(record<>, record<>) noexcept = default;
 
     template<typename T>
     [[nodiscard]] KUMI_ABI constexpr operator T() const noexcept
-    requires(concepts::unit_type<T>)
+    requires(kumi::concepts::unit_type<T>)
     {
       return {};
     }
 
     template<typename T>
     [[nodiscard]] KUMI_ABI constexpr operator T() noexcept
-    requires(concepts::unit_type<T>)
+    requires(kumi::concepts::unit_type<T>)
     {
       return {};
     }
@@ -396,12 +400,13 @@ namespace kumi
   // Specialisation to clearly signal errors due to duplicate fields
   //====================================================================================================================
   template<typename... Ts>
-  requires(!concepts::uniquely_named<Ts...> || !concepts::fully_named<Ts...> || !concepts::uniquely_labeled<Ts...>)
+  requires(!kumi::concepts::uniquely_named<Ts...> || !kumi::concepts::fully_named<Ts...> ||
+           !kumi::concepts::uniquely_labeled<Ts...>)
   struct record<Ts...>
   {
-    static_assert(concepts::uniquely_named<Ts...>, "Duplicate fields in record definition");
-    static_assert(concepts::uniquely_labeled<Ts...>, "Duplicate identifier representation in record definition");
-    static_assert(concepts::fully_named<Ts...>, "Anonymous field usage in record definition");
+    static_assert(kumi::concepts::uniquely_named<Ts...>, "Duplicate fields in record definition");
+    static_assert(kumi::concepts::uniquely_labeled<Ts...>, "Duplicate identifier representation in record definition");
+    static_assert(kumi::concepts::fully_named<Ts...>, "Anonymous field usage in record definition");
     record(Ts&&...) = delete;
   };
 
@@ -444,8 +449,8 @@ namespace kumi
     @include doc/record/api/tie.cpp
   **/
   //====================================================================================================================
-  template<concepts::identifier auto... Fields, typename... Ts>
-  [[nodiscard]] KUMI_ABI constexpr auto tie(Ts&... ts) -> record<field<decltype(Fields), Ts&>...>
+  template<kumi::concepts::identifier auto... Fields, typename... Ts>
+  [[nodiscard]] KUMI_ABI constexpr auto tie(Ts&... ts) -> kumi::record<kumi::field<decltype(Fields), Ts&>...>
   requires(sizeof...(Fields) == sizeof...(Ts))
   {
     return {ts...};
@@ -470,8 +475,9 @@ namespace kumi
     @include doc/record/api/forward_as_record.cpp
   **/
   //====================================================================================================================
-  template<concepts::identifier auto... Fields, typename... Ts>
-  [[nodiscard]] KUMI_ABI constexpr auto forward_as_record(Ts&&... ts) -> record<field<decltype(Fields), Ts&&>...>
+  template<kumi::concepts::identifier auto... Fields, typename... Ts>
+  [[nodiscard]] KUMI_ABI constexpr auto forward_as_record(Ts&&... ts)
+    -> kumi::record<kumi::field<decltype(Fields), Ts&&>...>
   requires(sizeof...(Fields) == sizeof...(Ts))
   {
     return {KUMI_FWD(ts)...};
@@ -490,8 +496,8 @@ namespace kumi
   **/
   //====================================================================================================================
   template<typename... Ts>
-  [[nodiscard]] KUMI_ABI constexpr auto make_record(Ts&&... ts) -> record<std::unwrap_ref_decay_t<Ts>...>
-  requires(concepts::uniquely_named<Ts...> && concepts::fully_named<Ts...>)
+  [[nodiscard]] KUMI_ABI constexpr auto make_record(Ts&&... ts) -> kumi::record<std::unwrap_ref_decay_t<Ts>...>
+  requires(kumi::concepts::uniquely_named<Ts...> && kumi::concepts::fully_named<Ts...>)
   {
     return {KUMI_FWD(ts)...};
   }
@@ -509,11 +515,12 @@ namespace kumi
     @include doc/record/api/to_ref.cpp
   **/
   //====================================================================================================================
-  template<concepts::record_type R> [[nodiscard]] KUMI_ABI constexpr auto to_ref(R&& r)
+  template<kumi::concepts::record_type R> [[nodiscard]] KUMI_ABI constexpr auto to_ref(R&& r)
   {
     return [&]<std::size_t... I>(std::index_sequence<I...>) {
-      return kumi::forward_as_record<identifier_of<element_t<I, R>>()...>(field_value_of(get<I>(KUMI_FWD(r)))...);
-    }(std::make_index_sequence<size_v<R>>{});
+      return kumi::forward_as_record<kumi::identifier_of<kumi::element_t<I, R>>()...>(
+        kumi::field_value_of(get<I>(KUMI_FWD(r)))...);
+    }(std::make_index_sequence<kumi::size_v<R>>{});
   }
 
   //====================================================================================================================
@@ -542,13 +549,15 @@ namespace kumi
     @include doc/record/api/from_record.cpp
   **/
   //====================================================================================================================
-  template<concepts::record_type Type, typename... Ts>
+  template<kumi::concepts::record_type Type, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr auto from_record(record<Ts...> const& r)
-  requires(concepts::equivalent<typename _::as_tuple<Type, std::make_index_sequence<size_v<Type>>>::type, tuple<Ts...>>)
+  requires(
+    kumi::concepts::equivalent<typename kumi::_::as_tuple<Type, std::make_index_sequence<kumi::size_v<Type>>>::type,
+                               kumi::tuple<Ts...>>)
   {
     return [&]<std::size_t... I>(std::index_sequence<I...>) {
-      return Type{get<identifier_of<element_t<I, Type>>()>(r)...};
-    }(std::make_index_sequence<size_v<Type>>());
+      return Type{get<kumi::identifier_of<kumi::element_t<I, Type>>()>(r)...};
+    }(std::make_index_sequence<kumi::size_v<Type>>());
   }
 
   //====================================================================================================================
@@ -565,14 +574,14 @@ namespace kumi
     @include doc/record/api/to_record.cpp
   **/
   //====================================================================================================================
-  template<concepts::record_type Type> [[nodiscard]] KUMI_ABI constexpr auto to_record(Type&& r)
+  template<kumi::concepts::record_type Type> [[nodiscard]] KUMI_ABI constexpr auto to_record(Type&& r)
   {
-    if constexpr (concepts::empty_product_type<Type>) return kumi::record{};
+    if constexpr (kumi::concepts::empty_product_type<Type>) return kumi::record{};
     else
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return record{
-          capture_field<identifier_of<element_t<I, Type>>()>(get<identifier_of<element_t<I, Type>>()>(KUMI_FWD(r)))...};
-      }(std::make_index_sequence<size_v<Type>>{});
+        return kumi::record{kumi::capture_field<kumi::identifier_of<kumi::element_t<I, Type>>()>(
+          get<kumi::identifier_of<kumi::element_t<I, Type>>()>(KUMI_FWD(r)))...};
+      }(std::make_index_sequence<kumi::size_v<Type>>{});
   }
 
   //====================================================================================================================
@@ -609,7 +618,7 @@ namespace kumi
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(record<Ts...>& r) noexcept
   requires(I < sizeof...(Ts))
   {
-    return r[index<I>];
+    return r[kumi::index<I>];
   }
 
   /// @related record
@@ -618,7 +627,7 @@ namespace kumi
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(record<Ts...>&& r) noexcept
   requires(I < sizeof...(Ts))
   {
-    return static_cast<record<Ts...>&&>(r)[index<I>];
+    return static_cast<record<Ts...>&&>(r)[kumi::index<I>];
   }
 
   /// @related record
@@ -627,7 +636,7 @@ namespace kumi
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(record<Ts...> const& r) noexcept
   requires(I < sizeof...(Ts))
   {
-    return r[index<I>];
+    return r[kumi::index<I>];
   }
 
   /// @related record
@@ -636,7 +645,7 @@ namespace kumi
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(record<Ts...> const&& r) noexcept
   requires(I < sizeof...(Ts))
   {
-    return static_cast<record<Ts...> const&&>(r)[index<I>];
+    return static_cast<record<Ts...> const&&>(r)[kumi::index<I>];
   }
 
   //====================================================================================================================
@@ -658,38 +667,38 @@ namespace kumi
     @include doc/record/api/labeled_get.cpp
   **/
   //====================================================================================================================
-  template<str L, typename... Ts>
+  template<kumi::str L, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(record<Ts...>& r) noexcept
-  requires(_::contains_label<L, Ts...>())
+  requires(kumi::_::contains_label<L, Ts...>())
   {
-    return r[label<L>];
+    return r[kumi::label<L>];
   }
 
   /// @related record
   /// @overload
-  template<str L, typename... Ts>
+  template<kumi::str L, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(record<Ts...>&& r) noexcept
-  requires(_::contains_label<L, Ts...>())
+  requires(kumi::_::contains_label<L, Ts...>())
   {
-    return static_cast<record<Ts...>&&>(r)[label<L>];
+    return static_cast<record<Ts...>&&>(r)[kumi::label<L>];
   }
 
   /// @related record
   /// @overload
-  template<str L, typename... Ts>
+  template<kumi::str L, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(record<Ts...> const& r) noexcept
-  requires(_::contains_label<L, Ts...>())
+  requires(kumi::_::contains_label<L, Ts...>())
   {
-    return r[label<L>];
+    return r[kumi::label<L>];
   }
 
   /// @related record
   /// @overload
-  template<str L, typename... Ts>
+  template<kumi::str L, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(record<Ts...> const&& r) noexcept
-  requires(_::contains_label<L, Ts...>())
+  requires(kumi::_::contains_label<L, Ts...>())
   {
-    return static_cast<record<Ts...> const&&>(r)[label<L>];
+    return static_cast<record<Ts...> const&&>(r)[kumi::label<L>];
   }
 
   //====================================================================================================================
@@ -711,36 +720,36 @@ namespace kumi
     @include doc/record/api/named_get.cpp
   **/
   //====================================================================================================================
-  template<concepts::identifier auto Id, typename... Ts>
+  template<kumi::concepts::identifier auto Id, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(record<Ts...>& r) noexcept
-  requires(concepts::contains_identifier<decltype(Id), Ts...>)
+  requires(kumi::concepts::contains_identifier<decltype(Id), Ts...>)
   {
     return r[Id];
   }
 
   /// @related record
   /// @overload
-  template<concepts::identifier auto Id, typename... Ts>
+  template<kumi::concepts::identifier auto Id, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(record<Ts...>&& r) noexcept
-  requires(concepts::contains_identifier<decltype(Id), Ts...>)
+  requires(kumi::concepts::contains_identifier<decltype(Id), Ts...>)
   {
     return static_cast<record<Ts...>&&>(r)[Id];
   }
 
   /// @related record
   /// @overload
-  template<concepts::identifier auto Id, typename... Ts>
+  template<kumi::concepts::identifier auto Id, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(record<Ts...> const& r) noexcept
-  requires(concepts::contains_identifier<decltype(Id), Ts...>)
+  requires(kumi::concepts::contains_identifier<decltype(Id), Ts...>)
   {
     return r[Id];
   }
 
   /// @related record
   /// @overload
-  template<concepts::identifier auto Id, typename... Ts>
+  template<kumi::concepts::identifier auto Id, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(record<Ts...> const&& r) noexcept
-  requires(concepts::contains_identifier<decltype(Id), Ts...>)
+  requires(kumi::concepts::contains_identifier<decltype(Id), Ts...>)
   {
     return static_cast<record<Ts...> const&&>(r)[Id];
   }
@@ -766,36 +775,40 @@ namespace kumi
   //====================================================================================================================
   template<typename T, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(record<Ts...>& r) noexcept
-  requires(concepts::uniquely_typed<_::type_of_t<Ts>...> && concepts::contains_type<T, _::type_of_t<Ts>...>)
+  requires(kumi::concepts::uniquely_typed<kumi::_::type_of_t<Ts>...> &&
+           kumi::concepts::contains_type<T, kumi::_::type_of_t<Ts>...>)
   {
-    return r[as<T>{}];
+    return r[kumi::as<T>{}];
   }
 
   /// @related record
   /// @overload
   template<typename T, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(record<Ts...>&& r) noexcept
-  requires(concepts::uniquely_typed<_::type_of_t<Ts>...> && concepts::contains_type<T, _::type_of_t<Ts>...>)
+  requires(kumi::concepts::uniquely_typed<kumi::_::type_of_t<Ts>...> &&
+           kumi::concepts::contains_type<T, kumi::_::type_of_t<Ts>...>)
   {
-    return static_cast<record<Ts...>&&>(r)[as<T>{}];
+    return static_cast<record<Ts...>&&>(r)[kumi::as<T>{}];
   }
 
   /// @related record
   /// @overload
   template<typename T, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(record<Ts...> const& r) noexcept
-  requires(concepts::uniquely_typed<_::type_of_t<Ts>...> && concepts::contains_type<T, _::type_of_t<Ts>...>)
+  requires(kumi::concepts::uniquely_typed<kumi::_::type_of_t<Ts>...> &&
+           kumi::concepts::contains_type<T, kumi::_::type_of_t<Ts>...>)
   {
-    return r[as<T>{}];
+    return r[kumi::as<T>{}];
   }
 
   /// @related record
   /// @overload
   template<typename T, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(record<Ts...> const&& r) noexcept
-  requires(concepts::uniquely_typed<_::type_of_t<Ts>...> && concepts::contains_type<T, _::type_of_t<Ts>...>)
+  requires(kumi::concepts::uniquely_typed<kumi::_::type_of_t<Ts>...> &&
+           kumi::concepts::contains_type<T, kumi::_::type_of_t<Ts>...>)
   {
-    return static_cast<record<Ts...> const&&>(r)[as<T>{}];
+    return static_cast<record<Ts...> const&&>(r)[kumi::as<T>{}];
   }
 
   //====================================================================================================================
@@ -804,27 +817,27 @@ namespace kumi
 #ifndef KUMI_DOXYGEN_INVOKED
   /// Improves diagnostic for out of bounds index
   template<std::size_t I, typename R>
-  requires(is_kumi_record_v<std::remove_cvref_t<R>> && ((I >= size_v<R>) || (I < 0)))
+  requires(kumi::is_kumi_record_v<std::remove_cvref_t<R>> && ((I >= kumi::size_v<R>) || (I < 0)))
   constexpr auto get(R&& r) = delete;
 
   /// Improves diagnostic for non present label
-  template<str S, typename R>
-  requires(is_kumi_record_v<std::remove_cvref_t<R>> && !_::contains_identifier<S, R>())
+  template<kumi::str S, typename R>
+  requires(kumi::is_kumi_record_v<std::remove_cvref_t<R>> && !kumi::_::contains_identifier<S, R>())
   constexpr auto get(R&& r) = delete;
 
   /// Improves diagnostic for non present identifier
-  template<concepts::identifier auto S, typename R>
-  requires(is_kumi_record_v<std::remove_cvref_t<R>> && !concepts::contains_identifier<decltype(S), R>)
+  template<kumi::concepts::identifier auto S, typename R>
+  requires(kumi::is_kumi_record_v<std::remove_cvref_t<R>> && !kumi::concepts::contains_identifier<decltype(S), R>)
   constexpr auto get(R&& r) = delete;
 
   /// Improves diagnostic for non present type
   template<typename U, typename R>
-  requires(is_kumi_record_v<std::remove_cvref_t<R>> && !concepts::contains_type<U, R>)
+  requires(kumi::is_kumi_record_v<std::remove_cvref_t<R>> && !kumi::concepts::contains_type<U, R>)
   constexpr auto get(R&& r) = delete;
 #endif
 
   // Builder protocole
-  template<concepts::record_type R> struct builder<R>
+  template<kumi::concepts::record_type R> struct builder<R>
   {
     using type = R;
 
@@ -842,7 +855,7 @@ namespace kumi
   };
 
   // As we are lacking a proper mechanism to find the least restrictive subtype, we fallback to a specializable trait
-  template<concepts::record_type... Ts> struct common_product_type<Ts...>
+  template<kumi::concepts::record_type... Ts> struct common_product_type<Ts...>
   {
     using type = kumi::record<>;
   };

--- a/include/kumi/product_types/tuple.hpp
+++ b/include/kumi/product_types/tuple.hpp
@@ -31,7 +31,7 @@ namespace kumi
   //====================================================================================================================
   template<typename... Ts> struct tuple
   {
-    using binder_t = _::make_binder_t<std::make_integer_sequence<int, sizeof...(Ts)>, Ts...>;
+    using binder_t = kumi::_::make_binder_t<std::make_integer_sequence<int, sizeof...(Ts)>, Ts...>;
 
     static constexpr bool is_homogeneous = binder_t::is_homogeneous;
 
@@ -57,7 +57,7 @@ namespace kumi
     **/
     //==================================================================================================================
     template<std::size_t I>
-    KUMI_ABI constexpr decltype(auto) operator[]([[maybe_unused]] index_t<I> i) & noexcept
+    KUMI_ABI constexpr decltype(auto) operator[]([[maybe_unused]] kumi::index_t<I> i) & noexcept
     requires(I < sizeof...(Ts))
     {
       return impl(std::integral_constant<std::size_t, I>{});
@@ -65,7 +65,7 @@ namespace kumi
 
     /// @overload
     template<std::size_t I>
-    KUMI_ABI constexpr decltype(auto) operator[](index_t<I>) && noexcept
+    KUMI_ABI constexpr decltype(auto) operator[](kumi::index_t<I>) && noexcept
     requires(I < sizeof...(Ts))
     {
       return static_cast<decltype(impl)&&>(impl)(std::integral_constant<std::size_t, I>{});
@@ -73,7 +73,7 @@ namespace kumi
 
     /// @overload
     template<std::size_t I>
-    KUMI_ABI constexpr decltype(auto) operator[](index_t<I>) const&& noexcept
+    KUMI_ABI constexpr decltype(auto) operator[](kumi::index_t<I>) const&& noexcept
     requires(I < sizeof...(Ts))
     {
       return static_cast<decltype(impl) const&&>(impl)(std::integral_constant<std::size_t, I>{});
@@ -81,7 +81,7 @@ namespace kumi
 
     /// @overload
     template<std::size_t I>
-    KUMI_ABI constexpr decltype(auto) operator[](index_t<I>) const& noexcept
+    KUMI_ABI constexpr decltype(auto) operator[](kumi::index_t<I>) const& noexcept
     requires(I < sizeof...(Ts))
     {
       return impl(std::integral_constant<std::size_t, I>{});
@@ -102,32 +102,32 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename T>
-    KUMI_ABI constexpr decltype(auto) operator[]([[maybe_unused]] as<T> type) & noexcept
-    requires(concepts::uniquely_typed<Ts...> && concepts::contains_type<T, Ts...>)
+    KUMI_ABI constexpr decltype(auto) operator[]([[maybe_unused]] kumi::as<T> type) & noexcept
+    requires(kumi::concepts::uniquely_typed<Ts...> && kumi::concepts::contains_type<T, Ts...>)
     {
       return impl(std::type_identity<T>{});
     }
 
     /// @overload
     template<typename T>
-    KUMI_ABI constexpr decltype(auto) operator[](as<T>) && noexcept
-    requires(concepts::uniquely_typed<Ts...> && concepts::contains_type<T, Ts...>)
+    KUMI_ABI constexpr decltype(auto) operator[](kumi::as<T>) && noexcept
+    requires(kumi::concepts::uniquely_typed<Ts...> && kumi::concepts::contains_type<T, Ts...>)
     {
       return static_cast<decltype(impl)&&>(impl)(std::type_identity<T>{});
     }
 
     /// @overload
     template<typename T>
-    KUMI_ABI constexpr decltype(auto) operator[](as<T>) const&& noexcept
-    requires(concepts::uniquely_typed<Ts...> && concepts::contains_type<T, Ts...>)
+    KUMI_ABI constexpr decltype(auto) operator[](kumi::as<T>) const&& noexcept
+    requires(kumi::concepts::uniquely_typed<Ts...> && kumi::concepts::contains_type<T, Ts...>)
     {
       return static_cast<decltype(impl) const&&>(impl)(std::type_identity<T>{});
     }
 
     /// @overload
     template<typename T>
-    KUMI_ABI constexpr decltype(auto) operator[](as<T>) const& noexcept
-    requires(concepts::uniquely_typed<Ts...> && concepts::contains_type<T, Ts...>)
+    KUMI_ABI constexpr decltype(auto) operator[](kumi::as<T>) const& noexcept
+    requires(kumi::concepts::uniquely_typed<Ts...> && kumi::concepts::contains_type<T, Ts...>)
     {
       return impl(std::type_identity<T>{});
     }
@@ -145,35 +145,35 @@ namespace kumi
       @include doc/tuple/api/labeled_subscript.cpp
     **/
     //==================================================================================================================
-    template<str L>
-    KUMI_ABI constexpr decltype(auto) operator[]([[maybe_unused]] label_t<L> s) & noexcept
-    requires(concepts::contains_label<label_t<L>, Ts...>)
+    template<kumi::str L>
+    KUMI_ABI constexpr decltype(auto) operator[]([[maybe_unused]] kumi::label_t<L> s) & noexcept
+    requires(kumi::concepts::contains_label<kumi::label_t<L>, Ts...>)
     {
-      return impl(std::integral_constant<str, L>{});
+      return impl(std::integral_constant<kumi::str, L>{});
     }
 
     /// @overload
-    template<str L>
-    KUMI_ABI constexpr decltype(auto) operator[](label_t<L>) && noexcept
-    requires(concepts::contains_label<label_t<L>, Ts...>)
+    template<kumi::str L>
+    KUMI_ABI constexpr decltype(auto) operator[](kumi::label_t<L>) && noexcept
+    requires(kumi::concepts::contains_label<kumi::label_t<L>, Ts...>)
     {
-      return static_cast<decltype(impl)&&>(impl)(std::integral_constant<str, L>{});
+      return static_cast<decltype(impl)&&>(impl)(std::integral_constant<kumi::str, L>{});
     }
 
     /// @overload
-    template<str L>
-    KUMI_ABI constexpr decltype(auto) operator[](label_t<L>) const&& noexcept
-    requires(concepts::contains_label<label_t<L>, Ts...>)
+    template<kumi::str L>
+    KUMI_ABI constexpr decltype(auto) operator[](kumi::label_t<L>) const&& noexcept
+    requires(kumi::concepts::contains_label<kumi::label_t<L>, Ts...>)
     {
-      return static_cast<decltype(impl) const&&>(impl)(std::integral_constant<str, L>{});
+      return static_cast<decltype(impl) const&&>(impl)(std::integral_constant<kumi::str, L>{});
     }
 
     /// @overload
-    template<str L>
-    KUMI_ABI constexpr decltype(auto) operator[](label_t<L>) const& noexcept
-    requires(concepts::contains_label<label_t<L>, Ts...>)
+    template<kumi::str L>
+    KUMI_ABI constexpr decltype(auto) operator[](kumi::label_t<L>) const& noexcept
+    requires(kumi::concepts::contains_label<kumi::label_t<L>, Ts...>)
     {
-      return impl(std::integral_constant<str, L>{});
+      return impl(std::integral_constant<kumi::str, L>{});
     }
 
     //==================================================================================================================
@@ -189,35 +189,35 @@ namespace kumi
       @include doc/tuple/api/named_subscript.cpp
     **/
     //==================================================================================================================
-    template<concepts::identifier Id>
+    template<kumi::concepts::identifier Id>
     KUMI_ABI constexpr decltype(auto) operator[](Id const&) & noexcept
-    requires(concepts::uniquely_named<Ts...> && concepts::contains_identifier<Id, Ts...>)
+    requires(kumi::concepts::uniquely_named<Ts...> && kumi::concepts::contains_identifier<Id, Ts...>)
     {
-      return impl(_::tag_of_t<Id>{});
+      return impl(kumi::_::tag_of_t<Id>{});
     }
 
     /// @overload
-    template<concepts::identifier Id>
+    template<kumi::concepts::identifier Id>
     KUMI_ABI constexpr decltype(auto) operator[](Id const&) && noexcept
-    requires(concepts::uniquely_named<Ts...> && concepts::contains_identifier<Id, Ts...>)
+    requires(kumi::concepts::uniquely_named<Ts...> && kumi::concepts::contains_identifier<Id, Ts...>)
     {
-      return static_cast<decltype(impl)&&>(impl)(_::tag_of_t<Id>{});
+      return static_cast<decltype(impl)&&>(impl)(kumi::_::tag_of_t<Id>{});
     }
 
     /// @overload
-    template<concepts::identifier Id>
+    template<kumi::concepts::identifier Id>
     KUMI_ABI constexpr decltype(auto) operator[](Id const&) const&& noexcept
-    requires(concepts::uniquely_named<Ts...> && concepts::contains_identifier<Id, Ts...>)
+    requires(kumi::concepts::uniquely_named<Ts...> && kumi::concepts::contains_identifier<Id, Ts...>)
     {
-      return static_cast<decltype(impl) const&&>(impl)(_::tag_of_t<Id>{});
+      return static_cast<decltype(impl) const&&>(impl)(kumi::_::tag_of_t<Id>{});
     }
 
     /// @overload
-    template<concepts::identifier Id>
+    template<kumi::concepts::identifier Id>
     KUMI_ABI constexpr decltype(auto) operator[](Id const&) const& noexcept
-    requires(concepts::uniquely_named<Ts...> && concepts::contains_identifier<Id, Ts...>)
+    requires(kumi::concepts::uniquely_named<Ts...> && kumi::concepts::contains_identifier<Id, Ts...>)
     {
-      return impl(_::tag_of_t<Id>{});
+      return impl(kumi::_::tag_of_t<Id>{});
     }
 
     //==================================================================================================================
@@ -238,10 +238,13 @@ namespace kumi
     [[nodiscard]] KUMI_ABI static constexpr bool empty() noexcept { return sizeof...(Ts) == 0; }
 
     /// Returns the identifier associated to the elements of a kumi::tuple
-    [[nodiscard]] KUMI_ABI static constexpr auto identifiers() noexcept { return kumi::tuple{identifier_of<Ts>()...}; }
+    [[nodiscard]] KUMI_ABI static constexpr auto identifiers() noexcept
+    {
+      return kumi::tuple{kumi::identifier_of<Ts>()...};
+    }
 
     /// Returns the labels associated to the elements of a kumi::tuple
-    [[nodiscard]] KUMI_ABI static constexpr auto labels() noexcept { return kumi::tuple{label_of<Ts>()...}; }
+    [[nodiscard]] KUMI_ABI static constexpr auto labels() noexcept { return kumi::tuple{kumi::label_of<Ts>()...}; }
     //==================================================================================================================
     //! @}
     //==================================================================================================================
@@ -272,11 +275,11 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename... Us>
-    [[nodiscard]] KUMI_ABI explicit(!_::piecewise_convertible<tuple<Ts const&...>, tuple<Us...>>) constexpr
+    [[nodiscard]] KUMI_ABI explicit(!kumi::_::piecewise_convertible<tuple<Ts const&...>, tuple<Us...>>) constexpr
     operator tuple<Us...>() const
     requires(sizeof...(Us) == sizeof...(Ts)) && (!std::same_as<tuple<Ts...>, tuple<Us...>>)
 #ifndef KUMI_DOXYGEN_INVOKED
-            && (_::piecewise_constructible<tuple<Ts const&...>, tuple<Us...>>)
+            && (kumi::_::piecewise_constructible<tuple<Ts const&...>, tuple<Us...>>)
 #endif
     {
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
@@ -286,11 +289,11 @@ namespace kumi
 
     /// @overload
     template<typename... Us>
-    [[nodiscard]] KUMI_ABI explicit(!_::piecewise_convertible<tuple<Ts&...>, tuple<Us...>>) constexpr operator tuple<
-      Us...>()
+    [[nodiscard]] KUMI_ABI explicit(!kumi::_::piecewise_convertible<tuple<Ts&...>, tuple<Us...>>) constexpr
+    operator tuple<Us...>()
     requires(sizeof...(Us) == sizeof...(Ts)) && (!std::same_as<tuple<Ts...>, tuple<Us...>>)
 #ifndef KUMI_DOXYGEN_INVOKED
-            && (_::piecewise_constructible<tuple<Ts&...>, tuple<Us...>>)
+            && (kumi::_::piecewise_constructible<tuple<Ts&...>, tuple<Us...>>)
 #endif
 
     {
@@ -316,7 +319,7 @@ namespace kumi
     template<typename... Us>
     KUMI_ABI constexpr tuple& operator=(tuple<Us...> const& other)
 #ifndef KUMI_DOXYGEN_INVOKED
-    requires(_::piecewise_convertible<tuple, tuple<Us...>>)
+    requires(kumi::_::piecewise_convertible<tuple, tuple<Us...>>)
 #endif
     {
       [&]<std::size_t... I>(std::index_sequence<I...>) {
@@ -330,7 +333,7 @@ namespace kumi
     template<typename... Us>
     KUMI_ABI constexpr tuple& operator=(tuple<Us...>&& other)
 #ifndef KUMI_DOXYGEN_INVOKED
-    requires(_::piecewise_convertible<tuple, tuple<Us...>>)
+    requires(kumi::_::piecewise_convertible<tuple, tuple<Us...>>)
 #endif
     {
       [&]<std::size_t... I>(std::index_sequence<I...>) {
@@ -351,7 +354,7 @@ namespace kumi
     template<typename... Us>
     KUMI_ABI friend constexpr auto operator==(tuple const& self, tuple<Us...> const& other) noexcept
 #ifndef KUMI_DOXYGEN_INVOKED
-    requires(_::piecewise_comparable<tuple, tuple<Us...>>)
+    requires(kumi::_::piecewise_comparable<tuple, tuple<Us...>>)
 #endif
     {
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
@@ -363,7 +366,7 @@ namespace kumi
     template<typename... Us>
     KUMI_ABI friend constexpr auto operator!=(tuple const& self, tuple<Us...> const& other) noexcept
 #ifndef KUMI_DOXYGEN_INVOKED
-    requires(_::piecewise_comparable<tuple, tuple<Us...>>)
+    requires(kumi::_::piecewise_comparable<tuple, tuple<Us...>>)
 #endif
     {
       return !(self == other);
@@ -375,7 +378,7 @@ namespace kumi
     KUMI_ABI friend constexpr auto operator<(tuple const& lhs, tuple<Us...> const& rhs) noexcept
     requires(sizeof...(Ts) == sizeof...(Us))
 #ifndef KUMI_DOXYGEN_INVOKED
-            && (_::piecewise_ordered<tuple, tuple<Us...>>)
+            && (kumi::_::piecewise_ordered<tuple, tuple<Us...>>)
 #endif
     {
       // lexicographical order is defined as
@@ -384,12 +387,12 @@ namespace kumi
 
       auto const order = [&]<typename Index>(Index i) {
         auto y_less_x_prev = rhs[i] < lhs[i];
-        auto x_less_y = lhs[index_t<Index::value + 1>{}] < rhs[index_t<Index::value + 1>{}];
+        auto x_less_y = lhs[kumi::index_t<Index::value + 1>{}] < rhs[kumi::index_t<Index::value + 1>{}];
         return x_less_y && !y_less_x_prev;
       };
 
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return (res || ... || order(index_t<I>{}));
+        return (res || ... || order(kumi::index_t<I>{}));
       }(std::make_index_sequence<sizeof...(Ts) - 1>{});
     }
 
@@ -432,9 +435,9 @@ namespace kumi
     {
       os << "( ";
       [&]<std::size_t... I>(std::index_sequence<I...>) {
-        ((os << _::make_streamable(t[index<I>]) << ", "), ...);
-      }(std::make_index_sequence<size_v<tuple> - 1>{});
-      os << _::make_streamable(t[index<size_v<tuple> - 1>]) << " )";
+        ((os << kumi::_::make_streamable(t[index<I>]) << ", "), ...);
+      }(std::make_index_sequence<kumi::size_v<tuple> - 1>{});
+      os << kumi::_::make_streamable(t[index<kumi::size_v<tuple> - 1>]) << " )";
       return os;
     }
   };
@@ -447,20 +450,20 @@ namespace kumi
 
     [[nodiscard]] KUMI_ABI static constexpr auto empty() noexcept { return true; }
 
-    [[nodiscard]] KUMI_ABI static constexpr auto names() noexcept { return tuple{}; }
+    [[nodiscard]] KUMI_ABI static constexpr auto names() noexcept { return kumi::tuple{}; }
 
     KUMI_ABI friend constexpr auto operator<=>(tuple<>, tuple<>) noexcept = default;
 
     template<typename T>
     [[nodiscard]] KUMI_ABI constexpr operator T() const noexcept
-    requires(concepts::unit_type<T>)
+    requires(kumi::concepts::unit_type<T>)
     {
       return {};
     }
 
     template<typename T>
     [[nodiscard]] KUMI_ABI constexpr operator T() noexcept
-    requires(concepts::unit_type<T>)
+    requires(kumi::concepts::unit_type<T>)
     {
       return {};
     }
@@ -509,7 +512,7 @@ namespace kumi
     @include doc/tuple/api/tie.cpp
   **/
   //====================================================================================================================
-  template<typename... Ts> [[nodiscard]] KUMI_ABI constexpr auto tie(Ts&... ts) -> tuple<Ts&...>
+  template<typename... Ts> [[nodiscard]] KUMI_ABI constexpr auto tie(Ts&... ts) -> kumi::tuple<Ts&...>
   {
     return {ts...};
   }
@@ -532,7 +535,7 @@ namespace kumi
     @include doc/tuple/api/forward_as_tuple.cpp
   **/
   //====================================================================================================================
-  template<typename... Ts> [[nodiscard]] KUMI_ABI constexpr auto forward_as_tuple(Ts&&... ts) -> tuple<Ts&&...>
+  template<typename... Ts> [[nodiscard]] KUMI_ABI constexpr auto forward_as_tuple(Ts&&... ts) -> kumi::tuple<Ts&&...>
   {
     return {KUMI_FWD(ts)...};
   }
@@ -550,7 +553,7 @@ namespace kumi
   **/
   //====================================================================================================================
   template<typename... Ts>
-  [[nodiscard]] KUMI_ABI constexpr auto make_tuple(Ts&&... ts) -> tuple<std::unwrap_ref_decay_t<Ts>...>
+  [[nodiscard]] KUMI_ABI constexpr auto make_tuple(Ts&&... ts) -> kumi::tuple<std::unwrap_ref_decay_t<Ts>...>
   {
     return {KUMI_FWD(ts)...};
   }
@@ -568,11 +571,11 @@ namespace kumi
     @include doc/tuple/api/to_ref.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto to_ref(T&& t)
+  template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto to_ref(T&& t)
   {
     return [&]<std::size_t... I>(std::index_sequence<I...>) {
       return kumi::forward_as_tuple(get<I>(KUMI_FWD(t))...);
-    }(std::make_index_sequence<size_v<T>>{});
+    }(std::make_index_sequence<kumi::size_v<T>>{});
   }
 
   //====================================================================================================================
@@ -603,7 +606,7 @@ namespace kumi
   //====================================================================================================================
   template<typename Type, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr auto from_tuple(tuple<Ts...> const& t)
-  requires(!concepts::product_type<Type> && _::implicit_constructible<Type, Ts...>)
+  requires(!kumi::concepts::product_type<Type> && kumi::_::implicit_constructible<Type, Ts...>)
   {
     return [&]<std::size_t... I>(std::index_sequence<I...>) {
       return Type{get<I>(t)...};
@@ -626,42 +629,44 @@ namespace kumi
     @include doc/tuple/api/to_tuple.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto to_tuple(T&& t)
+  template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto to_tuple(T&& t)
   {
-    if constexpr (concepts::empty_product_type<T>) return tuple{};
+    if constexpr (kumi::concepts::empty_product_type<T>) return kumi::tuple{};
     else
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
         return tuple{get<I>(KUMI_FWD(t))...};
-      }(std::make_index_sequence<size_v<T>>{});
+      }(std::make_index_sequence<kumi::size_v<T>>{});
   }
 
   /// @overload
-  template<concepts::static_container S>
+  template<kumi::concepts::static_container S>
   [[nodiscard]] KUMI_ABI constexpr auto to_tuple(S&& s)
-  requires(!concepts::product_type<S>)
+  requires(!kumi::concepts::product_type<S>)
   {
-    constexpr auto N = container_size_v<S>;
-    if constexpr (N == 0) return tuple{};
+    constexpr auto N = kumi::container_size_v<S>;
+    if constexpr (N == 0) return kumi::tuple{};
     else
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return tuple{KUMI_FWD(s)[I]...};
+        return kumi::tuple{KUMI_FWD(s)[I]...};
       }(std::make_index_sequence<N>{});
   }
 
   namespace _
   {
-    template<concepts::product_type T, typename IndexSequence, template<typename...> class Meta = std::type_identity>
+    template<kumi::concepts::product_type T,
+             typename IndexSequence,
+             template<typename...> class Meta = std::type_identity>
     struct as_tuple;
 
-    template<concepts::product_type T, std::size_t... I> struct as_tuple<T, std::index_sequence<I...>>
+    template<kumi::concepts::product_type T, std::size_t... I> struct as_tuple<T, std::index_sequence<I...>>
     {
-      using type = tuple<element_t<I, T>...>;
+      using type = kumi::tuple<kumi::element_t<I, T>...>;
     };
 
-    template<concepts::product_type T, std::size_t... I, template<typename...> class Meta>
+    template<kumi::concepts::product_type T, std::size_t... I, template<typename...> class Meta>
     struct as_tuple<T, std::index_sequence<I...>, Meta>
     {
-      using type = tuple<typename Meta<element_t<I, T>>::type...>;
+      using type = tuple<typename Meta<kumi::element_t<I, T>>::type...>;
     };
   }
 
@@ -670,7 +675,7 @@ namespace kumi
     @ingroup tuple_related
     @brief Generate a kumi::tuple type from a type
 
-    If `T` is a @ref kumi::concepts::product_type, returns the kumi::tuple type containing the same element
+    If `T` is a @ref kumi::kumi::concepts::product_type, returns the kumi::tuple type containing the same element
     as `T`. Otherwise, it returns `kumi::tuple<T>`.
 
     A template meta-function can be optionally passed to be applied to each of those types when
@@ -696,20 +701,20 @@ namespace kumi
   template<typename T, template<typename...> class Meta = std::type_identity> struct as_tuple;
 
   template<typename T, template<typename...> class Meta>
-  requires(concepts::product_type<T>)
-  struct as_tuple<T, Meta> : _::as_tuple<T, std::make_index_sequence<size_v<T>>, Meta>
+  requires(kumi::concepts::product_type<T>)
+  struct as_tuple<T, Meta> : kumi::_::as_tuple<T, std::make_index_sequence<kumi::size_v<T>>, Meta>
   {
   };
 
   template<typename T, template<typename...> class Meta>
-  requires(!concepts::product_type<T>)
+  requires(!kumi::concepts::product_type<T>)
   struct as_tuple<T, Meta>
   {
-    using type = tuple<typename Meta<T>::type>;
+    using type = kumi::tuple<typename Meta<T>::type>;
   };
 
   template<typename T, template<typename...> class Meta = std::type_identity>
-  using as_tuple_t = typename as_tuple<T, Meta>::type;
+  using as_tuple_t = typename kumi::as_tuple<T, Meta>::type;
 
   //====================================================================================================================
   //! @}
@@ -734,13 +739,13 @@ namespace kumi
     @include doc/infra/members_of.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto members_of(as<T>) noexcept
+  template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto members_of(as<T>) noexcept
   {
-    if constexpr (concepts::sized_product_type<T, 0>) return tuple{};
+    if constexpr (kumi::concepts::sized_product_type<T, 0>) return kumi::tuple{};
     else
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return tuple{identifier_of<element_t<I, T>>()...};
-      }(std::make_index_sequence<size_v<T>>{});
+        return kumi::tuple{kumi::identifier_of<kumi::element_t<I, T>>()...};
+      }(std::make_index_sequence<kumi::size_v<T>>{});
   }
 
   //====================================================================================================================
@@ -755,30 +760,31 @@ namespace kumi
     @include doc/infra/values_of.cpp
   **/
   //====================================================================================================================
-  template<concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto values_of(T&& t) noexcept
+  template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto values_of(T&& t) noexcept
   {
-    if constexpr (concepts::sized_product_type<T, 0>) return tuple{};
+    if constexpr (kumi::concepts::sized_product_type<T, 0>) return kumi::tuple{};
     else
       return [&]<std::size_t... I>(std::index_sequence<I...>) {
-        return tuple<result::field_value_of_t<member_t<I, T>>...>{field_value_of(get<I>(KUMI_FWD(t)))...};
-      }(std::make_index_sequence<size_v<T>>{});
+        return kumi::tuple<kumi::result::field_value_of_t<kumi::member_t<I, T>>...>{
+          kumi::field_value_of(get<I>(KUMI_FWD(t)))...};
+      }(std::make_index_sequence<kumi::size_v<T>>{});
   }
 
   namespace result
   {
-    template<concepts::product_type T> struct members_of
+    template<kumi::concepts::product_type T> struct members_of
     {
       using type = decltype(kumi::members_of(as<T>{}));
     };
 
-    template<concepts::product_type T> struct values_of
+    template<kumi::concepts::product_type T> struct values_of
     {
       using type = decltype(kumi::values_of(std::declval<T>()));
     };
 
-    template<concepts::product_type T> using members_of_t = typename members_of<T>::type;
+    template<kumi::concepts::product_type T> using members_of_t = typename kumi::result::members_of<T>::type;
 
-    template<concepts::product_type T> using values_of_t = typename values_of<T>::type;
+    template<kumi::concepts::product_type T> using values_of_t = typename kumi::result::values_of<T>::type;
   }
 
   //====================================================================================================================
@@ -815,7 +821,7 @@ namespace kumi
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(tuple<Ts...>& t) noexcept
   requires(I < sizeof...(Ts))
   {
-    return t[index<I>];
+    return t[kumi::index<I>];
   }
 
   /// @related tuple
@@ -824,7 +830,7 @@ namespace kumi
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(tuple<Ts...>&& arg) noexcept
   requires(I < sizeof...(Ts))
   {
-    return static_cast<tuple<Ts...>&&>(arg)[index<I>];
+    return static_cast<tuple<Ts...>&&>(arg)[kumi::index<I>];
   }
 
   /// @related tuple
@@ -833,7 +839,7 @@ namespace kumi
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(tuple<Ts...> const& arg) noexcept
   requires(I < sizeof...(Ts))
   {
-    return arg[index<I>];
+    return arg[kumi::index<I>];
   }
 
   /// @related tuple
@@ -842,7 +848,7 @@ namespace kumi
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(tuple<Ts...> const&& arg) noexcept
   requires(I < sizeof...(Ts))
   {
-    return static_cast<tuple<Ts...> const&&>(arg)[index<I>];
+    return static_cast<tuple<Ts...> const&&>(arg)[kumi::index<I>];
   }
 
   //====================================================================================================================
@@ -864,38 +870,38 @@ namespace kumi
     @include doc/tuple/api/labeled_get.cpp
   **/
   //====================================================================================================================
-  template<str L, typename... Ts>
+  template<kumi::str L, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(tuple<Ts...>& t) noexcept
-  requires(concepts::uniquely_named<Ts...> && _::contains_label<L, Ts...>())
+  requires(kumi::concepts::uniquely_named<Ts...> && kumi::_::contains_label<L, Ts...>())
   {
-    return t[label<L>];
+    return t[kumi::label<L>];
   }
 
   /// @related tuple
   /// @overload
-  template<str L, typename... Ts>
+  template<kumi::str L, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(tuple<Ts...>&& t) noexcept
-  requires(concepts::uniquely_named<Ts...> && _::contains_label<L, Ts...>())
+  requires(kumi::concepts::uniquely_named<Ts...> && kumi::_::contains_label<L, Ts...>())
   {
-    return static_cast<tuple<Ts...>&&>(t)[label<L>];
+    return static_cast<tuple<Ts...>&&>(t)[kumi::label<L>];
   }
 
   /// @related tuple
   /// @overload
-  template<str L, typename... Ts>
+  template<kumi::str L, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(tuple<Ts...> const& t) noexcept
-  requires(concepts::uniquely_named<Ts...> && _::contains_label<L, Ts...>())
+  requires(kumi::concepts::uniquely_named<Ts...> && kumi::_::contains_label<L, Ts...>())
   {
-    return t[label<L>];
+    return t[kumi::label<L>];
   }
 
   /// @related tuple
   /// @overload
-  template<str L, typename... Ts>
+  template<kumi::str L, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(tuple<Ts...> const&& t) noexcept
-  requires(concepts::uniquely_named<Ts...> && _::contains_label<L, Ts...>())
+  requires(kumi::concepts::uniquely_named<Ts...> && kumi::_::contains_label<L, Ts...>())
   {
-    return static_cast<tuple<Ts...> const&&>(t)[label<L>];
+    return static_cast<tuple<Ts...> const&&>(t)[kumi::label<L>];
   }
 
   //====================================================================================================================
@@ -917,36 +923,36 @@ namespace kumi
     @include doc/tuple/api/named_get.cpp
   **/
   //====================================================================================================================
-  template<concepts::identifier auto Id, typename... Ts>
+  template<kumi::concepts::identifier auto Id, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(tuple<Ts...>& t) noexcept
-  requires(concepts::uniquely_named<Ts...> && concepts::contains_identifier<decltype(Id), Ts...>)
+  requires(kumi::concepts::uniquely_named<Ts...> && kumi::concepts::contains_identifier<decltype(Id), Ts...>)
   {
     return t[Id];
   }
 
   /// @related tuple
   /// @overload
-  template<concepts::identifier auto Id, typename... Ts>
+  template<kumi::concepts::identifier auto Id, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(tuple<Ts...>&& t) noexcept
-  requires(concepts::uniquely_named<Ts...> && concepts::contains_identifier<decltype(Id), Ts...>)
+  requires(kumi::concepts::uniquely_named<Ts...> && kumi::concepts::contains_identifier<decltype(Id), Ts...>)
   {
     return static_cast<tuple<Ts...>&&>(t)[Id];
   }
 
   /// @related tuple
   /// @overload
-  template<concepts::identifier auto Id, typename... Ts>
+  template<kumi::concepts::identifier auto Id, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(tuple<Ts...> const& t) noexcept
-  requires(concepts::uniquely_named<Ts...> && concepts::contains_identifier<decltype(Id), Ts...>)
+  requires(kumi::concepts::uniquely_named<Ts...> && kumi::concepts::contains_identifier<decltype(Id), Ts...>)
   {
     return t[Id];
   }
 
   /// @related tuple
   /// @overload
-  template<concepts::identifier auto Id, typename... Ts>
+  template<kumi::concepts::identifier auto Id, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(tuple<Ts...> const&& t) noexcept
-  requires(concepts::uniquely_named<Ts...> && concepts::contains_identifier<decltype(Id), Ts...>)
+  requires(kumi::concepts::uniquely_named<Ts...> && kumi::concepts::contains_identifier<decltype(Id), Ts...>)
   {
     return static_cast<tuple<Ts...> const&&>(t)[Id];
   }
@@ -969,36 +975,36 @@ namespace kumi
   //====================================================================================================================
   template<typename T, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(tuple<Ts...>& t) noexcept
-  requires(concepts::uniquely_typed<Ts...> && concepts::contains_type<T, Ts...>)
+  requires(kumi::concepts::uniquely_typed<Ts...> && kumi::concepts::contains_type<T, Ts...>)
   {
-    return t[as<T>{}];
+    return t[kumi::as<T>{}];
   }
 
   /// @related tuple
   /// @overload
   template<typename T, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(tuple<Ts...>&& t) noexcept
-  requires(concepts::uniquely_typed<Ts...> && concepts::contains_type<T, Ts...>)
+  requires(kumi::concepts::uniquely_typed<Ts...> && kumi::concepts::contains_type<T, Ts...>)
   {
-    return static_cast<tuple<Ts...>&&>(t)[as<T>{}];
+    return static_cast<tuple<Ts...>&&>(t)[kumi::as<T>{}];
   }
 
   /// @related tuple
   /// @overload
   template<typename T, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(tuple<Ts...> const& t) noexcept
-  requires(concepts::uniquely_typed<Ts...> && concepts::contains_type<T, Ts...>)
+  requires(kumi::concepts::uniquely_typed<Ts...> && kumi::concepts::contains_type<T, Ts...>)
   {
-    return t[as<T>{}];
+    return t[kumi::as<T>{}];
   }
 
   /// @related tuple
   /// @overload
   template<typename T, typename... Ts>
   [[nodiscard]] KUMI_ABI constexpr decltype(auto) get(tuple<Ts...> const&& t) noexcept
-  requires(concepts::uniquely_typed<Ts...> && concepts::contains_type<T, Ts...>)
+  requires(kumi::concepts::uniquely_typed<Ts...> && kumi::concepts::contains_type<T, Ts...>)
   {
-    return static_cast<tuple<Ts...> const&&>(t)[as<T>{}];
+    return static_cast<tuple<Ts...> const&&>(t)[kumi::as<T>{}];
   }
 
   //====================================================================================================================
@@ -1008,28 +1014,28 @@ namespace kumi
 #ifndef KUMI_DOXYGEN_INVOKED
   /// Improves diagnostic for out of bounds index
   template<std::size_t I, typename T>
-  requires(is_kumi_tuple_v<std::remove_cvref_t<T>> && (I >= size_v<T>))
+  requires(kumi::is_kumi_tuple_v<std::remove_cvref_t<T>> && (I >= kumi::size_v<T>))
   constexpr auto get(T&& r) = delete;
 
   /// Improves diagnostic for non present label
   template<str S, typename T>
-  requires(is_kumi_tuple_v<std::remove_cvref_t<T>> && !_::contains_identifier<S, T>())
+  requires(kumi::is_kumi_tuple_v<std::remove_cvref_t<T>> && !kumi::_::contains_identifier<S, T>())
   constexpr auto get(T&& t) = delete;
 
   /// Improves diagnostic for non present identifier
-  template<concepts::identifier auto S, typename T>
-  requires(is_kumi_tuple_v<std::remove_cvref_t<T>> && !concepts::contains_identifier<decltype(S), T>)
+  template<kumi::concepts::identifier auto S, typename T>
+  requires(kumi::is_kumi_tuple_v<std::remove_cvref_t<T>> && !kumi::concepts::contains_identifier<decltype(S), T>)
   constexpr auto get(T&& t) = delete;
 
   /// Improves diagnostic for non present type
   template<typename U, typename T>
-  requires(is_kumi_tuple_v<std::remove_cvref_t<T>> && !concepts::contains_type<U, T>)
+  requires(kumi::is_kumi_tuple_v<std::remove_cvref_t<T>> && !kumi::concepts::contains_type<U, T>)
   constexpr auto get(T&& t) = delete;
 #endif
 
   // Builder protocole
-  template<concepts::product_type T>
-  requires(!concepts::record_type<T>)
+  template<kumi::concepts::product_type T>
+  requires(!kumi::concepts::record_type<T>)
   struct builder<T>
   {
     using type = T;
@@ -1048,8 +1054,8 @@ namespace kumi
   };
 
   // As we are lacking a proper mechanism to find the least restrictive subtype, we fallback to a specializable trait
-  template<concepts::product_type... Ts>
-  requires(!concepts::record_type<Ts> && ...)
+  template<kumi::concepts::product_type... Ts>
+  requires(!kumi::concepts::record_type<Ts> && ...)
   struct common_product_type<Ts...>
   {
     using type = kumi::tuple<>;

--- a/include/kumi/utils/concepts.hpp
+++ b/include/kumi/utils/concepts.hpp
@@ -16,26 +16,27 @@ namespace kumi
     //==================================================================================================================
     template<typename F, typename T>
     concept supports_apply = []<std::size_t... N>(std::index_sequence<N...>) {
-      return std::invocable<F, stored_member_t<N, T>...>;
-    }(std::make_index_sequence<size_v<T>>{});
+      return std::invocable<F, kumi::stored_member_t<N, T>...>;
+    }(std::make_index_sequence<kumi::size_v<T>>{});
 
     template<typename F, typename T>
     concept supports_nothrow_apply = []<std::size_t... N>(std::index_sequence<N...>) {
-      return std::is_nothrow_invocable_v<F, stored_member_t<N, T>...>;
-    }(std::make_index_sequence<size_v<T>>{});
+      return std::is_nothrow_invocable_v<F, kumi::stored_member_t<N, T>...>;
+    }(std::make_index_sequence<kumi::size_v<T>>{});
 
     template<typename F, typename... Ts>
     concept supports_call = []<std::size_t... I>(std::index_sequence<I...>) {
       return ([]<std::size_t J>(std::integral_constant<std::size_t, J>) {
-        return std::invocable<F, stored_member_t<J, Ts>...>;
+        return std::invocable<F, kumi::stored_member_t<J, Ts>...>;
       }(std::integral_constant<std::size_t, I>{}) &&
               ...);
-    }(std::make_index_sequence<(size_v<Ts>, ...)>{});
+    }(std::make_index_sequence<(kumi::size_v<Ts>, ...)>{});
 
     template<typename T>
-    concept supports_transpose = (size_v<T> <= 1) || ([]<std::size_t... N>(std::index_sequence<N...>) {
-                                   return ((size_v<stored_member_t<0, T>> == size_v<stored_member_t<N + 1, T>>) && ...);
-                                 }(std::make_index_sequence<size_v<T> - 1>{}));
+    concept supports_transpose =
+      (kumi::size_v<T> <= 1) || ([]<std::size_t... N>(std::index_sequence<N...>) {
+        return ((kumi::size_v<kumi::stored_member_t<0, T>> == kumi::size_v<kumi::stored_member_t<N + 1, T>>) && ...);
+      }(std::make_index_sequence<kumi::size_v<T> - 1>{}));
 
   }
 
@@ -59,7 +60,7 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename T>
-    concept product_type = is_product_type<std::remove_cvref_t<T>>::value;
+    concept product_type = kumi::is_product_type<std::remove_cvref_t<T>>::value;
 
     //==================================================================================================================
     /**
@@ -76,7 +77,7 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename T>
-    concept record_type = product_type<T> && is_record_type<std::remove_cvref_t<T>>::value;
+    concept record_type = kumi::concepts::product_type<T> && kumi::is_record_type<std::remove_cvref_t<T>>::value;
 
     //==================================================================================================================
     /**
@@ -92,7 +93,7 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename T>
-    concept container = is_container_v<std::remove_cvref_t<T>>;
+    concept container = kumi::is_container_v<std::remove_cvref_t<T>>;
 
     //==================================================================================================================
     /**
@@ -106,7 +107,7 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename T>
-    concept static_container = container<T> && has_static_size_v<std::remove_cvref_t<T>>;
+    concept static_container = kumi::concepts::container<T> && kumi::has_static_size_v<std::remove_cvref_t<T>>;
 
     //==================================================================================================================
     /**
@@ -120,7 +121,8 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename T>
-    concept unit_type = (product_type<T> && (size_v<T> == 0)) || std::is_null_pointer_v<std::remove_cvref_t<T>>;
+    concept unit_type =
+      (kumi::concepts::product_type<T> && (kumi::size_v<T> == 0)) || std::is_null_pointer_v<std::remove_cvref_t<T>>;
 
     //==================================================================================================================
     /**
@@ -181,7 +183,7 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename T>
-    concept projection_map = is_projection_map_v<std::remove_cvref_t<T>>;
+    concept projection_map = kumi::is_projection_map_v<std::remove_cvref_t<T>>;
 
     //==================================================================================================================
     /**
@@ -193,7 +195,7 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename T>
-    concept projection = projection_map<T> || identifier<T> || index<T>;
+    concept projection = kumi::concepts::projection_map<T> || kumi::concepts::identifier<T> || kumi::concepts::index<T>;
 
     //==================================================================================================================
     /**
@@ -205,7 +207,7 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename T, std::size_t N>
-    concept sized_product_type = product_type<T> && (size_v<T> == N);
+    concept sized_product_type = kumi::concepts::product_type<T> && (kumi::size_v<T> == N);
 
     //==================================================================================================================
     /**
@@ -217,7 +219,7 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename T, std::size_t N>
-    concept sized_product_type_or_more = product_type<T> && (size_v<T> >= N);
+    concept sized_product_type_or_more = kumi::concepts::product_type<T> && (kumi::size_v<T> >= N);
 
     //==================================================================================================================
     /**
@@ -229,7 +231,7 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename T>
-    concept empty_product_type = product_type<T> && (size_v<T> == 0);
+    concept empty_product_type = kumi::concepts::product_type<T> && (kumi::size_v<T> == 0);
 
     //==================================================================================================================
     /**
@@ -241,7 +243,7 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename T>
-    concept non_empty_product_type = product_type<T> && (size_v<T> != 0);
+    concept non_empty_product_type = kumi::concepts::product_type<T> && (kumi::size_v<T> != 0);
 
     //==================================================================================================================
     /**
@@ -258,7 +260,8 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename T>
-    concept homogeneous_product_type = product_type<T> && is_homogeneous_v<std::remove_cvref_t<T>>;
+    concept homogeneous_product_type =
+      kumi::concepts::product_type<T> && kumi::is_homogeneous_v<std::remove_cvref_t<T>>;
 
     //==================================================================================================================
     /**
@@ -267,7 +270,7 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename... Ts>
-    concept has_named_fields = (... || field<Ts>);
+    concept has_named_fields = (... || kumi::concepts::field<Ts>);
 
     //==================================================================================================================
     /**
@@ -276,7 +279,7 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename... Ts>
-    concept fully_named = (... && field<Ts>);
+    concept fully_named = (... && kumi::concepts::field<Ts>);
 
     //==================================================================================================================
     /**
@@ -285,8 +288,8 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename... Ts>
-    concept uniquely_typed =
-      (sizeof...(Ts) == 0) || (!has_named_fields<Ts...> && all_uniques_v<std::remove_cvref_t<Ts>...>);
+    concept uniquely_typed = (sizeof...(Ts) == 0) || (!kumi::concepts::has_named_fields<Ts...> &&
+                                                      kumi::all_uniques_v<std::remove_cvref_t<Ts>...>);
 
     //==================================================================================================================
     /**
@@ -295,8 +298,8 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename... Ts>
-    concept uniquely_named =
-      (sizeof...(Ts) == 0) || (has_named_fields<Ts...> && all_unique_names_v<std::remove_cvref_t<Ts>...>);
+    concept uniquely_named = (sizeof...(Ts) == 0) || (kumi::concepts::has_named_fields<Ts...> &&
+                                                      kumi::all_unique_names_v<std::remove_cvref_t<Ts>...>);
 
     //==================================================================================================================
     /**
@@ -307,7 +310,8 @@ namespace kumi
     //==================================================================================================================
     template<typename... Ts>
     concept uniquely_labeled =
-      (sizeof...(Ts) == 0) || (fully_named<Ts...> && (all_uniques_v<_::value<std::remove_cvref_t<Ts>::label()>...>));
+      (sizeof...(Ts) == 0) || (kumi::concepts::fully_named<Ts...> &&
+                               (kumi::all_uniques_v<kumi::_::value<std::remove_cvref_t<Ts>::label()>...>));
 
     //==================================================================================================================
     /**
@@ -327,7 +331,7 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename Name, typename... Ts>
-    concept contains_identifier = identifier<Name> && kumi::_::can_get_field_by_value<Name, Ts...>;
+    concept contains_identifier = kumi::concepts::identifier<Name> && kumi::_::can_get_field_by_value<Name, Ts...>;
 
     //==================================================================================================================
     /**
@@ -338,8 +342,9 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename Label, typename... Ts>
-    concept contains_label = std::is_same_v<std::remove_cvref_t<decltype(std::remove_cvref_t<Label>::value)>, str> &&
-                             kumi::_::can_get_field_by_label<std::remove_cvref_t<Label>, Ts...>;
+    concept contains_label =
+      std::is_same_v<std::remove_cvref_t<decltype(std::remove_cvref_t<Label>::value)>, kumi::str> &&
+      kumi::_::can_get_field_by_label<std::remove_cvref_t<Label>, Ts...>;
 
     //==================================================================================================================
     /**
@@ -352,8 +357,8 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename T, typename U>
-    concept equivalent =
-      product_type<T> && product_type<U> && is_equivalent_v<std::remove_cvref_t<T>, std::remove_cvref_t<U>>;
+    concept equivalent = kumi::concepts::product_type<T> && kumi::concepts::product_type<U> &&
+                         kumi::is_equivalent_v<std::remove_cvref_t<T>, std::remove_cvref_t<U>>;
 
     //==================================================================================================================
     /**
@@ -365,8 +370,8 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename T, typename U>
-    concept equality_comparable =
-      equivalent<T, U> && is_equality_comparable_v<std::remove_cvref_t<T>, std::remove_cvref_t<U>>;
+    concept equality_comparable = kumi::concepts::equivalent<T, U> &&
+                                  kumi::is_equality_comparable_v<std::remove_cvref_t<T>, std::remove_cvref_t<U>>;
 
     //==================================================================================================================
     /**
@@ -378,7 +383,8 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename... Ts>
-    concept follows_same_semantic = ((product_type<Ts> && !record_type<Ts>) && ...) || ((record_type<Ts> && ...));
+    concept follows_same_semantic = ((kumi::concepts::product_type<Ts> && !kumi::concepts::record_type<Ts>) && ...) ||
+                                    ((kumi::concepts::record_type<Ts> && ...));
 
     //==================================================================================================================
     /**
@@ -391,7 +397,8 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename T, typename... Us>
-    concept compatible_product_types = (follows_same_semantic<T, Us...> && (equivalent<T, Us> && ...));
+    concept compatible_product_types =
+      (kumi::concepts::follows_same_semantic<T, Us...> && (kumi::concepts::equivalent<T, Us> && ...));
 
     //==================================================================================================================
     /**
@@ -426,9 +433,9 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename Type, typename T>
-    concept queryable_by_type = product_type<T> && []<std::size_t... I>(std::index_sequence<I...>) {
-      return _::can_get_field_by_type<Type, stored_element_t<I, T>...>;
-    }(std::make_index_sequence<size_v<T>>{});
+    concept queryable_by_type = kumi::concepts::product_type<T> && []<std::size_t... I>(std::index_sequence<I...>) {
+      return kumi::_::can_get_field_by_type<Type, kumi::stored_element_t<I, T>...>;
+    }(std::make_index_sequence<kumi::size_v<T>>{});
 
     //==================================================================================================================
     /**
@@ -441,10 +448,10 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename Id, typename T>
-    concept queryable_by_identifier =
-      identifier<Id> && product_type<T> && []<std::size_t... I>(std::index_sequence<I...>) {
-        return _::can_get_field_by_value<Id, element_t<I, T>...>;
-      }(std::make_index_sequence<size_v<T>>{});
+    concept queryable_by_identifier = kumi::concepts::identifier<Id> && kumi::concepts::product_type<T> &&
+                                      []<std::size_t... I>(std::index_sequence<I...>) {
+                                        return kumi::_::can_get_field_by_value<Id, kumi::element_t<I, T>...>;
+                                      }(std::make_index_sequence<kumi::size_v<T>>{});
 
     //==================================================================================================================
     /**
@@ -457,8 +464,9 @@ namespace kumi
     **/
     //==================================================================================================================
     template<typename L, typename T>
-    concept queryable_by_label = _::label<L> && product_type<T> && []<std::size_t... I>(std::index_sequence<I...>) {
-      return _::can_get_field_by_label<L, element_t<I, T>...>;
-    }(std::make_index_sequence<size_v<T>>{});
+    concept queryable_by_label =
+      kumi::_::label<L> && kumi::concepts::product_type<T> && []<std::size_t... I>(std::index_sequence<I...>) {
+        return kumi::_::can_get_field_by_label<L, kumi::element_t<I, T>...>;
+      }(std::make_index_sequence<kumi::size_v<T>>{});
   }
 }

--- a/include/kumi/utils/ct_helpers.hpp
+++ b/include/kumi/utils/ct_helpers.hpp
@@ -9,6 +9,16 @@
 
 namespace kumi
 {
+  namespace _
+  {
+    template<char... c> constexpr auto b10()
+    {
+      auto value = 0ULL;
+      ((value = value * 10 + (c - '0')), ...);
+      return value;
+    }
+  }
+
   //====================================================================================================================
   /**
     @ingroup types
@@ -33,7 +43,7 @@ namespace kumi
     @brief Inline integral constant value for kumi::index_t
   **/
   //====================================================================================================================
-  template<std::size_t N> inline constexpr index_t<N> const index = {};
+  template<std::size_t N> inline constexpr kumi::index_t<N> const index = {};
 
   //====================================================================================================================
   /**
@@ -44,15 +54,15 @@ namespace kumi
     Defines a Literal constant wrapper used to carry compile-time strings through API
   **/
   //====================================================================================================================
-  template<str Label> struct label_t
+  template<kumi::str Label> struct label_t
   {
     using type = str;
 
     /// Value stored by the constant
-    static constexpr str value = Label;
+    static constexpr kumi::str value = Label;
 
     /// Conversion operator to kumi::str
-    constexpr inline operator str() const noexcept { return Label; }
+    constexpr inline operator kumi::str() const noexcept { return Label; }
 
     template<typename CharT, typename Traits>
     friend std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, Traits>& os, label_t const&) noexcept
@@ -67,7 +77,7 @@ namespace kumi
     @brief Inline literal constant value for kumi::label_t
   **/
   //====================================================================================================================
-  template<str Label> inline constexpr label_t<Label> label = {};
+  template<str Label> inline constexpr kumi::label_t<Label> label = {};
 
   //====================================================================================================================
   /**
@@ -77,13 +87,6 @@ namespace kumi
   //====================================================================================================================
   inline namespace literals
   {
-    template<char... c> constexpr auto b10()
-    {
-      auto value = 0ULL;
-      ((value = value * 10 + (c - '0')), ...);
-      return value;
-    }
-
     //==================================================================================================================
     /**
       @ingroup utility
@@ -95,7 +98,7 @@ namespace kumi
     //==================================================================================================================
     template<char... c> constexpr auto operator""_c() noexcept
     {
-      return index<b10<c...>()>;
+      return kumi::index<kumi::_::b10<c...>()>;
     }
 
     //==================================================================================================================
@@ -109,7 +112,7 @@ namespace kumi
     //==================================================================================================================
     template<kumi::str ID> constexpr auto operator""_id() noexcept
     {
-      return name<ID>{};
+      return kumi::name<ID>{};
     }
 
     //==================================================================================================================
@@ -127,7 +130,7 @@ namespace kumi
     //==================================================================================================================
     template<kumi::str ID> constexpr auto operator""_l() noexcept
     {
-      return label<ID>;
+      return kumi::label<ID>;
     }
   }
 
@@ -155,13 +158,13 @@ namespace kumi
     @return the index of the element of type U in the product type if it exist
   **/
   //====================================================================================================================
-  template<typename U, concepts::product_type T>
+  template<typename U, kumi::concepts::product_type T>
   KUMI_ABI consteval auto get_index_of_type()
-  requires(concepts::queryable_by_type<U, T>)
+  requires(kumi::concepts::queryable_by_type<U, T>)
   {
     return [&]<std::size_t... I>(std::index_sequence<I...>) {
-      return _::get_index_by_type_v<U, stored_element_t<I, T>...>;
-    }(std::make_index_sequence<size_v<T>>{});
+      return kumi::_::get_index_by_type_v<U, kumi::stored_element_t<I, T>...>;
+    }(std::make_index_sequence<kumi::size_v<T>>{});
   }
 
   //====================================================================================================================
@@ -175,13 +178,13 @@ namespace kumi
     @return the index of the element whose identifier matches Id in the product type if it exist
   **/
   //====================================================================================================================
-  template<concepts::identifier Id, concepts::product_type T>
+  template<kumi::concepts::identifier Id, kumi::concepts::product_type T>
   KUMI_ABI consteval auto get_index_of_field()
-  requires(concepts::queryable_by_identifier<Id, T>)
+  requires(kumi::concepts::queryable_by_identifier<Id, T>)
   {
     return [&]<std::size_t... I>(std::index_sequence<I...>) {
-      return _::get_index_by_value_v<Id, element_t<I, T>...>;
-    }(std::make_index_sequence<size_v<T>>{});
+      return kumi::_::get_index_by_value_v<Id, kumi::element_t<I, T>...>;
+    }(std::make_index_sequence<kumi::size_v<T>>{});
   }
 
   //====================================================================================================================
@@ -195,12 +198,12 @@ namespace kumi
     @return the index of the element whose identifier matches Id in the product type if it exist
   **/
   //====================================================================================================================
-  template<str L, concepts::product_type T>
+  template<kumi::str L, kumi::concepts::product_type T>
   KUMI_ABI consteval auto get_index_of_label()
-  requires(concepts::queryable_by_label<label_t<L>, T>)
+  requires(kumi::concepts::queryable_by_label<kumi::label_t<L>, T>)
   {
     return [&]<std::size_t... I>(std::index_sequence<I...>) {
-      return _::get_index_by_label_v<label_t<L>, element_t<I, T>...>;
-    }(std::make_index_sequence<size_v<T>>{});
+      return kumi::_::get_index_by_label_v<kumi::label_t<L>, kumi::element_t<I, T>...>;
+    }(std::make_index_sequence<kumi::size_v<T>>{});
   }
 }

--- a/include/kumi/utils/identifier.hpp
+++ b/include/kumi/utils/identifier.hpp
@@ -28,7 +28,7 @@ namespace kumi
     @include doc/infra/only.cpp
   **/
   //====================================================================================================================
-  template<typename T> inline constexpr only_t<T> only = {};
+  template<typename T> inline constexpr kumi::only_t<T> only = {};
 
   //====================================================================================================================
   /**
@@ -51,7 +51,7 @@ namespace kumi
 
     constexpr identifier(ID const&) noexcept {}
 
-    template<typename T> constexpr field<type, std::unwrap_ref_decay_t<T>> operator=(T&& v) const noexcept
+    template<typename T> constexpr kumi::field<type, std::unwrap_ref_decay_t<T>> operator=(T&& v) const noexcept
     {
       return {KUMI_FWD(v)};
     }
@@ -60,7 +60,7 @@ namespace kumi
     friend std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, Traits>& os,
                                                          identifier const&) noexcept
     {
-      return os << _::make_str(type{});
+      return os << kumi::_::make_str(type{});
     }
   };
 
@@ -88,7 +88,7 @@ namespace kumi
     using type = identifier<ID, Checker>;
 
     //! A checked field str representation is the underlying type, checker is ignored
-    friend constexpr str to_str(identifier<ID, Checker> const&) { return _::make_str(ID{}); }
+    friend constexpr kumi::str to_str(identifier<ID, Checker> const&) { return kumi::_::make_str(ID{}); }
 
     //! @brief Default constructor
     constexpr identifier() noexcept {}
@@ -128,14 +128,14 @@ namespace kumi
     //==================================================================================================================
     template<typename T>
     requires(Checker::template value<T>)
-    constexpr auto operator=(T&& v) const noexcept -> field<type, std::unwrap_ref_decay_t<T>>
+    constexpr auto operator=(T&& v) const noexcept -> kumi::field<type, std::unwrap_ref_decay_t<T>>
     {
       return {KUMI_FWD(v)};
     }
 
     template<typename T>
     requires(!Checker::template value<T>)
-    constexpr field<type, std::unwrap_ref_decay_t<T>> operator=(T&& v) const = delete;
+    constexpr kumi::field<type, std::unwrap_ref_decay_t<T>> operator=(T&& v) const = delete;
 
     //! @related kumi::identifier
     //! @brief Output stream insertion
@@ -143,7 +143,7 @@ namespace kumi
     friend std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, Traits>& os,
                                                          identifier const& id) noexcept
     {
-      return os << _::make_str(id);
+      return os << kumi::_::make_str(id);
     }
   };
 
@@ -158,13 +158,13 @@ namespace kumi
     @tparam ID Compile-time string representing an indentifier
   **/
   //====================================================================================================================
-  template<str ID> struct name
+  template<kumi::str ID> struct name
   {
     //! @brief Derived identifier type
     using type = name<ID>;
 
     //! A name field str representation is it s owned str
-    friend constexpr str to_str(name<ID> const&) { return ID; }
+    friend constexpr kumi::str to_str(name<ID> const&) { return ID; }
 
     //==================================================================================================================
     /**
@@ -176,7 +176,7 @@ namespace kumi
       @return A kumi::field binding the identifier to `v`.
     **/
     //==================================================================================================================
-    template<typename T> constexpr auto operator=(T&& v) const noexcept -> field<type, std::unwrap_ref_decay_t<T>>
+    template<typename T> constexpr auto operator=(T&& v) const noexcept -> kumi::field<type, std::unwrap_ref_decay_t<T>>
     {
       return {KUMI_FWD(v)};
     }
@@ -191,7 +191,8 @@ namespace kumi
   };
 
   //! identifier comparison
-  template<concepts::identifier L, kumi::concepts::identifier R> KUMI_ABI constexpr bool operator==(L const&, R const&)
+  template<kumi::concepts::identifier L, kumi::concepts::identifier R>
+  KUMI_ABI constexpr bool operator==(L const&, R const&)
   {
     return std::same_as<std::remove_cvref_t<L>, std::remove_cvref_t<R>>;
   }
@@ -203,17 +204,17 @@ namespace kumi
     template<auto N, typename... Ts> KUMI_ABI constexpr auto contains_identifier()
     {
       if constexpr (std::integral<std::remove_cvref_t<decltype(N)>>) return false;
-      else if constexpr (concepts::index<decltype(N)>) return false;
-      else if constexpr (concepts::identifier<std::remove_cvref_t<decltype(N)>>) return false;
-      else return can_get_field_by_value<name<N>, Ts...>;
+      else if constexpr (kumi::concepts::index<decltype(N)>) return false;
+      else if constexpr (kumi::concepts::identifier<std::remove_cvref_t<decltype(N)>>) return false;
+      else return kumi::_::can_get_field_by_value<kumi::name<N>, Ts...>;
     }
 
     template<auto N, typename... Ts> KUMI_ABI constexpr auto contains_label()
     {
       if constexpr (std::integral<std::remove_cvref_t<decltype(N)>>) return false;
-      else if constexpr (concepts::index<decltype(N)>) return false;
-      else if constexpr (!std::is_same_v<std::remove_cvref_t<decltype(N)>, str>) return false;
-      else return can_get_field_by_label<std::integral_constant<kumi::str, N>, Ts...>;
+      else if constexpr (kumi::concepts::index<decltype(N)>) return false;
+      else if constexpr (!std::is_same_v<std::remove_cvref_t<decltype(N)>, kumi::str>) return false;
+      else return kumi::_::can_get_field_by_label<std::integral_constant<kumi::str, N>, Ts...>;
     }
   }
 }

--- a/include/kumi/utils/projections.hpp
+++ b/include/kumi/utils/projections.hpp
@@ -16,13 +16,13 @@ namespace kumi
     };
 
     template<std::size_t I, auto Head, auto... Tail>
-    struct value_at<I, kumi::projection_map<Head, Tail...>> : value_at<I - 1, kumi::projection_map<Tail...>>
+    struct value_at<I, kumi::projection_map<Head, Tail...>> : kumi::_::value_at<I - 1, kumi::projection_map<Tail...>>
     {
     };
 
     template<std::size_t I, auto... Vs> struct value_at<I, kumi::projection_map<Vs...> const>
     {
-      static constexpr auto value = value_at<I, kumi::projection_map<Vs...>>::value;
+      static constexpr auto value = kumi::_::value_at<I, kumi::projection_map<Vs...>>::value;
     };
 
     template<auto Head, auto... Tail> struct value_at<0, kumi::projection_map<Head, Tail...>>
@@ -85,9 +85,9 @@ namespace kumi
     //==================================================================================================================
     template<std::size_t I>
     requires(I < sizeof...(V))
-    KUMI_ABI constexpr decltype(auto) operator[]([[maybe_unused]] index_t<I> i) const noexcept
+    KUMI_ABI constexpr decltype(auto) operator[]([[maybe_unused]] kumi::index_t<I> i) const noexcept
     {
-      return _::value_at<I, projection_map>::value;
+      return kumi::_::value_at<I, projection_map>::value;
     }
 
     //==================================================================================================================
@@ -103,7 +103,7 @@ namespace kumi
     requires(I < sizeof...(V))
     [[nodiscard]] KUMI_ABI friend constexpr decltype(auto) get(projection_map const& pm) noexcept
     {
-      return pm[index<I>];
+      return pm[kumi::index<I>];
     }
 
     //==================================================================================================================
@@ -146,7 +146,7 @@ namespace kumi
   //====================================================================================================================
   template<concepts::index... Ts> [[nodiscard]] KUMI_ABI consteval auto indexes(Ts...) noexcept
   {
-    return projection_map<Ts{}...>{};
+    return kumi::projection_map<Ts{}...>{};
   }
 
   //====================================================================================================================
@@ -165,7 +165,7 @@ namespace kumi
   //====================================================================================================================
   template<std::convertible_to<std::size_t> auto... vs> [[nodiscard]] KUMI_ABI consteval auto make_indexes() noexcept
   {
-    return projection_map<index<vs>...>{};
+    return kumi::projection_map<kumi::index<vs>...>{};
   }
 
   //====================================================================================================================
@@ -183,20 +183,21 @@ namespace kumi
   **/
   //====================================================================================================================
   template<concepts::identifier... Ts>
-  requires(all_uniques_v<Ts...>)
+  requires(kumi::all_uniques_v<Ts...>)
   [[nodiscard]] KUMI_ABI consteval auto identifiers(Ts...) noexcept
   {
-    return projection_map<Ts{}...>{};
+    return kumi::projection_map<Ts{}...>{};
   }
 
   //====================================================================================================================
   // Specialisation to clearly signal errors due invalid projections
   //====================================================================================================================
   template<auto... Vs>
-  requires(!concepts::projection<decltype(Vs)> && ...)
+  requires(!kumi::concepts::projection<decltype(Vs)> && ...)
   struct projection_map<Vs...>
   {
-    static_assert((concepts::projection<decltype(Vs)> && ...), "Invalid projections in projection_map definition");
+    static_assert((kumi::concepts::projection<decltype(Vs)> && ...),
+                  "Invalid projections in projection_map definition");
     projection_map(decltype(Vs)...) = delete;
   };
 }

--- a/include/kumi/utils/traits.hpp
+++ b/include/kumi/utils/traits.hpp
@@ -304,7 +304,7 @@ namespace kumi
       else if constexpr (kumi::size_v<T> == 1) return true;
       else
         return []<std::size_t... I>(std::index_sequence<I...>) {
-          return kumi::_::all_the_same<element_t<I, T>...>;
+          return kumi::_::all_the_same<kumi::element_t<I, T>...>;
         }(std::make_index_sequence<kumi::size_v<T>>{});
     }
 
@@ -600,7 +600,7 @@ namespace kumi
   };
 
   template<typename T, typename U>
-  using is_equivalent_t = typename kumi::is_equivalent<std::make_index_sequence<size_v<T>>, T, U>::type;
+  using is_equivalent_t = typename kumi::is_equivalent<std::make_index_sequence<kumi::size_v<T>>, T, U>::type;
 
   template<typename T, typename U> inline constexpr bool is_equivalent_v = kumi::is_equivalent_t<T, U>::value;
 
@@ -640,11 +640,11 @@ namespace kumi
 
   template<std::size_t... Is, typename T, typename U>
   requires(kumi::is_record_type_v<T> && kumi::is_record_type_v<U> && kumi::size_v<T> == kumi::size_v<U>)
-  struct is_equality_comparable<std::index_sequence<Is...>, T, U> : kumi::_::check_value<element_t<Is, T>>...
+  struct is_equality_comparable<std::index_sequence<Is...>, T, U> : kumi::_::check_value<kumi::element_t<Is, T>>...
   {
-    using kumi::_::check_value<element_t<Is, T>>::get...;
+    using kumi::_::check_value<kumi::element_t<Is, T>>::get...;
 
-    static constexpr bool value = (kumi::_::comparable<decltype(get(std::declval<element_t<Is, U>>())),
+    static constexpr bool value = (kumi::_::comparable<decltype(get(std::declval<kumi::element_t<Is, U>>())),
                                                        kumi::_::type_of_t<kumi::element_t<Is, U>>> &&
                                    ...);
     using type = std::bool_constant<(sizeof...(Is) == 0) || value>;
@@ -654,13 +654,14 @@ namespace kumi
   requires(kumi::is_product_type_v<T> && kumi::is_product_type_v<U> &&
            (!kumi::is_record_type_v<U> || !kumi::is_record_type_v<T>) && kumi::size_v<T> == kumi::size_v<U>)
   struct is_equality_comparable<std::index_sequence<Is...>, T, U>
-    : std::bool_constant<(sizeof...(Is) == 0) || (kumi::_::comparable<element_t<Is, T>, kumi::element_t<Is, U>> && ...)>
+    : std::bool_constant<(sizeof...(Is) == 0) ||
+                         (kumi::_::comparable<kumi::element_t<Is, T>, kumi::element_t<Is, U>> && ...)>
   {
   };
 
   template<typename T, typename U>
   using is_equality_comparable_t =
-    typename kumi::is_equality_comparable<std::make_index_sequence<size_v<T>>, T, U>::type;
+    typename kumi::is_equality_comparable<std::make_index_sequence<kumi::size_v<T>>, T, U>::type;
 
   template<typename T, typename U>
   inline constexpr bool is_equality_comparable_v = kumi::is_equality_comparable_t<T, U>::value;
@@ -694,7 +695,7 @@ namespace kumi
     @endcode
   **/
   //====================================================================================================================
-  template<template<typename...> typename Traits, typename T, typename Seq = std::make_index_sequence<size_v<T>>>
+  template<template<typename...> typename Traits, typename T, typename Seq = std::make_index_sequence<kumi::size_v<T>>>
   requires is_product_type_v<std::remove_cvref_t<T>>
   struct apply_traits;
 

--- a/include/kumi/utils/traits.hpp
+++ b/include/kumi/utils/traits.hpp
@@ -27,7 +27,7 @@ namespace kumi
 
     // Concept specifying a type is a standard tuple-like type.
     template<typename T>
-    concept std_tuple_compatible = _::empty_tuple<T> || _::non_empty_tuple<T>;
+    concept std_tuple_compatible = kumi::_::empty_tuple<T> || kumi::_::non_empty_tuple<T>;
 
     //==================================================================================================================
     // Helper concepts for container detection
@@ -45,7 +45,7 @@ namespace kumi
 
     /// Concept for container types providing access to a contiguous block of data
     template<typename T>
-    concept contiguous_container_like = container_like<T> && requires(T const& t) {
+    concept contiguous_container_like = kumi::_::container_like<T> && requires(T const& t) {
       { t.data() };
     };
   }
@@ -70,7 +70,7 @@ namespace kumi
   {
   };
 
-  template<typename T> inline constexpr auto is_product_type_v = is_product_type<T>::value;
+  template<typename T> inline constexpr auto is_product_type_v = kumi::is_product_type<T>::value;
 
   //====================================================================================================================
   /**
@@ -101,7 +101,7 @@ namespace kumi
   {
   };
 
-  template<typename T> inline constexpr auto is_record_type_v = is_record_type<T>::value;
+  template<typename T> inline constexpr auto is_record_type_v = kumi::is_record_type<T>::value;
 
   //====================================================================================================================
   /**
@@ -120,7 +120,7 @@ namespace kumi
   {
   };
 
-  template<typename T> inline constexpr auto size_v = size<T>::value;
+  template<typename T> inline constexpr auto size_v = kumi::size<T>::value;
 
   //====================================================================================================================
   /**
@@ -143,7 +143,7 @@ namespace kumi
   {
   };
 
-  template<std::size_t I, typename T> using element_t = typename element<I, T>::type;
+  template<std::size_t I, typename T> using element_t = typename kumi::element<I, T>::type;
 
   //====================================================================================================================
   /**
@@ -167,7 +167,7 @@ namespace kumi
     using type = decltype(get<I>(std::declval<T&&>()));
   };
 
-  template<std::size_t I, typename T> using member_t = typename member<I, T>::type;
+  template<std::size_t I, typename T> using member_t = typename kumi::member<I, T>::type;
 }
 
 namespace kumi
@@ -194,19 +194,19 @@ namespace kumi
   template<typename T> struct is_container : std::false_type
   {
     using value_type = T;
-    using size = _::invalid;
+    using size = kumi::_::invalid;
   };
 
   template<typename T>
-  requires _::container_like<T>
+  requires kumi::_::container_like<T>
   struct is_container<T> : std::true_type
   {
     using value_type = typename T::value_type;
-    using size = _::invalid;
+    using size = kumi::_::invalid;
   };
 
   template<template<class, std::size_t> typename Container, typename T, std::size_t N>
-  requires _::container_like<Container<T, N>> && (N != static_cast<std::size_t>(-1))
+  requires kumi::_::container_like<Container<T, N>> && (N != static_cast<std::size_t>(-1))
   struct is_container<Container<T, N>> : std::true_type
   {
     using value_type = T;
@@ -219,7 +219,7 @@ namespace kumi
     using size = std::integral_constant<std::size_t, N>;
   };
 
-  template<typename T> inline constexpr auto is_container_v = is_container<T>::value;
+  template<typename T> inline constexpr auto is_container_v = kumi::is_container<T>::value;
 
   //====================================================================================================================
   /**
@@ -237,11 +237,11 @@ namespace kumi
     @endcode
   **/
   //====================================================================================================================
-  template<typename T> struct container_size : is_container<std::remove_cvref_t<T>>::size
+  template<typename T> struct container_size : kumi::is_container<std::remove_cvref_t<T>>::size
   {
   };
 
-  template<typename T> inline constexpr auto container_size_v = container_size<T>::value;
+  template<typename T> inline constexpr auto container_size_v = kumi::container_size<T>::value;
 
   //====================================================================================================================
   /**
@@ -259,12 +259,12 @@ namespace kumi
     @endcode
   **/
   //====================================================================================================================
-  template<typename T> struct container_type : is_container<std::remove_cvref_t<T>>
+  template<typename T> struct container_type : kumi::is_container<std::remove_cvref_t<T>>
   {
-    using type = typename is_container<std::remove_cvref_t<T>>::value_type;
+    using type = typename kumi::is_container<std::remove_cvref_t<T>>::value_type;
   };
 
-  template<typename T> using container_type_t = typename container_type<T>::type;
+  template<typename T> using container_type_t = typename kumi::container_type<T>::type;
 }
 
 namespace kumi
@@ -292,26 +292,26 @@ namespace kumi
 
   // Specific is_homogeneous overload
   template<typename T>
-  requires(is_product_type_v<T>)
+  requires(kumi::is_product_type_v<T>)
   struct is_homogeneous<T>
   {
     static consteval bool check()
     {
       if constexpr (requires { T::is_homogeneous; }) return T::is_homogeneous;
-      else if constexpr (is_record_type_v<T>) return false;
-      else if constexpr (is_container_v<T>) return true;
-      else if constexpr (size_v<T> == 0) return false;
-      else if constexpr (size_v<T> == 1) return true;
+      else if constexpr (kumi::is_record_type_v<T>) return false;
+      else if constexpr (kumi::is_container_v<T>) return true;
+      else if constexpr (kumi::size_v<T> == 0) return false;
+      else if constexpr (kumi::size_v<T> == 1) return true;
       else
         return []<std::size_t... I>(std::index_sequence<I...>) {
-          return _::all_the_same<element_t<I, T>...>;
-        }(std::make_index_sequence<size_v<T>>{});
+          return kumi::_::all_the_same<element_t<I, T>...>;
+        }(std::make_index_sequence<kumi::size_v<T>>{});
     }
 
     static constexpr bool value = check();
   };
 
-  template<typename T> inline constexpr auto is_homogeneous_v = is_homogeneous<T>::value;
+  template<typename T> inline constexpr auto is_homogeneous_v = kumi::is_homogeneous<T>::value;
 
   //====================================================================================================================
   /**
@@ -335,17 +335,17 @@ namespace kumi
   };
 
   template<typename T>
-  requires(_::contiguous_container_like<T>)
+  requires(kumi::_::contiguous_container_like<T>)
   struct has_static_size<T>
   {
-    static constexpr bool value = !std::same_as<typename is_container<T>::size, _::invalid>;
+    static constexpr bool value = !std::same_as<typename kumi::is_container<T>::size, kumi::_::invalid>;
   };
 
   template<typename T, std::size_t N> struct has_static_size<T[N]> : std::true_type
   {
   };
 
-  template<typename T> inline constexpr auto has_static_size_v = has_static_size<T>::value;
+  template<typename T> inline constexpr auto has_static_size_v = kumi::has_static_size<T>::value;
 
   //====================================================================================================================
   /**
@@ -373,7 +373,7 @@ namespace kumi
   {
   };
 
-  template<typename T> inline constexpr auto is_projection_map_v = is_projection_map<T>::value;
+  template<typename T> inline constexpr auto is_projection_map_v = kumi::is_projection_map<T>::value;
 
   //====================================================================================================================
   /**
@@ -395,18 +395,18 @@ namespace kumi
   //====================================================================================================================
   template<std::size_t I, typename T> struct stored_member
   {
-    using type = member_t<I, T>;
+    using type = kumi::member_t<I, T>;
   };
 
   template<std::size_t I, typename T>
-  requires(is_record_type_v<std::remove_cvref_t<T>>)
+  requires(kumi::is_record_type_v<std::remove_cvref_t<T>>)
   struct stored_member<I, T>
   {
     using field_type = decltype(get<I>(std::declval<T&&>()));
     using type = decltype(std::declval<field_type&&>()(typename std::remove_cvref_t<field_type>::identifier_type{}));
   };
 
-  template<std::size_t I, typename T> using stored_member_t = typename stored_member<I, T>::type;
+  template<std::size_t I, typename T> using stored_member_t = typename kumi::stored_member<I, T>::type;
 
   //====================================================================================================================
   /**
@@ -431,17 +431,17 @@ namespace kumi
   //====================================================================================================================
   template<std::size_t I, typename T> struct stored_element
   {
-    using type = element_t<I, T>;
+    using type = kumi::element_t<I, T>;
   };
 
   template<std::size_t I, typename T>
-  requires(is_record_type<std::remove_cvref_t<T>>::value)
+  requires(kumi::is_record_type<std::remove_cvref_t<T>>::value)
   struct stored_element<I, T>
   {
-    using type = typename element_t<I, T>::type;
+    using type = typename kumi::element_t<I, T>::type;
   };
 
-  template<std::size_t I, typename T> using stored_element_t = typename stored_element<I, T>::type;
+  template<std::size_t I, typename T> using stored_element_t = typename kumi::stored_element<I, T>::type;
 
   //====================================================================================================================
   /**
@@ -478,20 +478,21 @@ namespace kumi
 
   template<std::size_t... Ints, typename... Ts> struct all_uniques<std::index_sequence<Ints...>, Ts...>
   {
-    struct all_uniques_inner : _::unique<Ints, Ts>...
+    struct all_uniques_inner : kumi::_::unique<Ints, Ts>...
     {
     };
 
     template<typename... Us>
-    static consteval auto is_set(Us...) -> decltype(_::true_fn(static_cast<Us>(all_uniques_inner())...));
+    static consteval auto is_set(Us...) -> decltype(kumi::_::true_fn(static_cast<Us>(all_uniques_inner())...));
     static consteval std::false_type is_set(...);
 
     using type = decltype(is_set(std::type_identity<Ts>{}...));
   };
 
-  template<typename... Ts> using all_uniques_t = typename all_uniques<std::index_sequence_for<Ts...>, Ts...>::type;
+  template<typename... Ts>
+  using all_uniques_t = typename kumi::all_uniques<std::index_sequence_for<Ts...>, Ts...>::type;
 
-  template<typename... Ts> inline constexpr auto all_uniques_v = all_uniques_t<Ts...>::value;
+  template<typename... Ts> inline constexpr auto all_uniques_v = kumi::all_uniques_t<Ts...>::value;
 
   //====================================================================================================================
   /**
@@ -529,21 +530,21 @@ namespace kumi
 
   template<std::size_t... Ints, typename... Ts> struct all_unique_names<std::index_sequence<Ints...>, Ts...>
   {
-    struct all_uniques_inner : _::unique_name<Ints, Ts>...
+    struct all_uniques_inner : kumi::_::unique_name<Ints, Ts>...
     {
     };
 
     template<typename... Us>
-    static consteval auto is_set(Us...) -> decltype(_::true_fn(static_cast<Us>(all_uniques_inner())...));
+    static consteval auto is_set(Us...) -> decltype(kumi::_::true_fn(static_cast<Us>(all_uniques_inner())...));
     static consteval std::false_type is_set(...);
 
-    using type = decltype(is_set(_::get_key<Ints, Ts>()...));
+    using type = decltype(is_set(kumi::_::get_key<Ints, Ts>()...));
   };
 
   template<typename... Ts>
-  using all_unique_names_t = typename all_unique_names<std::index_sequence_for<Ts...>, Ts...>::type;
+  using all_unique_names_t = typename kumi::all_unique_names<std::index_sequence_for<Ts...>, Ts...>::type;
 
-  template<typename... Ts> inline constexpr auto all_unique_names_v = all_unique_names_t<Ts...>::value;
+  template<typename... Ts> inline constexpr auto all_unique_names_v = kumi::all_unique_names_t<Ts...>::value;
 
   //====================================================================================================================
   /**
@@ -581,27 +582,27 @@ namespace kumi
   };
 
   template<std::size_t... Is, typename T, typename U>
-  requires(is_product_type_v<T> && is_product_type_v<U> && size_v<T> == size_v<U>)
+  requires(kumi::is_product_type_v<T> && kumi::is_product_type_v<U> && kumi::size_v<T> == kumi::size_v<U>)
   struct is_equivalent<std::index_sequence<Is...>, T, U>
   {
-    struct match : _::unique_name<Is, element_t<Is, U>>...
+    struct match : kumi::_::unique_name<Is, kumi::element_t<Is, U>>...
     {
     };
 
     template<typename... Key>
     requires(sizeof...(Is) != 0)
-    static consteval auto is_present(Key...) -> decltype(_::true_fn(static_cast<Key>(std::declval<match>())...));
+    static consteval auto is_present(Key...) -> decltype(kumi::_::true_fn(static_cast<Key>(std::declval<match>())...));
     static consteval std::false_type is_present(...);
     static consteval std::true_type is_present(...)
     requires(sizeof...(Is) == 0);
 
-    using type = decltype(is_present(_::get_key<Is, element_t<Is, T>>()...));
+    using type = decltype(is_present(kumi::_::get_key<Is, kumi::element_t<Is, T>>()...));
   };
 
   template<typename T, typename U>
-  using is_equivalent_t = typename is_equivalent<std::make_index_sequence<size_v<T>>, T, U>::type;
+  using is_equivalent_t = typename kumi::is_equivalent<std::make_index_sequence<size_v<T>>, T, U>::type;
 
-  template<typename T, typename U> inline constexpr bool is_equivalent_v = is_equivalent_t<T, U>::value;
+  template<typename T, typename U> inline constexpr bool is_equivalent_v = kumi::is_equivalent_t<T, U>::value;
 
   //====================================================================================================================
   /**
@@ -638,29 +639,31 @@ namespace kumi
   };
 
   template<std::size_t... Is, typename T, typename U>
-  requires(is_record_type_v<T> && is_record_type_v<U> && size_v<T> == size_v<U>)
-  struct is_equality_comparable<std::index_sequence<Is...>, T, U> : _::check_value<element_t<Is, T>>...
+  requires(kumi::is_record_type_v<T> && kumi::is_record_type_v<U> && kumi::size_v<T> == kumi::size_v<U>)
+  struct is_equality_comparable<std::index_sequence<Is...>, T, U> : kumi::_::check_value<element_t<Is, T>>...
   {
-    using _::check_value<element_t<Is, T>>::get...;
+    using kumi::_::check_value<element_t<Is, T>>::get...;
 
-    static constexpr bool value =
-      (_::comparable<decltype(get(std::declval<element_t<Is, U>>())), _::type_of_t<element_t<Is, U>>> && ...);
+    static constexpr bool value = (kumi::_::comparable<decltype(get(std::declval<element_t<Is, U>>())),
+                                                       kumi::_::type_of_t<kumi::element_t<Is, U>>> &&
+                                   ...);
     using type = std::bool_constant<(sizeof...(Is) == 0) || value>;
   };
 
   template<std::size_t... Is, typename T, typename U>
-  requires(is_product_type_v<T> && is_product_type_v<U> && (!is_record_type_v<U> || !is_record_type_v<T>) &&
-           size_v<T> == size_v<U>)
+  requires(kumi::is_product_type_v<T> && kumi::is_product_type_v<U> &&
+           (!kumi::is_record_type_v<U> || !kumi::is_record_type_v<T>) && kumi::size_v<T> == kumi::size_v<U>)
   struct is_equality_comparable<std::index_sequence<Is...>, T, U>
-    : std::bool_constant<(sizeof...(Is) == 0) || (_::comparable<element_t<Is, T>, element_t<Is, U>> && ...)>
+    : std::bool_constant<(sizeof...(Is) == 0) || (kumi::_::comparable<element_t<Is, T>, kumi::element_t<Is, U>> && ...)>
   {
   };
 
   template<typename T, typename U>
-  using is_equality_comparable_t = typename is_equality_comparable<std::make_index_sequence<size_v<T>>, T, U>::type;
+  using is_equality_comparable_t =
+    typename kumi::is_equality_comparable<std::make_index_sequence<size_v<T>>, T, U>::type;
 
   template<typename T, typename U>
-  inline constexpr bool is_equality_comparable_v = is_equality_comparable_t<T, U>::value;
+  inline constexpr bool is_equality_comparable_v = kumi::is_equality_comparable_t<T, U>::value;
 
   //====================================================================================================================
   /**
@@ -696,15 +699,15 @@ namespace kumi
   struct apply_traits;
 
   template<template<typename...> typename Traits, typename T, std::size_t... Is>
-  requires is_product_type_v<std::remove_cvref_t<T>> && (requires { typename Traits<element_t<Is, T>...>::type; })
+  requires is_product_type_v<std::remove_cvref_t<T>> && (requires { typename Traits<kumi::element_t<Is, T>...>::type; })
   struct apply_traits<Traits, T, std::index_sequence<Is...>>
   {
-    using type = typename Traits<element_t<Is, T>...>::type;
+    using type = typename Traits<kumi::element_t<Is, T>...>::type;
   };
 
   template<template<typename...> typename Traits, typename T>
-  requires is_product_type_v<std::remove_cvref_t<T>>
-  using apply_traits_t = typename apply_traits<Traits, T>::type;
+  requires kumi::is_product_type_v<std::remove_cvref_t<T>>
+  using apply_traits_t = typename kumi::apply_traits<Traits, T>::type;
 
   //====================================================================================================================
   /**
@@ -735,20 +738,21 @@ namespace kumi
     @endcode
   **/
   //====================================================================================================================
-  template<template<typename...> typename Traits, typename T, typename Seq = std::make_index_sequence<size_v<T>>>
-  requires is_product_type_v<std::remove_cvref_t<T>>
+  template<template<typename...> typename Traits, typename T, typename Seq = std::make_index_sequence<kumi::size_v<T>>>
+  requires kumi::is_product_type_v<std::remove_cvref_t<T>>
   struct map_traits;
 
   template<template<typename...> typename Traits, typename T, std::size_t... Is>
-  requires is_product_type_v<std::remove_cvref_t<T>> && (requires { typename Traits<element_t<Is, T>>::type; } && ...)
+  requires kumi::is_product_type_v<std::remove_cvref_t<T>> &&
+           (requires { typename Traits<kumi::element_t<Is, T>>::type; } && ...)
   struct map_traits<Traits, T, std::index_sequence<Is...>>
   {
-    using type = builder_make_t<T, typename Traits<element_t<Is, T>>::type...>;
+    using type = builder_make_t<T, typename Traits<kumi::element_t<Is, T>>::type...>;
   };
 
   template<template<typename...> typename Traits, typename T>
-  requires is_product_type_v<std::remove_cvref_t<T>>
-  using map_traits_t = typename map_traits<Traits, T>::type;
+  requires kumi::is_product_type_v<std::remove_cvref_t<T>>
+  using map_traits_t = typename kumi::map_traits<Traits, T>::type;
 }
 
 namespace kumi
@@ -756,14 +760,14 @@ namespace kumi
 #ifndef KUMI_DOXYGEN_INVOKED
   // A type with the tuple interface is automatically a product_type
   template<typename T>
-  requires(_::std_tuple_compatible<T>)
+  requires(kumi::_::std_tuple_compatible<T>)
   struct is_product_type<T> : std::true_type
   {
   };
 
   // A static container with tuple interface is indeed a product_type
   template<typename T>
-  requires(is_container_v<T> && has_static_size_v<T> && _::std_tuple_compatible<T>)
+  requires(kumi::is_container_v<T> && kumi::has_static_size_v<T> && kumi::_::std_tuple_compatible<T>)
   struct is_product_type<T> : std::true_type
   {
   };
@@ -782,7 +786,7 @@ namespace kumi
   {
   };
 
-  template<typename T> inline constexpr bool is_kumi_tuple_v = is_kumi_tuple<T>::value;
+  template<typename T> inline constexpr bool is_kumi_tuple_v = kumi::is_kumi_tuple<T>::value;
 
   template<typename T> struct is_kumi_record : std::false_type
   {
@@ -792,6 +796,6 @@ namespace kumi
   {
   };
 
-  template<typename T> inline constexpr bool is_kumi_record_v = is_kumi_record<T>::value;
+  template<typename T> inline constexpr bool is_kumi_record_v = kumi::is_kumi_record<T>::value;
 #endif
 }

--- a/include/kumi/utils/unit_type.hpp
+++ b/include/kumi/utils/unit_type.hpp
@@ -25,14 +25,14 @@ namespace kumi
 
     template<typename T>
     [[nodiscard]] KUMI_ABI constexpr operator T() const noexcept
-    requires(concepts::unit_type<T>)
+    requires(kumi::concepts::unit_type<T>)
     {
       return {};
     }
 
     template<typename T>
     [[nodiscard]] KUMI_ABI constexpr operator T() noexcept
-    requires(concepts::unit_type<T>)
+    requires(kumi::concepts::unit_type<T>)
     {
       return {};
     }
@@ -50,5 +50,5 @@ namespace kumi
     @brief Inline constant representing a kumi::unit.
   **/
   //====================================================================================================================
-  inline constexpr unit none = {};
+  inline constexpr kumi::unit none{};
 }


### PR DESCRIPTION
This PR aims at fixing lookup of functions/traits inside the library. This was brought up due to collisions with `std::bind_front`.
  
- Functions not requiring ADL are now fully qualified
- Traits/concepts/meta functions that are specific to kumi are fully qualified
