### PR TITLE
Feat: compress algorithm

### DIFF
--- a/include/kumi/algorithm/flatten.hpp
+++ b/include/kumi/algorithm/flatten.hpp
@@ -59,7 +59,41 @@ namespace kumi
     {
       return kumi::builder<T>::make(visitor(KUMI_FWD(t), get<I>(KUMI_FWD(t)), f, self)...);
     }
+
+    template<typename E, std::size_t... I>
+    KUMI_ABI constexpr auto compress_(kumi::_::adl_tag_t, E&& e, std::index_sequence<I...>)
+    {
+      using V = kumi::result::field_value_of_t<E>;
+      if constexpr (sizeof...(I) == 0 || kumi::concepts::empty_product_type<V>) return kumi::builder<V>::make();
+      else
+      {
+        constexpr auto outer = kumi::label_of<E>();
+        return kumi::builder<V>::make(
+          kumi::capture_field<kumi::name<outer + kumi::label_of<kumi::element_t<I, V>>()>{}>(
+            kumi::field_value_of(get<I>(kumi::field_value_of(KUMI_FWD(e)))))...);
+      }
+    }
   }
+
+  struct compress_t
+  {
+    template<kumi::concepts::product_type T> [[nodiscard]] KUMI_ABI constexpr auto operator()(T&& t) const
+    {
+      if constexpr (kumi::concepts::empty_product_type<T>) return KUMI_FWD(t);
+      else
+      {
+        using V = kumi::result::field_value_of_t<kumi::element_t<0, T>>;
+        if constexpr (kumi::concepts::sized_product_type<T, 1> && kumi::concepts::follows_same_semantic<T, V>)
+        {
+          if constexpr (kumi::concepts::record_type<T>)
+            return (*this)(
+              compress_(kumi::_::adl_tag, get<0>(KUMI_FWD(t)), std::make_index_sequence<kumi::size_v<V>>{}));
+          else return (*this)(get<0>(KUMI_FWD(t)));
+        }
+        else return KUMI_FWD(t);
+      }
+    }
+  };
 
   struct flatten_t
   {
@@ -105,6 +139,62 @@ namespace kumi
       return this->flatten_all_t::operator()(KUMI_FWD(t), [](auto& m) { return &m; });
     }
   };
+
+  //====================================================================================================================
+  /**
+    @ingroup generators
+
+    @var compress
+    @brief Callable object converting a product type of product type into a single product type recursively, or returns
+    the input.
+
+    This construction naturally arises from the definition of product types, a product type of the form T(T(x...)) is
+    strictly equivalent to T(x...) as long as the T is the same type.
+
+    On record types, the names of the outer record are concatenated to the inner ones ultimately constructing names
+    such as "outer.inner". If the input is a product type containing record types or vice versa only the inner types
+    matching the outer semantic will be compressed. Thus a record inside a tuple will not be compressed.
+
+    @qualifier nodiscard
+    @qualifier inline
+    @qualifier constexpr
+
+    @groupheader{Header file}
+    @code
+    #include <kumi/algorithm/flatten.hpp>
+    @endcode
+
+    @groupheader{Call Signature}
+
+    @code
+      template<product_type T>
+      constexpr auto compress(T && t) noexcept;
+    @endcode
+
+    @subgroupheader{Parameters}
+
+      - `t`: Product type to process
+
+    @subgroupheader{Return value}
+
+      - The resulting value of the application of `T0(...(Tn(values))) => T(values)`
+
+    @groupheader{Helper type}
+
+    @snippet include/kumi/algorithm/flatten.hpp compress_t
+
+    Computes the return type of a call to kumi::compress
+
+    @groupheader{Examples}
+
+    @subgroupheader{Tuple}
+    @godbolt{doc/tuple/algo/compress.cpp}
+
+    @subgroupheader{Record}
+    @godbolt{doc/record/algo/compress.cpp}
+  **/
+  //====================================================================================================================
+  inline constexpr compress_t compress{};
 
   //====================================================================================================================
   /**
@@ -275,6 +365,16 @@ namespace kumi
 
   namespace result
   {
+    //! [compress_t]
+    template<kumi::concepts::product_type T> struct compress
+    {
+      using type = decltype(kumi::compress(std::declval<T>()));
+    };
+
+    template<kumi::concepts::product_type T> using compress_t = typename kumi::result::compress<T>::type;
+
+    //! [compress_t]
+
     //! [flatten_t]
     template<kumi::concepts::product_type T> struct flatten
     {

--- a/test/doc/record/algo/compress.cpp
+++ b/test/doc/record/algo/compress.cpp
@@ -1,0 +1,21 @@
+/**
+  KUMI - Compact Tuple Tools
+  Copyright : KUMI Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+#include <kumi/kumi.hpp>
+#include <iostream>
+
+int main()
+{
+  using namespace kumi::literals;
+
+  auto r      = kumi::record{"a"_id = 1,"b"_id = 2, "c"_id = 3};
+  auto nest_1 = kumi::record{"e"_id = r};
+  auto nest_2 = kumi::record{"f"_id = nest_1};
+
+  auto r2 = kumi::record{"g"_id = nest_1, "h"_id = nest_2};
+
+  std::cout << kumi::compress( nest_2 ) << "\n";
+  std::cout << kumi::compress( r2 ) << "\n";
+}

--- a/test/doc/tuple/algo/compress.cpp
+++ b/test/doc/tuple/algo/compress.cpp
@@ -1,0 +1,19 @@
+/**
+  KUMI - Compact Tuple Tools
+  Copyright : KUMI Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+#include <kumi/kumi.hpp>
+#include <iostream>
+
+int main()
+{
+  auto t      = kumi::tuple{1,2,3};
+  auto nest_1 = kumi::tuple{t};
+  auto nest_2 = kumi::tuple{nest_1};
+
+  auto t2 = kumi::tuple{nest_1, nest_2};
+
+  std::cout << kumi::compress( nest_2 ) << "\n";
+  std::cout << kumi::compress( t2 ) << "\n";
+}

--- a/test/unit/record/algo/compress.cpp
+++ b/test/unit/record/algo/compress.cpp
@@ -1,0 +1,95 @@
+//==================================================================================================
+/*
+  KUMI - Compact Tuple Tools
+  Copyright : KUMI Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#define TTS_MAIN
+#include <kumi/record.hpp>
+#include <kumi/algorithm/flatten.hpp>
+#include <tts/tts.hpp>
+#include "test.hpp"
+
+TTS_CASE("Check kumi::result::compress behavior on records")
+{
+  using char_f = kumi::field<kumi::name<"a">, char>;
+  using short_f = kumi::field<kumi::name<"b">, short>;
+  using int_f = kumi::field<kumi::name<"c">, int>;
+  using double_f = kumi::field<kumi::name<"d">, double>;
+
+  TTS_TYPE_IS((kumi::result::compress_t<kumi::record<>>), (kumi::record<>));
+
+  TTS_TYPE_IS((kumi::result::compress_t<kumi::record<kumi::field<kumi::name<"a">, kumi::record<>>>>), (kumi::record<>));
+
+  TTS_TYPE_IS(
+    (kumi::result::compress_t<kumi::record<kumi::field<
+       kumi::name<"a">, kumi::record<kumi::field<kumi::name<"b">, kumi::record<double_f, char_f, short_f>>>>>>),
+    (kumi::record<kumi::field<kumi::name<"a.b.d">, double>, kumi::field<kumi::name<"a.b.a">, char>,
+                  kumi::field<kumi::name<"a.b.b">, short>>));
+
+  TTS_TYPE_IS((kumi::result::compress_t<kumi::record<char_f, short_f, int_f, double_f>>),
+              (kumi::record<char_f, short_f, int_f, double_f>));
+
+  TTS_TYPE_IS(
+    (kumi::result::compress_t<kumi::record<
+       char_f, kumi::field<kumi::name<"b">,
+                           kumi::record<short_f, int_f, kumi::field<kumi::name<"f">, kumi::record<double_f>>>>>>),
+    (kumi::record<char_f,
+                  kumi::field<kumi::name<"b">,
+                              kumi::record<short_f, int_f, kumi::field<kumi::name<"f">, kumi::record<double_f>>>>>));
+};
+
+TTS_CASE("Check kumi::compress behavior on records")
+{
+  using namespace kumi::literals;
+
+  auto t0 = kumi::record{};
+  auto t1 = kumi::record{"a"_id = 2., "b"_id = 1, "c"_id = short{55}};
+  auto t2 = kumi::record{"a"_id = kumi::record{"b"_id = 2., "c"_id = 1, "d"_id = short{55}}};
+  auto t3 = kumi::record{"a"_id = kumi::record{"b"_id = kumi::record{"c"_id = 2., "d"_id = 1, "e"_id = short{55}}}};
+  auto t4 =
+    kumi::record{"a"_id = 3.25f, "b"_id = kumi::record{"c"_id = 2., "d"_id = 1, "e"_id = short{55}}, "f"_id = 'z'};
+  auto t5 =
+    kumi::record{"a"_id = 3.25f,
+                 "b"_id = kumi::record{"c"_id = 2., "d"_id = kumi::record{"e"_id = 2., "f"_id = 1, "g"_id = short{55}},
+                                       "h"_id = short{55}},
+                 "i"_id = 'z'};
+
+  TTS_EQUAL(kumi::compress(t0), t0);
+  TTS_EQUAL((kumi::compress(t1)), (t1));
+  TTS_EQUAL((kumi::compress(t2)), (kumi::record{"a.b"_id = 2., "a.c"_id = 1, "a.d"_id = short{55}}));
+  TTS_EQUAL((kumi::compress(t3)), (kumi::record{"a.b.c"_id = 2., "a.b.d"_id = 1, "a.b.e"_id = short{55}}));
+
+  TTS_EQUAL((kumi::compress(t4)), (t4));
+  TTS_EQUAL((kumi::compress(t5)), (t5));
+
+  auto r = kumi::record{"a"_id = 1.f, "b"_id = 'x', "c"_id = short{66}, "d"_id = moveonly{}};
+  TTS_EXPECT_COMPILES(r, { kumi::compress(std::move(r)); });
+};
+
+TTS_CASE("Check kumi::compress constexpr behavior on records")
+{
+  using namespace kumi::literals;
+
+  constexpr auto t0 = kumi::record{};
+  constexpr auto t1 = kumi::record{"a"_id = 2., "b"_id = 1, "c"_id = short{55}};
+  constexpr auto t2 = kumi::record{"a"_id = kumi::record{"b"_id = 2., "c"_id = 1, "d"_id = short{55}}};
+  constexpr auto t3 =
+    kumi::record{"a"_id = kumi::record{"b"_id = kumi::record{"c"_id = 2., "d"_id = 1, "e"_id = short{55}}}};
+  constexpr auto t4 =
+    kumi::record{"a"_id = 3.25f, "b"_id = kumi::record{"c"_id = 2., "d"_id = 1, "e"_id = short{55}}, "f"_id = 'z'};
+  constexpr auto t5 =
+    kumi::record{"a"_id = 3.25f,
+                 "b"_id = kumi::record{"c"_id = 2., "d"_id = kumi::record{"e"_id = 2., "f"_id = 1, "g"_id = short{55}},
+                                       "h"_id = short{55}},
+                 "i"_id = 'z'};
+
+  TTS_CONSTEXPR_EQUAL(kumi::compress(t0), t0);
+  TTS_CONSTEXPR_EQUAL((kumi::compress(t1)), (t1));
+  TTS_CONSTEXPR_EQUAL((kumi::compress(t2)), (kumi::record{"a.b"_id = 2., "a.c"_id = 1, "a.d"_id = short{55}}));
+  TTS_CONSTEXPR_EQUAL((kumi::compress(t3)), (kumi::record{"a.b.c"_id = 2., "a.b.d"_id = 1, "a.b.e"_id = short{55}}));
+
+  TTS_CONSTEXPR_EQUAL((kumi::compress(t4)), (t4));
+  TTS_CONSTEXPR_EQUAL((kumi::compress(t5)), (t5));
+};

--- a/test/unit/tuple/algo/compress.cpp
+++ b/test/unit/tuple/algo/compress.cpp
@@ -1,0 +1,59 @@
+//==================================================================================================
+/*
+  KUMI - Compact Tuple Tools
+  Copyright : KUMI Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#define TTS_MAIN
+#include <kumi/tuple.hpp>
+#include <kumi/algorithm/flatten.hpp>
+#include <tts/tts.hpp>
+#include "test.hpp"
+
+TTS_CASE("Check kumi::result::compress behavior on tuples")
+{
+  TTS_TYPE_IS((kumi::result::compress_t<kumi::tuple<>>), (kumi::tuple<>));
+
+  TTS_TYPE_IS((kumi::result::compress_t<kumi::tuple<kumi::tuple<>>>), (kumi::tuple<>));
+
+  TTS_TYPE_IS((kumi::result::compress_t<kumi::tuple<kumi::tuple<kumi::tuple<double, char, short>>>>),
+              (kumi::tuple<double, char, short>));
+
+  TTS_TYPE_IS((kumi::result::compress_t<kumi::tuple<char, short, int, double>>),
+              (kumi::tuple<char, short, int, double>));
+
+  TTS_TYPE_IS((kumi::result::compress_t<kumi::tuple<char, kumi::tuple<short, int, kumi::tuple<double>>>>),
+              (kumi::tuple<char, kumi::tuple<short, int, kumi::tuple<double>>>));
+};
+
+TTS_CASE("Check kumi::compress behavior on tuples")
+{
+  TTS_EQUAL(kumi::compress(kumi::tuple{}), kumi::tuple{});
+  TTS_EQUAL((kumi::compress(kumi::tuple{2., 1, short{55}})), (kumi::tuple{2., 1, short{55}}));
+  TTS_EQUAL((kumi::compress(kumi::tuple{kumi::tuple{2., 1, short{55}}})), (kumi::tuple{2., 1, short{55}}));
+  TTS_EQUAL((kumi::compress(kumi::tuple{kumi::tuple{kumi::tuple{2., 1, short{55}}}})), (kumi::tuple{2., 1, short{55}}));
+  TTS_EQUAL((kumi::compress(kumi::tuple{3.25f, kumi::tuple{2., 1, short{55}}, 'z'})),
+            (kumi::tuple{3.25f, kumi::tuple{2., 1, short{55}}, 'z'}));
+  TTS_EQUAL((kumi::compress(kumi::tuple{3.25f, kumi::tuple{2., kumi::tuple{2., 1, short{55}}, short{55}}, 'z'})),
+            (kumi::tuple{3.25f, kumi::tuple{2., kumi::tuple{2., 1, short{55}}, short{55}}, 'z'}));
+
+  auto t = kumi::tuple{1.f, 'x', short{66}, moveonly{}};
+  TTS_EXPECT_COMPILES(t, { kumi::compress(std::move(t)); });
+};
+
+TTS_CASE("Check kumi::compress constexpr behavior on tuples")
+{
+  constexpr auto t0 = kumi::tuple{2., 1, short{55}};
+  constexpr auto t1 = kumi::tuple{kumi::tuple{2., 1, short{55}}};
+  constexpr auto t2 = kumi::tuple{kumi::tuple{kumi::tuple{2., 1, short{55}}}};
+  constexpr auto t3 = kumi::tuple{3.25f, kumi::tuple{2., 1, short{55}}, 'z'};
+  constexpr auto t4 = kumi::tuple{3.25f, kumi::tuple{2., kumi::tuple{2., 1, short{55}}, short{55}}, 'z'};
+
+  TTS_CONSTEXPR_EQUAL(kumi::compress(kumi::tuple{}), kumi::tuple{});
+  TTS_CONSTEXPR_EQUAL(kumi::compress(t0), (kumi::tuple{2., 1, short{55}}));
+  TTS_CONSTEXPR_EQUAL(kumi::compress(t1), (kumi::tuple{2., 1, short{55}}));
+  TTS_CONSTEXPR_EQUAL(kumi::compress(t2), (kumi::tuple{2., 1, short{55}}));
+  TTS_CONSTEXPR_EQUAL(kumi::compress(t3), (t3));
+  TTS_CONSTEXPR_EQUAL(kumi::compress(t4), (t4));
+};


### PR DESCRIPTION
The branch is based on [PR 210](https://github.com/jfalcou/kumi/pull/210) and will need to be merged afterwards.

Sometimes it is usefull to flatten product types if an only if the outer containers is matching the inner one but not expanding it to tuples of multi arguments. Thus a specific algorithm is required to do the following operation :
`T(T(...T(value))) => T(values)` where T is flatten iff it s a tuple of size one containing an other tuple. It can be expanded recursively naturally.