### PR TITLE
Pin pre-commit and install it binary-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,8 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install pre-commit
-        run: pip install pre-commit
+        # Pinned, and binary-only so no dependency gets to run a setup script during install
+        run: pip install --only-binary ":all:" pre-commit==4.6.2
       - name: Run pre-commit checks
         run: pre-commit run --all-files --show-diff-on-failure --color=always
 


### PR DESCRIPTION
An unpinned install lets a dependency run a setup script during install; --only-binary keeps it to wheels. Same change already made on spy, where SonarCloud flagged it as new code.