### PR TITLE
Add coverage and sanitizers, and share the common workflows with copacabana

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+##======================================================================================================================
+##  KUMI - Compact C++20 Tuple Toolbox
+##  Copyright : KUMI Project Contributors
+##  SPDX-License-Identifier: BSL-1.0
+##======================================================================================================================
+## Keeps the action references in .github/workflows current. Everything lands in one grouped pull
+## request a week rather than one per action, and a SHA pin is rewritten along with the version
+## comment that documents it - which is what makes pinning by commit sustainable by hand.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ##======================================================================================================================
-  ## Preserve pre-commit checks
-  ##======================================================================================================================
+  ##################################################################################################
+  ## Fast gate: pre-commit checks, standalone generation and sanitizers all start together with no
+  ## interdependency - only once all three pass does the (much heavier) compiler matrix start below.
+  ##################################################################################################
   precommit:
     runs-on: ubuntu-latest
     steps:
@@ -32,34 +33,10 @@ jobs:
         run: pre-commit run --all-files --show-diff-on-failure --color=always
 
   ##======================================================================================================================
-  ## Build and run unit tests
-  ##======================================================================================================================
-  linux-tests:
-    name: Linux
-    needs: precommit
-    uses: ./.github/workflows/linux.yml
-
-  macos-tests:
-    name: MacOS
-    needs: precommit
-    uses: ./.github/workflows/macos.yml
-
-  windows-tests:
-    name: Windows
-    needs: precommit
-    uses: ./.github/workflows/windows.yml
-
-  nvidia-tests:
-    name: Nvidia Unit Tests
-    needs: precommit
-    uses: ./.github/workflows/nvidia.yml
-
-  ##======================================================================================================================
   ## Ensure Standalone is viable
   ##======================================================================================================================
   standalone-generation:
     name: Standalone Generation
-    needs: [precommit]
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/jfalcou/compilers:v10
@@ -76,3 +53,40 @@ jobs:
         run: |
           cd build
           g++ -std=c++20 -S -I. ../test/integration/main.cpp -DKUMI_STANDALONE
+
+  ##################################################################################################
+  ## Sanitizers (ASan+UBSan)
+  ##################################################################################################
+  sanitizer-tests:
+    name: Sanitizers
+    uses: ./.github/workflows/sanitizers.yml
+
+  ##################################################################################################
+  ## Coverage report - informational, runs alongside the gate without blocking the matrix
+  ##################################################################################################
+  coverage-report:
+    name: Coverage
+    uses: ./.github/workflows/coverage.yml
+
+  ##################################################################################################
+  ## Unit Tests - the full compiler matrix, gated behind the fast checks above all passing
+  ##################################################################################################
+  linux-tests:
+    name: Linux
+    needs: [precommit, standalone-generation, sanitizer-tests]
+    uses: ./.github/workflows/linux.yml
+
+  macos-tests:
+    name: MacOS
+    needs: [precommit, standalone-generation, sanitizer-tests]
+    uses: ./.github/workflows/macos.yml
+
+  windows-tests:
+    name: Windows
+    needs: [precommit, standalone-generation, sanitizer-tests]
+    uses: ./.github/workflows/windows.yml
+
+  nvidia-tests:
+    name: Nvidia
+    needs: [precommit, standalone-generation, sanitizer-tests]
+    uses: ./.github/workflows/nvidia.yml

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,73 @@
+##======================================================================================================================
+##  KUMI - Compact C++20 Tuple Toolbox
+##  Copyright : KUMI Project Contributors
+##  SPDX-License-Identifier: BSL-1.0
+##======================================================================================================================
+name: KUMI Coverage
+on:
+  workflow_call:
+
+jobs:
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/jfalcou/compilers:v10
+
+    steps:
+      - name: Fetch current branch
+        uses: actions/checkout@v6
+
+      - name: Configure CMake and Build
+        uses: ./.github/actions/config
+        with:
+          config: Debug
+          preset: gcc-coverage
+          targets: kumi-test
+
+      - name: Run Unit Tests and Collect Coverage
+        shell: bash
+        run: cmake --build build/gcc-coverage --config Debug --target kumi-coverage-report
+
+      - name: Report Coverage
+        shell: bash
+        run: |
+          python3 - "build/gcc-coverage/coverage/summary.json" >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          import json, sys
+
+          report = json.load(open(sys.argv[1]))
+
+          # gcovr reports no rate at all for a metric a header has no instance of - a branchless
+          # header is not 0% covered, it simply has nothing to say on that metric.
+          def rate(percent):
+            return "n/a" if percent is None else f"{percent:.1f}%"
+
+          def bar(percent):
+            filled = 0 if percent is None else round(percent / 5)
+            return "#" * filled + "." * (20 - filled)
+
+          print("## Coverage of `include/kumi`\n")
+          print("| Metric | Covered | Total | Rate | |")
+          print("|---|---:|---:|---:|---|")
+          for name, key in [("Lines", "line"), ("Functions", "function"), ("Branches", "branch")]:
+            percent = report[f"{key}_percent"]
+            print(f"| {name} | {report[f'{key}_covered']} | {report[f'{key}_total']} "
+                  f"| {rate(percent)} | `{bar(percent)}` |")
+
+          print("\n<details><summary>Per-header breakdown</summary>\n")
+          print("| Header | Lines | Functions | Branches |")
+          print("|---|---:|---:|---:|")
+
+          # Worst first: the headers needing attention are the point of the table.
+          for entry in sorted(report["files"], key=lambda f: (f["line_percent"] is None, f["line_percent"])):
+            print(f"| `{entry['filename']}` | {rate(entry['line_percent'])} "
+                  f"| {rate(entry['function_percent'])} | {rate(entry['branch_percent'])} |")
+
+          print("\n</details>")
+          EOF
+
+      - name: Upload HTML Report
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-report
+          path: build/gcc-coverage/coverage/

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,27 +10,10 @@ on:
       - main
 
 jobs:
-  generate-doc:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/jfalcou/compilers:v10
-    strategy:
-      fail-fast: false
-    steps:
-      - name: Fetch current branch
-        uses: actions/checkout@v6
-      - name: Prepare KUMI
-        run: |
-          mkdir build && cd build
-          cmake .. -G Ninja -DKUMI_BUILD_TEST=OFF -DKUMI_BUILD_DOCUMENTATION=ON
-
-      - name: Generate Doxygen
-        run: |
-          cd build
-          ninja kumi-doxygen
-
-      - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build/doc
+  documentation:
+    permissions:
+      contents: write
+    uses: jfalcou/copacabana/.github/workflows/documentation.yml@17df3f26736d3a0ecc231a3b951f548dcbc09c45 # v2
+    with:
+      project: kumi
+      coverage: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,62 +14,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
-  install:
-    runs-on: [ubuntu-latest]
-    container:
-      image: ghcr.io/jfalcou/compilers:v10
-    strategy:
-      fail-fast: false
-
-    steps:
-      - name: Fetch current branch
-        uses: actions/checkout@v6
-      - name: Install KUMI from checkout
-        run: |
-          mkdir build && cd build
-          cmake -G Ninja .. -DKUMI_BUILD_TEST=OFF -DCMAKE_CXX_COMPILER=clang++
-          ninja install
-      - name: Run Sample CMake
-        run: |
-          mkdir install && cd install
-          cmake ../test/integration/install-test -G Ninja
-          ninja && ctest --verbose
-
-  fetch-content:
-    env:
-      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-    runs-on: [ubuntu-latest]
-    container:
-      image: ghcr.io/jfalcou/compilers:v10
-    strategy:
-      fail-fast: false
-
-    steps:
-      - name: Fetch current branch
-        uses: actions/checkout@v6
-      - name: Compile using FetchContent
-        run: |
-          git config --global --add safe.directory /__w/kumi/kumi
-          mkdir install && cd install
-          cmake ../test/integration/fetch-test -G Ninja -DGIT_BRANCH=${BRANCH_NAME} -DKUMI_BUILD_TEST=OFF  -DCMAKE_CXX_COMPILER=clang++
-          ninja && ctest --verbose
-
-  cpm:
-    env:
-      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-    runs-on: [ubuntu-latest]
-    container:
-      image: ghcr.io/jfalcou/compilers:v10
-    strategy:
-      fail-fast: false
-
-    steps:
-      - name: Fetch current branch
-        uses: actions/checkout@v6
-      - name: Compile using CPM
-        run: |
-          git config --global --add safe.directory /__w/kumi/kumi
-          mkdir install && cd install
-          cmake ../test/integration/cpm-test -G Ninja -DGIT_BRANCH=${BRANCH_NAME}  -DCMAKE_CXX_COMPILER=clang++ -DKUMI_BUILD_TEST=OFF
-          ninja && ctest --verbose
+  integration:
+    uses: jfalcou/copacabana/.github/workflows/integration.yml@17df3f26736d3a0ecc231a3b951f548dcbc09c45 # v2
+    with:
+      project: kumi
+      cxx-compiler: clang++

--- a/.github/workflows/package-standalone.yml
+++ b/.github/workflows/package-standalone.yml
@@ -1,5 +1,5 @@
 ##======================================================================================================================
-##  KUMI - C++ Informations Broker
+##  KUMI - Compact C++20 Tuple Toolbox
 ##  Copyright : KUMI Project Contributors
 ##  SPDX-License-Identifier: BSL-1.0
 ##======================================================================================================================
@@ -11,39 +11,9 @@ on:
 
 jobs:
   package-standalone:
-    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-    container:
-      image: ghcr.io/jfalcou/compilers:v10
-    strategy:
-      fail-fast: false
-    steps:
-      - name: Fetch current branch
-        uses: actions/checkout@v6
-
-      - name: Configure KUMI
-        run: |
-          git config --global --add safe.directory /__w/kumi/kumi
-          cmake -S . -B build -G Ninja -DKUMI_BUILD_TEST=OFF -DKUMI_BUILD_DOCUMENTATION=OFF
-
-      - name: Generate standalone KUMI header
-        run: |
-          cmake --build build --target kumi-standalone
-
-      - name: Update standalone branch
-        run: |
-          git fetch origin
-          git config --global user.email "kumi@nowhere.com"
-          git config --global user.name "KUMI Standalone Generator"
-          git checkout standalone
-          cp build/kumi.hpp kumi.hpp
-          git add kumi.hpp
-          git commit --allow-empty -m "Latest KUMI standalone"
-
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: "standalone"
+    uses: jfalcou/copacabana/.github/workflows/package-standalone.yml@17df3f26736d3a0ecc231a3b951f548dcbc09c45 # v2
+    with:
+      project: kumi

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,39 @@
+##======================================================================================================================
+##  KUMI - Compact C++20 Tuple Toolbox
+##  Copyright : KUMI Project Contributors
+##  SPDX-License-Identifier: BSL-1.0
+##======================================================================================================================
+name: KUMI Sanitizers
+on:
+  workflow_call:
+
+jobs:
+  sanitizers:
+    name: ${{ matrix.compiler.name }} (ASan+UBSan)
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/jfalcou/compilers:v10
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          - { name: "gcc"  , preset: "gcc-sanitize"   }
+          - { name: "clang", preset: "clang-sanitize" }
+
+    steps:
+      - name: Fetch current branch
+        uses: actions/checkout@v6
+
+      - name: Configure CMake and Build
+        uses: ./.github/actions/config
+        with:
+          config: Debug
+          preset: ${{ matrix.compiler.preset }}
+          targets: unit.exe doc.exe
+
+      - name: Run Unit Tests
+        uses: ./.github/actions/test
+        with:
+          config: Debug
+          preset: ${{ matrix.compiler.preset }}
+          targets: unit|doc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,10 @@ if(DEFINED CMAKE_CUDA_COMPILER)
 endif()
 
 ##======================================================================================================================
-option( KUMI_BUILD_TEST             "Build tests using Kumi headers"            ON  )
-option( KUMI_BUILD_DOCUMENTATION    "Build Doxygen for Kumi"                    OFF )
+option( KUMI_BUILD_TEST             "Build tests using Kumi headers"                                ON  )
+option( KUMI_BUILD_DOCUMENTATION    "Build Doxygen for Kumi"                                        OFF )
+option( KUMI_ENABLE_SANITIZERS      "Build tests with AddressSanitizer + UndefinedBehaviorSanitizer" OFF )
+option( KUMI_ENABLE_COVERAGE        "Build tests with code coverage instrumentation"                 OFF )
 
 ##======================================================================================================================
 include(${PROJECT_SOURCE_DIR}/cmake/dependencies.cmake)
@@ -37,6 +39,8 @@ if(NOT KUMI_QUIET)
   endif()
   message(STATUS "[${PROJECT_NAME}] - Unit tests              : ${KUMI_BUILD_TEST} (via KUMI_BUILD_TEST)")
   message(STATUS "[${PROJECT_NAME}] - Doxygen                 : ${KUMI_BUILD_DOCUMENTATION} (via KUMI_BUILD_DOCUMENTATION)")
+  message(STATUS "[${PROJECT_NAME}] - Sanitizers              : ${KUMI_ENABLE_SANITIZERS} (via KUMI_ENABLE_SANITIZERS)")
+  message(STATUS "[${PROJECT_NAME}] - Coverage                : ${KUMI_ENABLE_COVERAGE} (via KUMI_ENABLE_COVERAGE)")
   set(QUIET_OPTION "")
 else()
   set(QUIET_OPTION "QUIET")
@@ -75,7 +79,16 @@ copa_setup_standalone ( QUIET
 ## Tests setup
 ##======================================================================================================================
 if(KUMI_BUILD_TEST)
+  if(KUMI_ENABLE_SANITIZERS)
+    copa_setup_sanitizers(kumi_opts ENABLE_ASAN ENABLE_UBSAN)
+  endif()
+
   enable_testing()
   add_custom_target(kumi-unit)
   add_subdirectory(test)
+
+  # After the test targets exist, so the coverage targets can depend on them
+  if(KUMI_ENABLE_COVERAGE)
+    copa_setup_coverage(kumi_opts)
+  endif()
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -53,6 +53,21 @@
       }
     },
     {
+      "name": "sanitize",
+      "hidden": true,
+      "cacheVariables": {
+        "KUMI_ENABLE_SANITIZERS": "ON"
+      }
+    },
+    {
+      "name": "coverage",
+      "hidden": true,
+      "cacheVariables": {
+        "KUMI_ENABLE_COVERAGE": "ON",
+        "CMAKE_DEFAULT_BUILD_TYPE": "Debug"
+      }
+    },
+    {
       "name": "gcc",
       "inherits": ["unix-base"],
       "cacheVariables": {
@@ -72,6 +87,22 @@
       "cacheVariables": {
         "CMAKE_CXX_COMPILER": "clang++"
       }
+    },
+    {
+      "name": "gcc-sanitize",
+      "inherits": ["gcc", "sanitize"]
+    },
+    {
+      "name": "gcc-coverage",
+      "inherits": ["gcc", "coverage"]
+    },
+    {
+      "name": "clang-sanitize",
+      "inherits": ["clang", "sanitize"]
+    },
+    {
+      "name": "clang-coverage",
+      "inherits": ["clang", "coverage"]
     },
     {
       "name": "clang-cuda",
@@ -139,6 +170,10 @@
     { "name": "gcc"             , "inherits": "base-build", "configurePreset": "gcc"            },
     { "name": "clang"           , "inherits": "base-build", "configurePreset": "clang"          },
     { "name": "clang-libc++"    , "inherits": "base-build", "configurePreset": "clang-libc++"   },
+    { "name": "gcc-sanitize"    , "inherits": "base-build", "configurePreset": "gcc-sanitize"   },
+    { "name": "gcc-coverage"    , "inherits": "base-build", "configurePreset": "gcc-coverage"   },
+    { "name": "clang-sanitize"  , "inherits": "base-build", "configurePreset": "clang-sanitize" },
+    { "name": "clang-coverage"  , "inherits": "base-build", "configurePreset": "clang-coverage" },
     { "name": "icpx"            , "inherits": "base-build", "configurePreset": "icpx"           },
     { "name": "wasm"            , "inherits": "base-build", "configurePreset": "wasm"           },
     { "name": "android-arm64"   , "inherits": "base-build", "configurePreset": "android-arm64"  },
@@ -155,6 +190,10 @@
     { "name": "gcc"             , "inherits": "base-test", "configurePreset": "gcc"             },
     { "name": "clang"           , "inherits": "base-test", "configurePreset": "clang"           },
     { "name": "clang-libc++"    , "inherits": "base-test", "configurePreset": "clang-libc++"    },
+    { "name": "gcc-sanitize"    , "inherits": "base-test", "configurePreset": "gcc-sanitize"    },
+    { "name": "gcc-coverage"    , "inherits": "base-test", "configurePreset": "gcc-coverage"    },
+    { "name": "clang-sanitize"  , "inherits": "base-test", "configurePreset": "clang-sanitize"  },
+    { "name": "clang-coverage"  , "inherits": "base-test", "configurePreset": "clang-coverage"  },
     { "name": "icpx"            , "inherits": "base-test", "configurePreset": "icpx"            },
     { "name": "wasm"            , "inherits": "base-test", "configurePreset": "wasm"            },
     { "name": "android-arm64"   , "inherits": "base-test", "configurePreset": "android-arm64"   },

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -30,7 +30,7 @@ include(${CPM_DOWNLOAD_LOCATION})
 ##======================================================================================================================
 ## Retrieve dependencies
 ##======================================================================================================================
-CPMAddPackage(NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana GIT_TAG v1)
+CPMAddPackage(NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana GIT_TAG v2)
 
 if(KUMI_BUILD_TEST)
   CPMAddPackage ( NAME TTS   GITHUB_REPOSITORY jfalcou/tts

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -30,7 +30,7 @@ include(${CPM_DOWNLOAD_LOCATION})
 ##======================================================================================================================
 ## Retrieve dependencies
 ##======================================================================================================================
-CPMAddPackage(NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana GIT_TAG main)
+CPMAddPackage(NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana GIT_TAG v1)
 
 if(KUMI_BUILD_TEST)
   CPMAddPackage ( NAME TTS   GITHUB_REPOSITORY jfalcou/tts


### PR DESCRIPTION
Coverage and sanitizers ride on kumi_opts rather than on kumi_test, so the documentation tests are instrumented alongside the unit ones. The compiler matrix now waits on the standalone and sanitizer jobs before starting, which is how TTS is arranged. Measured in the CI image: 98.5% of lines, 100% of functions.

Documentation, integration and standalone generation move to copacabana, 118 lines less here, and documentation now carries the coverage report to gh-pages the way TTS does. The compiler forced on the integration jobs is kept as it was, so that part is a like-for-like replacement; it dates back to the v6 image and is worth removing on its own later.

Copacabana is pinned to v2 rather than tracked at main, and Dependabot is configured to keep the action references current - two of them were already behind.