### PR TITLE
Never collapse a short block onto one line

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -69,7 +69,7 @@ AlignTrailingComments:
 AllowAllArgumentsOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowBreakBeforeNoexceptSpecifier: Always
-AllowShortBlocksOnASingleLine: Always
+AllowShortBlocksOnASingleLine: Never
 AllowShortCaseExpressionOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortCompoundRequirementOnASingleLine: true

--- a/test/unit/record/algo/for_each.cpp
+++ b/test/unit/record/algo/for_each.cpp
@@ -86,7 +86,10 @@ TTS_CASE("Check for_each_field behavior")
   auto t = kumi::record{"a"_id = 1, "ab"_id = 3., "cr"_id = 3.4f, "de"_id = '5'};
   kumi::for_each_field(
     [](auto name, auto& m) {
-      if (name == "a") { m++; }
+      if (name == "a")
+      {
+        m++;
+      }
       else m--;
     },
     t);


### PR DESCRIPTION
clang-format 19 ignored AllowShortBlocksOnASingleLine in this position and 22 honours it, so a TTS_CASE body folds onto a single line. TTS already had Never; this is the only one of the five options that mattered, and it takes the fleet from hundreds of reformatted files down to a handful.