### PR TITLE
Algorithms clean up & enhancement

### DIFF
--- a/include/kumi/algorithm/cartesian_product.hpp
+++ b/include/kumi/algorithm/cartesian_product.hpp
@@ -30,7 +30,7 @@ namespace kumi
       else
       {
         constexpr auto sq = std::make_index_sequence<(kumi::size_v<Ts> * ...)>{};
-        constexpr auto idx = kumi::function::cartesian_producer(sq, kumi::index<kumi::size_v<Ts>>...);
+        constexpr auto idx = kumi::function::cartesian_producer(kumi::index<kumi::size_v<Ts>>...);
         return cartesian_product_(kumi::_::adl_tag, kumi::forward_as_tuple(KUMI_FWD(ts)...), idx, sq);
       }
     }

--- a/include/kumi/algorithm/cat.hpp
+++ b/include/kumi/algorithm/cat.hpp
@@ -18,7 +18,7 @@ namespace kumi
       if constexpr (sizeof...(Ts) == 0) return kumi::tuple{};
       else
       {
-        constexpr auto pos = kumi::function::concatenater(std::index_sequence<kumi::size_v<Ts>...>{});
+        constexpr auto pos = kumi::function::concatenater(kumi::index<kumi::size_v<Ts>>...);
         return kumi::function::builder(kumi::forward_as_tuple(KUMI_FWD(ts)...), get<1>(pos), get<0>(pos));
       }
     }

--- a/include/kumi/algorithm/extract.hpp
+++ b/include/kumi/algorithm/extract.hpp
@@ -11,49 +11,65 @@ namespace kumi
 {
   struct extract_t
   {
-    template<kumi::concepts::product_type T, std::size_t I0, std::size_t I1>
-    [[nodiscard]] KUMI_ABI constexpr auto operator()(T&& t, kumi::index_t<I0>, kumi::index_t<I1>) const noexcept
+    template<kumi::concepts::product_type T, std::size_t B, std::size_t E, std::size_t S>
+    [[nodiscard]] KUMI_ABI constexpr auto operator()(T&& t,
+                                                     kumi::index_t<B> b,
+                                                     kumi::index_t<E>,
+                                                     kumi::index_t<S> s) const noexcept
     {
-      static_assert((I0 <= kumi::size_v<T>) && (I1 <= kumi::size_v<T>), "[KUMI] - Invalid index");
-      return kumi::function::builder(KUMI_FWD(t), kumi::function::shifter(std::integral_constant<std::size_t, I0>{},
-                                                                          std::make_index_sequence<I1 - I0>{}));
+      static_assert((B <= kumi::size_v<T>) && (E <= kumi::size_v<T>), "[KUMI] - Invalid index");
+      return kumi::function::builder(KUMI_FWD(t), kumi::function::slicer(b, kumi::index<E>, s));
     }
 
-    template<kumi::concepts::product_type T, std::size_t I>
-    [[nodiscard]] KUMI_ABI constexpr auto operator()(T&& t, kumi::index_t<I> i) const noexcept
+    template<kumi::concepts::product_type T, std::size_t B, std::size_t E>
+    [[nodiscard]] KUMI_ABI constexpr auto operator()(T&& t, kumi::index_t<B> b, kumi::index_t<E>) const noexcept
     {
-      static_assert(I <= kumi::size_v<T>, "[KUMI] - Invalid index");
-      return (*this)(KUMI_FWD(t), i, kumi::index<size_v<T>>);
+      static_assert((B <= kumi::size_v<T>) && (E <= kumi::size_v<T>), "[KUMI] - Invalid index");
+      return kumi::function::builder(KUMI_FWD(t), kumi::function::slicer(b, kumi::index<E>));
+    }
+
+    template<kumi::concepts::product_type T, std::size_t B>
+    [[nodiscard]] KUMI_ABI constexpr auto operator()(T&& t, kumi::index_t<B> b) const noexcept
+    {
+      static_assert(B <= kumi::size_v<T>, "[KUMI] - Invalid index");
+      return (*this)(KUMI_FWD(t), b, kumi::index<size_v<T>>);
     }
   };
 
   struct remove_t
   {
-    template<kumi::concepts::product_type T, std::size_t I0, std::size_t I1>
-    [[nodiscard]] KUMI_ABI constexpr auto operator()(T&& t, kumi::index_t<I0>, kumi::index_t<I1>) const noexcept
+    template<kumi::concepts::product_type T, std::size_t B, std::size_t E, std::size_t S>
+    [[nodiscard]] KUMI_ABI constexpr auto operator()(T&& t,
+                                                     kumi::index_t<B> b,
+                                                     kumi::index_t<E> e,
+                                                     kumi::index_t<S> s) const noexcept
     {
-      static_assert((I0 <= kumi::size_v<T>) && (I1 <= kumi::size_v<T>), "[KUMI] - Invalid index");
-      return kumi::function::builder(
-        KUMI_FWD(t),
-        kumi::function::extractor(std::integral_constant<std::size_t, I0>{}, std::integral_constant<std::size_t, I1>{},
-                                  std::make_index_sequence<kumi::size_v<T> - (I1 - I0)>{}));
+      static_assert((B <= kumi::size_v<T>) && (E <= kumi::size_v<T>), "[KUMI] - Invalid index");
+      return kumi::function::builder(KUMI_FWD(t), kumi::function::extractor(b, e, kumi::index<kumi::size_v<T>>, s));
     }
 
-    template<kumi::concepts::product_type T, std::size_t I>
-    [[nodiscard]] KUMI_ABI constexpr auto operator()(T&& t, kumi::index_t<I> i) const noexcept
+    template<kumi::concepts::product_type T, std::size_t B, std::size_t E>
+    [[nodiscard]] KUMI_ABI constexpr auto operator()(T&& t, kumi::index_t<B> b, kumi::index_t<E> e) const noexcept
     {
-      static_assert(I <= kumi::size_v<T>, "[KUMI] - Invalid index");
-      return (*this)(KUMI_FWD(t), i, kumi::index<kumi::size_v<T>>);
+      static_assert((B <= kumi::size_v<T>) && (E <= kumi::size_v<T>), "[KUMI] - Invalid index");
+      return kumi::function::builder(KUMI_FWD(t), kumi::function::extractor(b, e, kumi::index<kumi::size_v<T>>));
+    }
+
+    template<kumi::concepts::product_type T, std::size_t B>
+    [[nodiscard]] KUMI_ABI constexpr auto operator()(T&& t, kumi::index_t<B> b) const noexcept
+    {
+      static_assert(B <= kumi::size_v<T>, "[KUMI] - Invalid index");
+      return (*this)(KUMI_FWD(t), b, kumi::index<kumi::size_v<T>>);
     }
   };
 
   struct split_t
   {
     template<kumi::concepts::product_type T, std::size_t I0>
-    [[nodiscard]] KUMI_ABI constexpr auto operator()(T&& t, [[maybe_unused]] kumi::index_t<I0> i0) const noexcept
+    [[nodiscard]] KUMI_ABI constexpr auto operator()(T&& t, kumi::index_t<I0>) const noexcept
     {
       static_assert(I0 <= kumi::size_v<T>, "[KUMI] - Invalid index");
-      constexpr auto proj = kumi::function::splitter(kumi::index<I0>, std::make_index_sequence<kumi::size_v<T> - I0>{});
+      constexpr auto proj = kumi::function::splitter(kumi::index<I0>, kumi::index<kumi::size_v<T>>);
 
       return kumi::tuple{kumi::function::builder(KUMI_FWD(t), get<0>(proj)),
                          kumi::function::builder(KUMI_FWD(t), get<1>(proj))};

--- a/include/kumi/algorithm/flatten.hpp
+++ b/include/kumi/algorithm/flatten.hpp
@@ -104,7 +104,7 @@ namespace kumi
       {
         constexpr auto proj = []<std::size_t... I>(std::index_sequence<I...>) {
           return kumi::function::concatenater(
-            std::index_sequence<kumi::function::size_or_v<kumi::stored_element_t<I, T>, 1>...>{});
+            kumi::index<kumi::function::size_or_v<kumi::stored_element_t<I, T>, 1>>...);
         }(std::make_index_sequence<kumi::size_v<T>>{});
 
         return flatten_(kumi::_::adl_tag, KUMI_FWD(t), kumi::_::flatten_case, get<1>(proj), get<0>(proj));

--- a/include/kumi/algorithm/fold.hpp
+++ b/include/kumi/algorithm/fold.hpp
@@ -41,8 +41,7 @@ namespace kumi
       else if constexpr (kumi::concepts::sized_product_type<T, 1>) return get<0>(KUMI_FWD(t));
       else
         return fold_left_(kumi::_::adl_tag, f, KUMI_FWD(t), get<0>(KUMI_FWD(t)),
-                          kumi::function::shifter(std::integral_constant<std::size_t, 1>{},
-                                                  std::make_index_sequence<kumi::size_v<T> - 1>{}));
+                          kumi::function::shifter(kumi::index<1>, kumi::index<kumi::size_v<T> - 1>));
     }
   };
 
@@ -63,8 +62,7 @@ namespace kumi
       else if constexpr (kumi::concepts::sized_product_type<T, 1>) return get<0>(KUMI_FWD(t));
       else
         return fold_right_(kumi::_::adl_tag, f, KUMI_FWD(t), get<0>(KUMI_FWD(t)),
-                           kumi::function::shifter(std::integral_constant<std::size_t, 1>{},
-                                                   std::make_index_sequence<kumi::size_v<T> - 1>{}));
+                           kumi::function::shifter(kumi::index<1>, kumi::index<kumi::size_v<T> - 1>));
     }
   };
 

--- a/include/kumi/algorithm/push_pop.hpp
+++ b/include/kumi/algorithm/push_pop.hpp
@@ -40,8 +40,7 @@ namespace kumi
       if constexpr (kumi::concepts::empty_product_type<T>) return kumi::builder<T>::make();
       else
         return kumi::function::builder(KUMI_FWD(t),
-                                       kumi::function::shifter(std::integral_constant<std::size_t, 1>{},
-                                                               std::make_index_sequence<kumi::size_v<T> - 1>{}));
+                                       kumi::function::shifter(kumi::index<1>, kumi::index<kumi::size_v<T> - 1>));
     }
   };
 

--- a/include/kumi/algorithm/reduce.hpp
+++ b/include/kumi/algorithm/reduce.hpp
@@ -52,7 +52,7 @@ namespace kumi
       else
       {
         constexpr auto sz = kumi::size_v<T>;
-        constexpr auto pos = kumi::function::reducer(std::make_index_sequence<sz / 2>{}, index<sz % 2>);
+        constexpr auto pos = kumi::function::reducer(kumi::index<sz / 2>, kumi::index<sz % 2>);
         return reduce_(kumi::_::adl_tag, KUMI_FWD(m), (*this), KUMI_FWD(t), get<2>(pos), get<0>(pos), get<1>(pos));
       }
     }
@@ -76,7 +76,7 @@ namespace kumi
       else
       {
         constexpr auto sz = kumi::size_v<T>;
-        constexpr auto pos = kumi::function::reducer(std::make_index_sequence<sz / 2>{}, index<sz % 2>);
+        constexpr auto pos = kumi::function::reducer(kumi::index<sz / 2>, kumi::index<sz % 2>);
         return map_reduce_(kumi::_::adl_tag, KUMI_FWD(m), KUMI_FWD(t), f, kumi::reduce_t{}, get<2>(pos), get<0>(pos),
                            get<1>(pos));
       }

--- a/include/kumi/algorithm/reverse.hpp
+++ b/include/kumi/algorithm/reverse.hpp
@@ -16,7 +16,7 @@ namespace kumi
       if constexpr (kumi::concepts::empty_product_type<T>) return builder<T>::make();
       else
       {
-        constexpr auto idx = kumi::function::reverser(std::make_index_sequence<kumi::size_v<T>>{});
+        constexpr auto idx = kumi::function::reverser(kumi::index<kumi::size_v<T>>);
         return kumi::function::builder(KUMI_FWD(t), idx);
       }
     }

--- a/include/kumi/algorithm/rotate.hpp
+++ b/include/kumi/algorithm/rotate.hpp
@@ -17,8 +17,7 @@ namespace kumi
       else if constexpr ((R % kumi::size_v<T>) == 0) return KUMI_FWD(t);
       else
       {
-        constexpr auto idxs =
-          kumi::function::rotater(std::make_index_sequence<kumi::size_v<T>>{}, kumi::index<(R % kumi::size_v<T>)>);
+        constexpr auto idxs = kumi::function::rotater(kumi::index<kumi::size_v<T>>, kumi::index<(R % kumi::size_v<T>)>);
         return kumi::function::builder(KUMI_FWD(t), idxs);
       }
     }
@@ -33,8 +32,7 @@ namespace kumi
       else
       {
         constexpr auto F = R % kumi::size_v<T>;
-        constexpr auto idxs =
-          kumi::function::rotater(std::make_index_sequence<kumi::size_v<T>>{}, kumi::index<(kumi::size_v<T> - F)>);
+        constexpr auto idxs = kumi::function::rotater(kumi::index<kumi::size_v<T>>, kumi::index<(kumi::size_v<T> - F)>);
         return kumi::function::builder(KUMI_FWD(t), idxs);
       }
     }

--- a/include/kumi/algorithm/tiler.hpp
+++ b/include/kumi/algorithm/tiler.hpp
@@ -15,8 +15,7 @@ namespace kumi
     KUMI_ABI constexpr auto tiles_(kumi::_::adl_tag_t, T&& t, std::index_sequence<B...>, std::index_sequence<E...>)
     {
       return kumi::tuple{
-        kumi::function::builder(KUMI_FWD(t), kumi::function::shifter(std::integral_constant<std::size_t, E>{},
-                                                                     std::make_index_sequence<B>{}))...};
+        kumi::function::builder(KUMI_FWD(t), kumi::function::shifter(kumi::index<E>, kumi::index<B>))...};
     }
   }
 
@@ -29,9 +28,8 @@ namespace kumi
       if constexpr (N == kumi::size_v<T>) return kumi::make_tuple(t);
       else
       {
-        constexpr auto bs = std::integral_constant<std::size_t, kumi::_::nb_blocks(kumi::size_v<T>, O, N)>{};
         constexpr auto proj = kumi::function::tiler(kumi::index<kumi::size_v<T>>, kumi::index<N>, kumi::index<O>,
-                                                    std::make_index_sequence<bs>{});
+                                                    kumi::index<kumi::_::nb_blocks(kumi::size_v<T>, O, N)>);
 
         return tiles_(kumi::_::adl_tag, KUMI_FWD(t), get<0>(proj), get<1>(proj));
       }

--- a/include/kumi/functional/indexable.hpp
+++ b/include/kumi/functional/indexable.hpp
@@ -7,291 +7,574 @@
 //======================================================================================================================
 #pragma once
 
+#include <utility>
+#include <type_traits>
+
 namespace kumi::function
 {
   //====================================================================================================================
   /**
     @ingroup functional
-    @brief  Logic provider to compute the index map associated to the cartesian product operation.
 
-    ## Callable object
+    @var cartesian_producer
+    @brief Callable object computing the index map associated to the cartesian product operation.
+
+    @qualifier consteval
+    @qualifier noexcept
+
+    @groupheader{Header file}
     @code
-      inline constexpr cartesian_product_t cartesian_producer{};
+    #include <kumi/functional/indexable.hpp>
     @endcode
+
+    @groupheader{Call Signature}
+    @code
+      template<typename... Shapes>
+      consteval auto cartesian_producer(Shapes... shapes) noexcept;
+    @endcode
+
+    @subgroupheader{Parameters}
+      - `shapes...`: Compile-time sizes representing the dimensions of the inputs to build a product from
+
+    @subgroupheader{Return value}
+      A `kumi::projection_map` handling cartesian index unflattening transformations.
   **/
   //====================================================================================================================
   struct cartesian_product_t
   {
+  private:
     template<std::size_t... H, std::size_t... S>
-    KUMI_ABI consteval auto operator()(std::index_sequence<H...>, kumi::index_t<S>...) const noexcept
+    consteval auto impl(std::index_sequence<H...>, kumi::index_t<S>...) const noexcept
     {
       return kumi::projection_map{kumi::_::digits(kumi::_::unflatten_index, std::make_index_sequence<sizeof...(S)>{},
                                                   std::index_sequence<H, S...>{})...};
     }
-  };
+
+  public:
+    template<std::size_t... S> consteval auto operator()(kumi::index_t<S>...) const noexcept
+    {
+      constexpr std::size_t N = (S * ... * 1ULL);
+      return impl(std::make_index_sequence<N>{}, kumi::index<S>...);
+    }
+  } inline constexpr cartesian_producer;
 
   //====================================================================================================================
   /**
     @ingroup functional
-    @brief  Logic provider to compute the index map associated to the concatenation operation.
 
-    ## Callable object
+    @var concatenater
+    @brief Callable object computing the index map associated to the concatenation operation.
+
+    @qualifier consteval
+    @qualifier noexcept
+
+    @groupheader{Header file}
     @code
-      inline constexpr cat_t concatenater{};
+    #include <kumi/functional/indexable.hpp>
     @endcode
+
+    @groupheader{Call Signature}
+    @code
+      template<typename... Sizes>
+      consteval auto concatenater(Sizes... sizes) noexcept;
+    @endcode
+
+    @subgroupheader{Parameters}
+      - `sizes...`: Compile-time sizes of all inputs tuples
+
+    @subgroupheader{Return value}
+      A `kumi::projection_map` mapping indices over combined tuple domains.
   **/
   //====================================================================================================================
   struct cat_t
   {
-    template<std::size_t... Sizes> KUMI_ABI consteval auto operator()(std::index_sequence<Sizes...>) const noexcept
+  private:
+    template<std::size_t... S> consteval auto impl(std::index_sequence<S...>) const noexcept
     {
-      constexpr auto N = (Sizes + ... + 0ULL);
-      constexpr auto Ids = std::index_sequence<Sizes...>{};
-
-      return kumi::projection_map{kumi::_::digits(kumi::_::container_of_index, std::make_index_sequence<N>{}, Ids),
-                                  kumi::_::digits(kumi::_::element_of_index, std::make_index_sequence<N>{}, Ids)};
+      constexpr auto N = (S + ... + 0ULL);
+      return kumi::projection_map{
+        kumi::_::digits(kumi::_::container_of_index, std::make_index_sequence<N>{}, std::index_sequence<S...>{}),
+        kumi::_::digits(kumi::_::element_of_index, std::make_index_sequence<N>{}, std::index_sequence<S...>{})};
     }
-  };
+
+  public:
+    template<std::size_t... S> consteval auto operator()(kumi::index_t<S>...) const noexcept
+    {
+      return impl(std::index_sequence<S...>{});
+    }
+  } inline constexpr concatenater;
 
   //====================================================================================================================
   /**
     @ingroup functional
-    @brief  Logic provider to compute the index map associated to the extraction operation.
 
-    ## Callable object
+    @var extractor
+    @brief Callable object computing the index map associated to the extraction operation.
+
+    @qualifier consteval
+    @qualifier noexcept
+
+    @groupheader{Header file}
     @code
-      inline constexpr extract_t extractor{};
+    #include <kumi/functional/indexable.hpp>
     @endcode
+
+    @groupheader{Call Signature}
+    @code
+      template<typename Begin, typename End, typename Size, typename Step>
+      consteval auto extractor(Begin b, End e, Size s, Step st) noexcept;
+    @endcode
+
+    @subgroupheader{Parameters}
+      - `b`: Compile-time index marking the beginning of the excluded window
+      - `e`: Compile-time index marking the end of the excluded window
+      - `s`: Total compile-time width limit of the original tuple frame
+      - `st`: Offset between consecutive elements to extract.
+
+    @subgroupheader{Return value}
+      A `std::index_sequence` mapping original layout indices while skipping the extracted block window.
   **/
   //====================================================================================================================
   struct extract_t
   {
-    template<std::size_t B, std::size_t E, std::size_t... I>
-    KUMI_ABI consteval auto operator()(std::integral_constant<std::size_t, B>,
-                                       std::integral_constant<std::size_t, E>,
-                                       std::index_sequence<I...>) const noexcept
+  private:
+    template<std::size_t B, std::size_t E, std::size_t S, std::size_t R, std::size_t... I>
+    consteval auto impl(
+      kumi::index_t<B>, kumi::index_t<E>, kumi::index_t<S>, kumi::index_t<R>, std::index_sequence<I...>) const noexcept
     {
-      return std::index_sequence<(I < B ? I : (I + (E - B)))...>{};
+      constexpr std::size_t K = (E > B) ? (E - B) - R : 0;
+      constexpr std::size_t S_1 = (S > 1) ? (S - 1) : 1;
+
+      return std::index_sequence<(I < B ? I : (I < B + K ? B + (I - B) + (I - B) / S_1 + 1 : I + R))...>{};
     }
-  };
+
+  public:
+    template<std::size_t B, std::size_t E, std::size_t S, std::size_t St = 1>
+    consteval auto operator()(kumi::index_t<B> b,
+                              kumi::index_t<E> e,
+                              kumi::index_t<S>,
+                              kumi::index_t<St> s = {}) const noexcept
+    {
+      constexpr std::size_t T = (E > B) ? (E - B + St - 1) / St : 0;
+      constexpr std::size_t N = S - T;
+      return impl(b, e, s, kumi::index<T>, std::make_index_sequence<N>{});
+    }
+  } inline constexpr extractor;
 
   //====================================================================================================================
   /**
     @ingroup functional
-    @brief  Logic provider to compute the index map associated to the rotation operation.
 
-    ## Callable object
+    @var rotater
+    @brief Callable object computing the index map associated to the rotation operation.
+
+    @qualifier consteval
+    @qualifier noexcept
+
+    @groupheader{Header file}
     @code
-      inline constexpr rotate_t rotater{};
+    #include <kumi/functional/indexable.hpp>
     @endcode
+
+    @groupheader{Call Signature}
+    @code
+      template<typename Size, typename Rotation>
+      consteval auto rotater(Size s, Rotation r) noexcept;
+    @endcode
+
+    @subgroupheader{Parameters}
+      - `s`: Compile-time length of the input domain
+      - `r`: Rotation factor
+
+    @subgroupheader{Return value}
+      A `std::index_sequence` mapping circularly rotated values.
   **/
   //====================================================================================================================
   struct rotate_t
   {
-    template<std::size_t... S, std::size_t R>
-    KUMI_ABI consteval auto operator()(std::index_sequence<S...>, kumi::index_t<R>) const noexcept
+  private:
+    template<std::size_t R, std::size_t... S>
+    consteval auto impl(kumi::index_t<R>, std::index_sequence<S...>) const noexcept
     {
       return std::index_sequence<((S + R) % sizeof...(S))...>{};
     }
-  };
+
+  public:
+    template<std::size_t S, std::size_t R>
+    consteval auto operator()(kumi::index_t<S>, kumi::index_t<R> r) const noexcept
+    {
+      return impl(r, std::make_index_sequence<S>{});
+    }
+  } inline constexpr rotater;
 
   //====================================================================================================================
   /**
     @ingroup functional
-    @brief  Logic provider to compute the index map associated to the reduction operation.
 
-    ## Callable object
+    @var reducer
+    @brief Callable object computing the index map associated to the reduction operation.
+
+    @qualifier consteval
+    @qualifier noexcept
+
+    @groupheader{Header file}
     @code
-      inline constexpr reduce_t reducer{};
+    #include <kumi/functional/indexable.hpp>
     @endcode
+
+    @groupheader{Call Signature}
+    @code
+      template<typename Count, typename N>
+      consteval auto reducer(Count c, N n) noexcept;
+    @endcode
+
+    @subgroupheader{Parameters}
+      - `c`: Total reduced pairs processing for the current step
+      - `n`: Remainder if the number of values is odd
+
+    @subgroupheader{Return value}
+      A `kumi::projection_map` segmenting the input domain in chunks of two consecutive elements plus the reminder.
   **/
   //====================================================================================================================
   struct reduce_t
   {
-    template<std::size_t... I, std::size_t N>
-    KUMI_ABI consteval auto operator()(std::index_sequence<I...>, kumi::index_t<N>) const noexcept
+  private:
+    template<std::size_t N, std::size_t... I>
+    consteval auto impl(kumi::index_t<N>, std::index_sequence<I...>) const noexcept
     {
       return kumi::projection_map{std::index_sequence<(2 * I)...>{}, std::index_sequence<(2 * I + 1)...>{},
                                   kumi::index<N>};
     }
-  };
 
-  struct repeat_t
-  {
-    template<std::size_t E, std::size_t... I>
-    KUMI_ABI consteval auto operator()(kumi::index_t<E>, std::index_sequence<I...>) const noexcept
+  public:
+    template<std::size_t C, std::size_t N>
+    consteval auto operator()(kumi::index_t<C>, kumi::index_t<N> n) const noexcept
     {
-      return std::index_sequence<(I - I + E)...>{};
+      return impl(n, std::make_index_sequence<C>{});
     }
-  };
+  } inline constexpr reducer;
 
   //====================================================================================================================
   /**
     @ingroup functional
-    @brief  Logic provider to compute the index map associated to the reverse operation.
 
-    ## Callable object
+    @var repeater
+    @brief Callable object generating an index sequence repeating a constant index.
+
+    @qualifier consteval
+    @qualifier noexcept
+
+    @groupheader{Header file}
     @code
-      inline constexpr reverse_t reverser{};
+    #include <kumi/functional/indexable.hpp>
     @endcode
+
+    @groupheader{Call Signature}
+    @code
+      template<typename Element, typename Count>
+      consteval auto repeater(Element e, Count c) noexcept;
+    @endcode
+
+    @subgroupheader{Parameters}
+      - `e`: Compile-time value to replicate
+      - `c`: Number of repetitions to generate
+
+    @subgroupheader{Return value}
+      A `std::index_sequence` filled completely with `e`.
+  **/
+  //====================================================================================================================
+  struct repeat_t
+  {
+  private:
+    template<std::size_t E, std::size_t... I>
+    consteval auto impl(kumi::index_t<E>, std::index_sequence<I...>) const noexcept
+    {
+      return std::index_sequence<((void)I, E)...>{};
+    }
+
+  public:
+    template<std::size_t E, std::size_t C>
+    consteval auto operator()(kumi::index_t<E> e, kumi::index_t<C>) const noexcept
+    {
+      return impl(e, std::make_index_sequence<C>{});
+    }
+  } inline constexpr repeater;
+
+  //====================================================================================================================
+  /**
+    @ingroup functional
+
+    @var reverser
+    @brief Callable object computing the reversed index sequence.
+
+    @qualifier consteval
+    @qualifier noexcept
+
+    @groupheader{Header file}
+    @code
+    #include <kumi/functional/indexable.hpp>
+    @endcode
+
+    @groupheader{Call Signature}
+    @code
+      template<typename Size>
+      consteval auto reverser(Size s) noexcept;
+    @endcode
+
+    @subgroupheader{Parameters}
+      - `s`: Length of the index sequence to generate
+
+    @subgroupheader{Return value}
+      An index sequence equivalent to std::make_index_sequence<N> but filled from the end.
   **/
   //====================================================================================================================
   struct reverse_t
   {
-    template<std::size_t... I> KUMI_ABI consteval auto operator()(std::index_sequence<I...>) const noexcept
+  private:
+    template<std::size_t... I> consteval auto impl(std::index_sequence<I...>) const noexcept
     {
       return std::index_sequence<(sizeof...(I) - 1 - I)...>{};
     }
-  };
 
-  struct shift_t
-  {
-    template<std::size_t N, std::size_t... I>
-    KUMI_ABI consteval auto operator()(std::integral_constant<std::size_t, N>, std::index_sequence<I...>) const noexcept
+  public:
+    template<std::size_t S> consteval auto operator()(kumi::index_t<S>) const noexcept
     {
-      return std::index_sequence<I + N...>{};
+      return impl(std::make_index_sequence<S>{});
     }
-  };
+  } inline constexpr reverser;
 
   //====================================================================================================================
   /**
     @ingroup functional
-    @brief  Logic provider to compute the index map associated to the split operation.
 
-    ## Callable object
+    @var shifter
+    @brief Callable object computing linear indexing translations.
+
+    @qualifier consteval
+    @qualifier noexcept
+
+    @groupheader{Header file}
     @code
-      inline constexpr split_t splitter{};
+    #include <kumi/functional/indexable.hpp>
     @endcode
+
+    @groupheader{Call Signature}
+    @code
+      template<typename Offset, typename Size>
+      consteval auto shifter(Offset o, Size s) noexcept;
+    @endcode
+
+    @subgroupheader{Parameters}
+      - `o`: Offset to add to each element in the input domain
+      - `s`: Size of the input domain
+
+    @subgroupheader{Return value}
+      A `std::index_sequence` shifted uniformly forward by `o`.
+  **/
+  //====================================================================================================================
+  struct shift_t
+  {
+  private:
+    template<std::size_t O, std::size_t... I>
+    consteval auto impl(kumi::index_t<O>, std::index_sequence<I...>) const noexcept
+    {
+      return std::index_sequence<I + O...>{};
+    }
+
+  public:
+    template<std::size_t O, std::size_t S>
+    consteval auto operator()(kumi::index_t<O> o, kumi::index_t<S>) const noexcept
+    {
+      return impl(o, std::make_index_sequence<S>{});
+    }
+  } inline constexpr shifter;
+
+  //====================================================================================================================
+  /**
+    @ingroup functional
+
+    @var splitter
+    @brief Callable object computing underlying index sequences of the input domain divided in two parts.
+
+    @qualifier consteval
+    @qualifier noexcept
+
+    @groupheader{Header file}
+    @code
+    #include <kumi/functional/indexable.hpp>
+    @endcode
+
+    @groupheader{Call Signature}
+    @code
+      template<typename N, typename Size>
+      consteval auto splitter(N n, Size s) noexcept;
+    @endcode
+
+    @subgroupheader{Parameters}
+      - `n`: Midpoint split pivot
+      - `s`: Size of the input domain to split
+
+    @subgroupheader{Return value}
+      A `kumi::projection_map` tracking partitioned left and right index segments.
   **/
   //====================================================================================================================
   struct split_t
   {
+  private:
     template<std::size_t N, std::size_t... S>
-    KUMI_ABI consteval auto operator()(kumi::index_t<N>, std::index_sequence<S...>) const noexcept
+    consteval auto impl(kumi::index_t<N>, std::index_sequence<S...>) const noexcept
     {
       return kumi::projection_map{std::make_index_sequence<N>{}, std::index_sequence<(S + N)...>{}};
     }
-  };
+
+  public:
+    template<std::size_t N, std::size_t S>
+    consteval auto operator()(kumi::index_t<N> n, kumi::index_t<S>) const noexcept
+    {
+      constexpr std::size_t R = S - N;
+      return impl(n, std::make_index_sequence<R>{});
+    }
+  } inline constexpr splitter;
 
   //====================================================================================================================
   /**
     @ingroup functional
-    @brief  Logic provider to compute the index map associated to the tiling operation.
 
-    ## Callable object
+    @var tiler
+    @brief Callable object computing multi-dimensional window block layout configurations.
+
+    @qualifier consteval
+    @qualifier noexcept
+
+    @groupheader{Header file}
     @code
-      inline constexpr tile_t tiler{};
+    #include <kumi/functional/indexable.hpp>
     @endcode
+
+    @groupheader{Call Signature}
+    @code
+      template<typename Sz, typename Extent, typename Stride, typename NumBlocks>
+      consteval auto tiler(Sz sz, Extent ext, Stride str, NumBlocks nb) noexcept;
+    @endcode
+
+    @subgroupheader{Parameters}
+      - `sz`: Size of the tiles to generate
+      - `ext`: Size of the input domain
+      - `str`: Dimensional stride representing elements to skip
+      - `nb`: Total number of tiles to generate
+
+    @subgroupheader{Return value}
+      A `kumi::projection_map` handling tile patterns and structural grid offset mappings.
   **/
   //====================================================================================================================
   struct tile_t
   {
-    template<std::size_t Sz, std::size_t Extent, std::size_t Stride, std::size_t... Blocks>
-    KUMI_ABI consteval auto operator()(kumi::index_t<Sz>,
-                                       kumi::index_t<Extent>,
-                                       kumi::index_t<Stride>,
-                                       std::index_sequence<Blocks...>) const noexcept
+  private:
+    template<std::size_t Sz, std::size_t E, std::size_t Sd, std::size_t... Bs>
+    consteval auto impl(kumi::index_t<Sz>,
+                        kumi::index_t<E>,
+                        kumi::index_t<Sd>,
+                        std::index_sequence<Bs...>) const noexcept
     {
-      using blocks = std::index_sequence<kumi::_::block_size(Blocks, Stride, Extent, Sz)...>;
-      using offsets = std::index_sequence<(Blocks * Stride)...>;
+      using blocks = std::index_sequence<kumi::_::block_size(Bs, Sd, E, Sz)...>;
+      using offsets = std::index_sequence<(Bs * Sd)...>;
       return kumi::projection_map{blocks{}, offsets{}};
     }
-  };
+
+  public:
+    template<std::size_t Sz, std::size_t E, std::size_t Sd, std::size_t Bs>
+    consteval auto operator()(kumi::index_t<Sz> sz,
+                              kumi::index_t<E> e,
+                              kumi::index_t<Sd> sd,
+                              kumi::index_t<Bs>) const noexcept
+    {
+      return impl(sz, e, sd, std::make_index_sequence<Bs>{});
+    }
+  } inline constexpr tiler;
 
   //====================================================================================================================
   /**
     @ingroup functional
-    @brief  Logic provider to compute the index map associated to the zip operation.
 
-    ## Callable object
+    @var zipper
+    @brief Callable object creating the index sequence corresponding to the zip operation.
+
+    @qualifier consteval
+    @qualifier noexcept
+
+    @groupheader{Header file}
     @code
-      inline constexpr zip_t zipper{};
+    #include <kumi/functional/indexable.hpp>
     @endcode
+
+    @groupheader{Call Signature}
+    @code
+      template<typename Count, typename Size>
+      consteval auto zipper(Count c, Size s) noexcept;
+    @endcode
+
+    @subgroupheader{Parameters}
+      - `c`: Number of values per zip slice
+      - `s`: Size of the input domain
+
+    @subgroupheader{Return value}
+      A kumi::projection_map storing offsets from the input paired with the number of elements to generate per zip
+      element
   **/
   //====================================================================================================================
   struct zip_t
   {
-    template<std::size_t Count, std::size_t Size>
-    KUMI_ABI consteval auto operator()(kumi::index_t<Count>, kumi::index_t<Size>) const noexcept
+    template<std::size_t C, std::size_t S> consteval auto operator()(kumi::index_t<C>, kumi::index_t<S>) const noexcept
     {
-      using tuples = std::make_index_sequence<Count>;
-      using elements = std::make_index_sequence<Size>;
-      return kumi::projection_map{tuples{}, elements{}};
+      return kumi::projection_map{std::make_index_sequence<C>{}, std::make_index_sequence<S>{}};
     }
-  };
+  } inline constexpr zipper;
 
   //====================================================================================================================
   /**
     @ingroup functional
-    @brief  Callable object computing the index map associated to the cartesian product operation.
+
+    @var slicer
+    @brief Callable object computing the index map associated to a slicing (begin, end, step) operation.
+
+    @qualifier consteval
+    @qualifier noexcept
+
+    @groupheader{Header file}
+    @code
+    #include <kumi/functional/indexable.hpp>
+    @endcode
+
+    @groupheader{Call Signature}
+    @code
+      template<typename Begin, typename End, typename Step>
+      consteval auto slicer(Begin b, End e, Step s) noexcept;
+    @endcode
+
+    @subgroupheader{Parameters}
+      - `b`: Compile-time index marking the beginning of the slice range
+      - `e`: Compile-time index marking the end boundary of the slice range (exclusive)
+      - `s`: Compile-time stride step hopping increment factor
+
+    @subgroupheader{Return value}
+      A `std::index_sequence` tracking linear jumps matching `Begin + I * Step`.
   **/
   //====================================================================================================================
-  inline constexpr kumi::function::cartesian_product_t cartesian_producer{};
+  struct slice_t
+  {
+  private:
+    template<std::size_t B, std::size_t S, std::size_t... I>
+    consteval auto impl(kumi::index_t<B>, kumi::index_t<S>, std::index_sequence<I...>) const noexcept
+    {
+      return std::index_sequence<(B + I * S)...>{};
+    }
 
-  //====================================================================================================================
-  /**
-    @ingroup functional
-    @brief  Callable object computing the index map associated to the concatenation operation.
-  **/
-  //====================================================================================================================
-  inline constexpr kumi::function::cat_t concatenater{};
-
-  //====================================================================================================================
-  /**
-    @ingroup functional
-    @brief  Callable object computing the index map associated to the extraction operation.
-  **/
-  //====================================================================================================================
-  inline constexpr kumi::function::extract_t extractor{};
-
-  //====================================================================================================================
-  /**
-    @ingroup functional
-    @brief  Callable object computing the index map associated to the rotation operation.
-  **/
-  //====================================================================================================================
-  inline constexpr kumi::function::rotate_t rotater{};
-
-  //====================================================================================================================
-  /**
-    @ingroup functional
-    @brief  Callable object computing the index map associated to the reduction operation.
-  **/
-  //====================================================================================================================
-  inline constexpr kumi::function::reduce_t reducer{};
-
-  inline constexpr kumi::function::repeat_t repeater{};
-
-  inline constexpr kumi::function::shift_t shifter{};
-  //====================================================================================================================
-  /**
-    @ingroup functional
-    @brief  Callable object computing the index map associated to the split operation.
-  **/
-  //====================================================================================================================
-  inline constexpr kumi::function::split_t splitter{};
-
-  //====================================================================================================================
-  /**
-    @ingroup functional
-    @brief  Callable object computing the index map associated to the reverse operation.
-  **/
-  //====================================================================================================================
-  inline constexpr kumi::function::reverse_t reverser{};
-
-  //====================================================================================================================
-  /**
-    @ingroup functional
-    @brief  Callable object computing the index map associated to the tiling operation.
-  **/
-  //====================================================================================================================
-  inline constexpr kumi::function::tile_t tiler{};
-
-  //====================================================================================================================
-  /**
-    @ingroup functional
-    @brief  Callable object computing the index map associated to the zip operation.
-  **/
-  //====================================================================================================================
-  inline constexpr kumi::function::zip_t zipper{};
+  public:
+    template<std::size_t B, std::size_t E, std::size_t S = 1>
+    consteval auto operator()(kumi::index_t<B> b, kumi::index_t<E>, kumi::index_t<S> s = {}) const noexcept
+    {
+      constexpr std::size_t N = (E > B) ? ((E - B + S - 1) / S) : 0;
+      return impl(b, s, std::make_index_sequence<N>{});
+    }
+  } inline constexpr slicer;
 }

--- a/test/unit/record/algo/extract.cpp
+++ b/test/unit/record/algo/extract.cpp
@@ -36,6 +36,10 @@ TTS_CASE("Check kumi::extract behavior on records")
   TTS_EQUAL((kumi::extract(t, 3_c, 3_c)), kumi::record{});
   TTS_EQUAL((kumi::extract(t, 4_c)), kumi::record{});
   TTS_EQUAL((kumi::extract(t, 4_c, 4_c)), kumi::record{});
+
+  TTS_EQUAL((kumi::extract(t, 0_c, 4_c, 2_c)), (kumi::record{"a"_id = '1', "c"_id = 3.f}));
+  TTS_EQUAL((kumi::extract(t, 0_c, 3_c, 3_c)), (kumi::record{"a"_id = '1'}));
+  TTS_EQUAL((kumi::extract(t, 0_c, 2_c, 1_c)), (kumi::record{"a"_id = '1', "b"_id = 2.}));
 };
 
 TTS_CASE("Check kumi::extract constexpr behavior on records")
@@ -64,4 +68,8 @@ TTS_CASE("Check kumi::extract constexpr behavior on records")
   TTS_CONSTEXPR_EQUAL((kumi::extract(t, 3_c, 3_c)), kumi::record{});
   TTS_CONSTEXPR_EQUAL((kumi::extract(t, 4_c)), kumi::record{});
   TTS_CONSTEXPR_EQUAL((kumi::extract(t, 4_c, 4_c)), kumi::record{});
+
+  TTS_EQUAL((kumi::extract(t, 0_c, 4_c, 2_c)), (kumi::record{"a"_id = '1', "c"_id = 3.f}));
+  TTS_EQUAL((kumi::extract(t, 0_c, 3_c, 3_c)), (kumi::record{"a"_id = '1'}));
+  TTS_EQUAL((kumi::extract(t, 0_c, 2_c, 1_c)), (kumi::record{"a"_id = '1', "b"_id = 2.}));
 };

--- a/test/unit/record/algo/remove.cpp
+++ b/test/unit/record/algo/remove.cpp
@@ -38,6 +38,12 @@ TTS_CASE("Check kumi::remove behavior on records")
   TTS_EQUAL((kumi::remove(r, 4_c)), (kumi::record{"a"_id = '1', "b"_id = 2., "c"_id = 3.f, "d"_id = 4}));
   TTS_EQUAL((kumi::remove(r, 4_c, 4_c)), (kumi::record{"a"_id = '1', "b"_id = 2., "c"_id = 3.f, "d"_id = 4}));
 
+  TTS_EQUAL((kumi::remove(r, 0_c, 4_c, 1_c)), (kumi::record{}));
+  TTS_EQUAL((kumi::remove(r, 0_c, 3_c, 2_c)), (kumi::record{"b"_id = 2., "d"_id = 4}));
+  TTS_EQUAL((kumi::remove(r, 0_c, 2_c, 2_c)), (kumi::record{"b"_id = 2., "c"_id = 3.f, "d"_id = 4}));
+  TTS_EQUAL((kumi::remove(r, 0_c, 1_c, 3_c)), (kumi::record{"b"_id = 2., "c"_id = 3.f, "d"_id = 4}));
+  TTS_EQUAL((kumi::remove(r, 0_c, 0_c, 4_c)), (kumi::record{"a"_id = '1', "b"_id = 2., "c"_id = 3.f, "d"_id = 4}));
+
   TTS_EQUAL((kumi::remove(std::move(r), 0_c)), (kumi::record{}));
 
   kumi::record r2 = {"a"_id = moveonly{}, "b"_id = 3., "c"_id = 'f'};
@@ -70,4 +76,11 @@ TTS_CASE("Check kumi::remove constexpr behavior on records")
   TTS_CONSTEXPR_EQUAL((kumi::remove(r, 3_c, 3_c)), (kumi::record{"a"_id = '1', "b"_id = 2., "c"_id = 3.f, "d"_id = 4}));
   TTS_CONSTEXPR_EQUAL((kumi::remove(r, 4_c)), (kumi::record{"a"_id = '1', "b"_id = 2., "c"_id = 3.f, "d"_id = 4}));
   TTS_CONSTEXPR_EQUAL((kumi::remove(r, 4_c, 4_c)), (kumi::record{"a"_id = '1', "b"_id = 2., "c"_id = 3.f, "d"_id = 4}));
+
+  TTS_CONSTEXPR_EQUAL((kumi::remove(r, 0_c, 4_c, 1_c)), (kumi::record{}));
+  TTS_CONSTEXPR_EQUAL((kumi::remove(r, 0_c, 3_c, 2_c)), (kumi::record{"b"_id = 2., "d"_id = 4}));
+  TTS_CONSTEXPR_EQUAL((kumi::remove(r, 0_c, 2_c, 2_c)), (kumi::record{"b"_id = 2., "c"_id = 3.f, "d"_id = 4}));
+  TTS_CONSTEXPR_EQUAL((kumi::remove(r, 0_c, 1_c, 3_c)), (kumi::record{"b"_id = 2., "c"_id = 3.f, "d"_id = 4}));
+  TTS_CONSTEXPR_EQUAL((kumi::remove(r, 0_c, 0_c, 4_c)),
+                      (kumi::record{"a"_id = '1', "b"_id = 2., "c"_id = 3.f, "d"_id = 4}));
 };

--- a/test/unit/tuple/algo/extract.cpp
+++ b/test/unit/tuple/algo/extract.cpp
@@ -38,6 +38,10 @@ TTS_CASE("Check tuple::extract behavior")
   TTS_EQUAL((kumi::extract(t, 4_c)), kumi::tuple{});
   TTS_EQUAL((kumi::extract(t, 4_c, 4_c)), kumi::tuple{});
 
+  TTS_EQUAL((kumi::extract(t, 0_c, 4_c, 2_c)), (kumi::tuple{'1', 3.f}));
+  TTS_EQUAL((kumi::extract(t, 0_c, 3_c, 3_c)), (kumi::tuple{'1'}));
+  TTS_EQUAL((kumi::extract(t, 0_c, 2_c, 1_c)), (kumi::tuple{'1', 2.}));
+
   TTS_EQUAL((kumi::extract(std::move(t), 0_c)), (kumi::tuple{'1', 2., 3.f, 4}));
 
   kumi::tuple t2 = {moveonly{}, 3., 'f'};
@@ -70,4 +74,8 @@ TTS_CASE("Check tuple::extract constexpr behavior")
   TTS_CONSTEXPR_EQUAL((kumi::extract(t, 3_c, 3_c)), kumi::tuple{});
   TTS_CONSTEXPR_EQUAL((kumi::extract(t, 4_c)), kumi::tuple{});
   TTS_CONSTEXPR_EQUAL((kumi::extract(t, 4_c, 4_c)), kumi::tuple{});
+
+  TTS_CONSTEXPR_EQUAL((kumi::extract(t, 0_c, 4_c, 2_c)), (kumi::tuple{'1', 3.f}));
+  TTS_CONSTEXPR_EQUAL((kumi::extract(t, 0_c, 3_c, 3_c)), (kumi::tuple{'1'}));
+  TTS_CONSTEXPR_EQUAL((kumi::extract(t, 0_c, 2_c, 1_c)), (kumi::tuple{'1', 2.}));
 };

--- a/test/unit/tuple/algo/remove.cpp
+++ b/test/unit/tuple/algo/remove.cpp
@@ -38,6 +38,12 @@ TTS_CASE("Check kumi::remove behavior on tuples")
   TTS_EQUAL((kumi::remove(t, 4_c)), (kumi::tuple{'1', 2., 3.f, 4}));
   TTS_EQUAL((kumi::remove(t, 4_c, 4_c)), (kumi::tuple{'1', 2., 3.f, 4}));
 
+  TTS_EQUAL((kumi::remove(t, 0_c, 4_c, 1_c)), (kumi::tuple{}));
+  TTS_EQUAL((kumi::remove(t, 0_c, 3_c, 2_c)), (kumi::tuple{2., 4}));
+  TTS_EQUAL((kumi::remove(t, 0_c, 2_c, 2_c)), (kumi::tuple{2., 3.f, 4}));
+  TTS_EQUAL((kumi::remove(t, 0_c, 1_c, 3_c)), (kumi::tuple{2., 3.f, 4}));
+  TTS_EQUAL((kumi::remove(t, 0_c, 0_c, 4_c)), (kumi::tuple{'1', 2., 3.f, 4}));
+
   TTS_EQUAL((kumi::remove(std::move(t), 0_c)), (kumi::tuple{}));
 
   kumi::tuple t2 = {moveonly{}, 3., 'f'};
@@ -70,4 +76,10 @@ TTS_CASE("Check kumi::remove constexpr behavior on tuples")
   TTS_CONSTEXPR_EQUAL((kumi::remove(t, 3_c, 3_c)), (kumi::tuple{'1', 2., 3.f, 4}));
   TTS_CONSTEXPR_EQUAL((kumi::remove(t, 4_c)), (kumi::tuple{'1', 2., 3.f, 4}));
   TTS_CONSTEXPR_EQUAL((kumi::remove(t, 4_c, 4_c)), (kumi::tuple{'1', 2., 3.f, 4}));
+
+  TTS_CONSTEXPR_EQUAL((kumi::remove(t, 0_c, 4_c, 1_c)), (kumi::tuple{}));
+  TTS_CONSTEXPR_EQUAL((kumi::remove(t, 0_c, 3_c, 2_c)), (kumi::tuple{2., 4}));
+  TTS_CONSTEXPR_EQUAL((kumi::remove(t, 0_c, 2_c, 2_c)), (kumi::tuple{2., 3.f, 4}));
+  TTS_CONSTEXPR_EQUAL((kumi::remove(t, 0_c, 1_c, 3_c)), (kumi::tuple{2., 3.f, 4}));
+  TTS_CONSTEXPR_EQUAL((kumi::remove(t, 0_c, 0_c, 4_c)), (kumi::tuple{'1', 2., 3.f, 4}));
 };


### PR DESCRIPTION
This PR closes #212 

- consteval utilities in functional do not need ABI markers wether it is for codegen (immediates) or CUDA visibility

- helpers computing projection maps should be independant. Index sequences are expanded internally

- extract and remove now have an overload considering a step