### PR TITLE
Towards better use of doxygen-awesome

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -284,10 +284,13 @@ TAB_SIZE               = 2
 # with the commands \{ and \} for these it is advised to use the version @{ and
 # @} or use a double escape (\\{ and \\})
 
-ALIASES                =
+ALIASES  =
 ALIASES += "groupheader{1}=<h2 class=\"groupheader\"> \1 </h2>"
 ALIASES += "subgroupheader{1}=<h3 class=\"groupheader\"> \1 </h3>"
 ALIASES += "godbolt{1}=@include \1"
+ALIASES += tab_begin="<div class=\"tabbed\">"
+ALIASES += tab_end="</div>"
+ALIASES += tab{1}="- <b class=\"tab-title\">\1</b>"
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For

--- a/doc/base.html
+++ b/doc/base.html
@@ -7,7 +7,7 @@
 <meta name="generator" content="Doxygen $doxygenversion"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 
-<meta name="description" content="Efficeint C++20 implementation of tuple-like classes and algorithms with better compile-time" />
+<meta name="description" content="Efficient C++20 implementation of tuple-like classes and algorithms with better compile-time" />
 <link rel="canonical" href="https://jfalcou.github.io/kumi/" />
 <link rel="icon" type="image/svg+xml" href="/logo.svg" />
 <meta property="og:title" content="KUMI - The C++20 Compact Tuple Tools" />

--- a/doc/glossary/identities.hpp
+++ b/doc/glossary/identities.hpp
@@ -58,7 +58,15 @@ struct unit {};
 
 ---
 
-[In the next page](@ref product), we will see how to combine the simple types we saw until now in order to create more 
+In the next page, we will see how to combine the simple types we saw until now in order to create more 
 complex types.
+
+<div class="section_buttons">
+ 
+| Previous                          |                              Next |
+|:----------------------------------|----------------------------------:|
+| [Introduction](@ref introduction) | [Product Types](@ref product)     |
+ 
+</div>
 
 **/

--- a/doc/glossary/introduction.hpp
+++ b/doc/glossary/introduction.hpp
@@ -77,7 +77,15 @@ state space dictates how much information a variable can have.
 
 ---
 
-[In the next page](@ref identity), we will see some more specific types that are used as a base for more complex 
+In the next page, we will see some more specific types that are used as a base for more complex 
 operations.
+
+<div class="section_buttons">
+ 
+|                              Next |
+|----------------------------------:|
+| [Identity Types](@ref identity)   |
+ 
+</div>
 
 **/

--- a/doc/glossary/product.hpp
+++ b/doc/glossary/product.hpp
@@ -114,4 +114,12 @@ element. However, as they are internally represented by a tuple, such operation 
 could "rotate" a record \f$ n \f$ positions to the left. Mathematically this might not make a lot of sense
 whereas for a programmer that has to consider memory representation, this is potentially critical to have.
 
+<div class="section_buttons">
+ 
+| Previous                        |
+|:--------------------------------|
+| [Identity Types](@ref identity) | 
+ 
+</div>
+
 **/

--- a/doc/setup.hpp
+++ b/doc/setup.hpp
@@ -18,7 +18,8 @@
   | MSVC            | 19    and  above   |
   | clang-CL        | 19    and above    |
   | AppleClang      | 15    and above    |
-  | nvcc/nvc++      | *Work In Progress* |
+  | nvcc            | 13.2.5             |
+  | nvc++           | 26.3.0             |
 
   @section setup-source Install from the source
 
@@ -29,31 +30,40 @@
   @endcode
 
   Once retrieved, you should have a %kumi folder which contains the whole source code.
+  
+  Then simply use **CMake** to generate the build system and directory for **KUMI**.
+  We recommend using Ninja but any build system is fine.
+  
+  @tab_begin
 
-  Create a `build` directory here and enter it. Once in the `build` directory,
-  you can use  **CMake** to generate the build system for **KUMI**. We recommend using
-  Ninja but any build system is fine.
+  @tab{Ninja}
 
-  @code
-  $ mkdir build
-  $ cd build
-  $ cmake .. -G Ninja
-  @endcode
+    @code
+    $ cmake -S . -B build -G Ninja
+    @endcode
 
+  @tab{Visual Studio}
+
+    @code
+    $ cmake -S . -B build -G "Visual Studio 17 2022" -A x64 
+    @endcode
+
+  @tab_end
+  
   Once **CMake** completes, you can use the `install` target to build and install **KUMI**.
   By default, the library will be installed in the `/usr/local` directory, thus requiring
   root privileges.
 
   @code
-  $ sudo ninja install
+  $ sudo cmake --build build --target install
   @endcode
 
   You can select an alternative installation path by specifying the `CMAKE_INSTALL_PREFIX`
   option at configuration time.
 
   @code
-  $ cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=path/to/install
-  $ ninja install
+  $ cmake .. -G <build-system> -DCMAKE_INSTALL_PREFIX=path/to/install
+  $ cmake --build build --target install
   @endcode
 
   Once installed, **KUMI** is usable directly by providing the path to its installed files.
@@ -71,46 +81,52 @@
 
   Use **KUMI** by just compiling your code with the include path pointing to the location of this single file.
 
-  @section setup-fetchcontent CMake FetchContent
+  @section dependency As a CMake dependency
+  
+  @tab_begin
+  
+  @tab{FetchContent}
 
-  You can also use CMake FetchContent operation and use the `kumi::kumi` library target that our CMake exports.
+    You can also use CMake FetchContent operation and use the `kumi::kumi` library target that our CMake exports.
 
-  @code{cmake}
-  ##==================================================================================================
-  ## Your project setup
-  ##==================================================================================================
-  cmake_minimum_required(VERSION 3.22)
-  project(kumi-fetch LANGUAGES CXX)
+    @code{cmake}
+    ##==================================================================================================
+    ## Your project setup
+    ##==================================================================================================
+    cmake_minimum_required(VERSION 3.28)
+    project(kumi-fetch LANGUAGES CXX)
 
-  include(FetchContent)
-  FetchContent_Declare(kumi GIT_REPOSITORY "https://github.com/jfalcou/kumi.git" GIT_TAG main)
-  FetchContent_MakeAvailable(kumi)
+    include(FetchContent)
+    FetchContent_Declare(kumi GIT_REPOSITORY "https://github.com/jfalcou/kumi.git" GIT_TAG main)
+    FetchContent_MakeAvailable(kumi)
 
-  add_executable(test_kumi ../main.cpp)
-  target_link_libraries(test_kumi PUBLIC kumi::kumi)
-  @endcode
+    add_executable(test_kumi ../main.cpp)
+    target_link_libraries(test_kumi PUBLIC kumi::kumi)
+    @endcode
 
-  @section setup-cpm Setup with CPM
+  @tab{CPM}
 
-  The **KUMI** library can be setup using [CPM](https://github.com/cpm-cmake/CPM.cmake):
+    The **KUMI** library can be setup using [CPM](https://github.com/cpm-cmake/CPM.cmake):
 
-  @code{cmake}
-  ##==================================================================================================
-  ## Your project setup
-  ##==================================================================================================
-  cmake_minimum_required(VERSION 3.18)
-  project(kumi-cpm LANGUAGES CXX)
+    @code{cmake}
+    ##==================================================================================================
+    ## Your project setup
+    ##==================================================================================================
+    cmake_minimum_required(VERSION 3.28)
+    project(kumi-cpm LANGUAGES CXX)
 
-  # Setup CPM - See https://github.com/cpm-cmake/CPM.cmake#adding-cpm
-  include(cpm.cmake)
+    # Setup CPM - See https://github.com/cpm-cmake/CPM.cmake#adding-cpm
+    include(cpm.cmake)
 
-  CPMAddPackage ( NAME kumi
-                  GIT_REPOSITORY "https://github.com/jfalcou/kumi.git"
-                  OPTIONS "KUMI_BUILD_TEST OFF"
-                )
+    CPMAddPackage ( NAME kumi
+                    GIT_REPOSITORY "https://github.com/jfalcou/kumi.git"
+                    OPTIONS "KUMI_BUILD_TEST OFF"
+                  )
 
-  add_executable(test_kumi ../main.cpp)
-  target_link_libraries(test_kumi PUBLIC kumi::kumi)
-  @endcode
+    add_executable(test_kumi ../main.cpp)
+    target_link_libraries(test_kumi PUBLIC kumi::kumi)
+    @endcode
+  
+  @tab_end
 
 **/

--- a/include/kumi/algorithm/apply.hpp
+++ b/include/kumi/algorithm/apply.hpp
@@ -85,11 +85,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/apply.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/apply.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr apply_t apply{};

--- a/include/kumi/algorithm/back_front.hpp
+++ b/include/kumi/algorithm/back_front.hpp
@@ -70,11 +70,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/back-front.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/back-front.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr front_t front{};
@@ -120,11 +124,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/back-front.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/back-front.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr back_t back{};

--- a/include/kumi/algorithm/cartesian_product.hpp
+++ b/include/kumi/algorithm/cartesian_product.hpp
@@ -78,11 +78,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/cartesian_product.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/cartesian_product.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr cartesian_product_t cartesian_product{};

--- a/include/kumi/algorithm/cast.hpp
+++ b/include/kumi/algorithm/cast.hpp
@@ -73,11 +73,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/member_cast.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/member_cast.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   template<typename T> inline constexpr member_cast_t<T> member_cast{};

--- a/include/kumi/algorithm/cat.hpp
+++ b/include/kumi/algorithm/cat.hpp
@@ -64,11 +64,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/cat.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/cat.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr cat_t cat{};

--- a/include/kumi/algorithm/contains.hpp
+++ b/include/kumi/algorithm/contains.hpp
@@ -115,11 +115,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/contains.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/contains.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr contains_t contains{};
@@ -165,11 +169,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/contains_any.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/contains_any.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr contains_any_t contains_any{};
@@ -215,11 +223,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/contains_only.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/contains_only.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr contains_only_t contains_only{};
@@ -265,11 +277,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/contains_none.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/contains_none.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr contains_none_t contains_none{};

--- a/include/kumi/algorithm/extract.hpp
+++ b/include/kumi/algorithm/extract.hpp
@@ -129,11 +129,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/extract.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/extract.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr extract_t extract{};
@@ -192,11 +196,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/remove.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/remove.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr remove_t remove{};
@@ -248,11 +256,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/split.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/split.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr split_t split{};

--- a/include/kumi/algorithm/find.hpp
+++ b/include/kumi/algorithm/find.hpp
@@ -70,11 +70,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/locate.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/locate.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr locate_t locate{};

--- a/include/kumi/algorithm/flatten.hpp
+++ b/include/kumi/algorithm/flatten.hpp
@@ -189,11 +189,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/compress.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/compress.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr compress_t compress{};
@@ -241,11 +245,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/flatten.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/flatten.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr flatten_t flatten{};
@@ -305,11 +313,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/flatten_all.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/flatten_all.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr flatten_all_t flatten_all{};
@@ -356,11 +368,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/as_flat_ptr.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/as_flat_ptr.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr as_flat_ptr_t as_flat_ptr{};

--- a/include/kumi/algorithm/fold.hpp
+++ b/include/kumi/algorithm/fold.hpp
@@ -114,11 +114,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/fold_left.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/fold_left.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr fold_left_t fold_left{};
@@ -171,11 +175,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/fold_right.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/fold_right.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr fold_right_t fold_right{};

--- a/include/kumi/algorithm/for_each.hpp
+++ b/include/kumi/algorithm/for_each.hpp
@@ -112,7 +112,6 @@ namespace kumi
     @note This function does not take part in overload resolution if `f` can't be applied to the
           elements of `t` and/or `ts`, or if the product type are not compatible. @see compatible_product_types.
 
-    @qualifier
     @qualifier inline
     @qualifier constexpr
 
@@ -139,11 +138,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/for_each.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/for_each.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr for_each_t for_each{};
@@ -159,7 +162,6 @@ namespace kumi
           elements of `t` and/or `ts` and an integral constant. This function cannot be applied
           on record types.
 
-    @qualifier
     @qualifier inline
     @qualifier constexpr
 
@@ -206,7 +208,6 @@ namespace kumi
     This function can only be applied to record types.
     The function needs to be defined to handle types modeling kumi::concepts::field.
 
-    @qualifier
     @qualifier inline
     @qualifier constexpr
 

--- a/include/kumi/algorithm/inner_product.hpp
+++ b/include/kumi/algorithm/inner_product.hpp
@@ -122,11 +122,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/inner_product.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/inner_product.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr inner_product_t inner_product{};

--- a/include/kumi/algorithm/map.hpp
+++ b/include/kumi/algorithm/map.hpp
@@ -146,11 +146,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/map.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/map.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr map_t map{};

--- a/include/kumi/algorithm/minmax.hpp
+++ b/include/kumi/algorithm/minmax.hpp
@@ -167,11 +167,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/max.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/max.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr max_t max{};
@@ -217,11 +221,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/max_flat.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/max_flat.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr max_flat_t max_flat{};
@@ -272,11 +280,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/min.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/min.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr min_t min{};
@@ -322,11 +334,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/min_flat.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/min_flat.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr min_flat_t min_flat{};

--- a/include/kumi/algorithm/partition.hpp
+++ b/include/kumi/algorithm/partition.hpp
@@ -104,11 +104,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/partition.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/partition.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   template<template<typename> typename Pred> inline constexpr partition_t<Pred> partition{};
@@ -159,11 +163,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/filter.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/filter.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   template<template<typename> typename Pred> inline constexpr filter_t<Pred> filter{};
@@ -214,11 +222,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/filter_not.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/filter_not.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   template<template<typename> typename Pred> inline constexpr filter_not_t<Pred> filter_not{};

--- a/include/kumi/algorithm/predicates.hpp
+++ b/include/kumi/algorithm/predicates.hpp
@@ -147,11 +147,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/all_of.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/all_of.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr all_of_t all_of{};
@@ -197,11 +201,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/any_of.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/any_of.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr any_of_t any_of{};
@@ -247,11 +255,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/none_of.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/none_of.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr none_of_t none_of{};
@@ -292,11 +304,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/count_if.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/count_if.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr count_if_t count_if{};
@@ -336,11 +352,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/count.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/count.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr count_t count{};

--- a/include/kumi/algorithm/push_pop.hpp
+++ b/include/kumi/algorithm/push_pop.hpp
@@ -104,11 +104,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/push_front.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/push_front.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr push_front_t push_front{};
@@ -155,11 +159,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/pop_front.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/pop_front.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr pop_front_t pop_front{};
@@ -207,11 +215,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/push_back.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/push_back.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr push_back_t push_back{};
@@ -258,11 +270,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/pop_back.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/pop_back.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr pop_back_t pop_back{};

--- a/include/kumi/algorithm/reduce.hpp
+++ b/include/kumi/algorithm/reduce.hpp
@@ -222,11 +222,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/reduce.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/reduce.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr reduce_t reduce{};
@@ -297,11 +301,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/map_reduce.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/map_reduce.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr map_reduce_t map_reduce{};
@@ -362,11 +370,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/sum.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/sum.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr sum_t sum{};
@@ -427,11 +439,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/prod.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/prod.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr prod_t prod{};
@@ -492,11 +508,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/bit_and.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/bit_and.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr bit_and_t bit_and{};
@@ -557,11 +577,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/bit_or.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/bit_or.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr bit_or_t bit_or{};
@@ -622,11 +646,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/bit_xor.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/bit_xor.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr bit_xor_t bit_xor{};

--- a/include/kumi/algorithm/reorder.hpp
+++ b/include/kumi/algorithm/reorder.hpp
@@ -117,11 +117,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/reorder.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/reorder.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   template<std::size_t... I> inline constexpr reorder_t<I...> reorder{};
@@ -236,11 +240,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/reindex.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/reindex.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   template<kumi::concepts::projection_map auto Projections> inline constexpr reindex_t<Projections> reindex{};

--- a/include/kumi/algorithm/reverse.hpp
+++ b/include/kumi/algorithm/reverse.hpp
@@ -64,11 +64,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/reverse.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/reverse.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr reverse_t reverse{};

--- a/include/kumi/algorithm/rotate.hpp
+++ b/include/kumi/algorithm/rotate.hpp
@@ -83,11 +83,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/rotate_left.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/rotate_left.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   template<std::size_t R> inline constexpr rotate_left_t<R> rotate_left{};
@@ -137,11 +141,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/rotate_right.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/rotate_right.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   template<std::size_t R> inline constexpr rotate_right_t<R> rotate_right{};

--- a/include/kumi/algorithm/scan.hpp
+++ b/include/kumi/algorithm/scan.hpp
@@ -191,11 +191,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/inclusive_scan_left.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/inclusive_scan_left.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr inclusive_scan_left_t inclusive_scan_left{};
@@ -254,11 +258,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/exclusive_scan_left.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/exclusive_scan_left.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr exclusive_scan_left_t exclusive_scan_left{};
@@ -317,11 +325,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/inclusive_scan_right.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/inclusive_scan_right.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr inclusive_scan_right_t inclusive_scan_right{};
@@ -380,11 +392,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/exclusive_scan_right.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/exclusive_scan_right.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr exclusive_scan_right_t exclusive_scan_right{};

--- a/include/kumi/algorithm/tiler.hpp
+++ b/include/kumi/algorithm/tiler.hpp
@@ -87,11 +87,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/tiles.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/tiles.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   template<std::size_t N, std::size_t O> inline constexpr tiles_t<N, O> tiles{};
@@ -146,11 +150,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/windows.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/windows.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   template<std::size_t N> inline constexpr tiles_t<N, 1> windows{};
@@ -206,11 +214,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/chunks.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/chunks.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   template<std::size_t N> inline constexpr tiles_t<N, N> chunks{};

--- a/include/kumi/algorithm/transpose.hpp
+++ b/include/kumi/algorithm/transpose.hpp
@@ -82,11 +82,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/transpose.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/transpose.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr transpose_t transpose{};

--- a/include/kumi/algorithm/unique.hpp
+++ b/include/kumi/algorithm/unique.hpp
@@ -103,11 +103,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/unique.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/unique.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr unique_t unique{};
@@ -153,11 +157,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/all_unique.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/all_unique.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr all_unique_t all_unique{};

--- a/include/kumi/algorithm/zip.hpp
+++ b/include/kumi/algorithm/zip.hpp
@@ -132,11 +132,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/zip.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/zip.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr zip_t zip{};
@@ -193,11 +197,15 @@ namespace kumi
 
     @groupheader{Examples}
 
-    @subgroupheader{Tuple}
+    @tab_begin
+
+    @tab{Tuple}
     @godbolt{doc/tuple/algo/zip_min.cpp}
 
-    @subgroupheader{Record}
+    @tab{Record}
     @godbolt{doc/record/algo/zip_min.cpp}
+
+    @tab_end
   **/
   //====================================================================================================================
   inline constexpr zip_min_t zip_min{};

--- a/test/doc/record/algo/apply_field.cpp
+++ b/test/doc/record/algo/apply_field.cpp
@@ -1,0 +1,33 @@
+/**
+  KUMI - Compact Tuple Tools
+  Copyright : KUMI Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+#include <kumi/kumi.hpp>
+#include <iostream>
+
+template<kumi::concepts::record_type Record>
+void print(std::ostream& os, Record const& t)
+{
+  kumi::apply_field
+  (
+    [&os](auto const&... args)
+    {
+      os << '[';
+      std::size_t n{0};
+      ((os << args << (++n != kumi::size<Record>::value ? ", " : "")), ...);
+      os << ']';
+    }, t
+  );
+
+  os << '\n';
+}
+
+int main()
+{
+  using namespace kumi::literals;
+
+  auto r = kumi::record{"x"_id = 1, "y"_id = 2., "z"_id = 3.f};
+  
+  print(std::cout, r);
+}


### PR DESCRIPTION
This PR enhances the documentation in kumi using doxygen-awesome features.

Note : This requires [Copacabana PR 18](https://github.com/jfalcou/copacabana/pull/18) to be merged for proper rendering.

- Tuple vs Record sections are now tabs -> smaller doc pages
- Links between pages are handled properly via buttons instead of raw links
- Setup section uses tabs per tools
    - Moved away from mentionning the build system inside commands where cmake is enough

- Missing doc file for apply_field