### PR TITLE
Trim the clang-format config down to its actual deltas

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,264 +1,29 @@
-## -------------------------------------------------------------------------------------------------
-##  KUMI - Compact C++20 Tuple Toolbox
-##  Copyright : KUMI Project Contributors
-##  SPDX-License-Identifier: BSL-1.0
-## -------------------------------------------------------------------------------------------------
 BasedOnStyle: Microsoft
-AccessModifierOffset: -2
-AlignAfterOpenBracket: Align
-AlignArrayOfStructures: None
-AlignConsecutiveAssignments:
-  AcrossEmptyLines: false
-  AcrossComments: false
-  AlignCompound: false
-  AlignFunctionPointers: false
-  PadOperators: true
-AlignConsecutiveBitFields:
-  Enabled: false
-  AcrossEmptyLines: false
-  AcrossComments: false
-  AlignCompound: false
-  AlignFunctionPointers: false
-  PadOperators: false
-AlignConsecutiveDeclarations:
-  Enabled: false
-  AcrossEmptyLines: false
-  AcrossComments: false
-  AlignCompound: false
-  AlignFunctionPointers: false
-  PadOperators: false
-AlignConsecutiveMacros:
-  Enabled: false
-  AcrossEmptyLines: false
-  AcrossComments: false
-  AlignCompound: false
-  AlignFunctionPointers: false
-  PadOperators: false
-AlignConsecutiveShortCaseStatements:
-  Enabled: false
-  AcrossEmptyLines: false
-  AcrossComments: false
-  AlignCaseArrows: false
-  AlignCaseColons: false
-AlignConsecutiveTableGenBreakingDAGArgColons:
-  Enabled: false
-  AcrossEmptyLines: false
-  AcrossComments: false
-  AlignCompound: false
-  AlignFunctionPointers: false
-  PadOperators: false
-AlignConsecutiveTableGenCondOperatorColons:
-  Enabled: false
-  AcrossEmptyLines: false
-  AcrossComments: false
-  AlignCompound: false
-  AlignFunctionPointers: false
-  PadOperators: false
-AlignConsecutiveTableGenDefinitionColons:
-  Enabled: false
-  AcrossEmptyLines: false
-  AcrossComments: false
-  AlignCompound: false
-  AlignFunctionPointers: false
-  PadOperators: false
-AlignEscapedNewlines: Right
-AlignOperands: Align
-AlignTrailingComments:
-  Kind: Always
-  OverEmptyLines: 0
 AllowAllArgumentsOnNextLine: false
-AllowAllParametersOfDeclarationOnNextLine: true
 AllowBreakBeforeNoexceptSpecifier: Always
-AllowShortBlocksOnASingleLine: Never
-AllowShortCaseExpressionOnASingleLine: true
-AllowShortCaseLabelsOnASingleLine: false
-AllowShortCompoundRequirementOnASingleLine: true
-AllowShortEnumsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: AllIfsAndElse
-AllowShortLambdasOnASingleLine: All
 AllowShortLoopsOnASingleLine: true
-AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakBeforeMultilineStrings: false
-AttributeMacros:
-  - __capability
-BinPackArguments: true
-BinPackParameters: false
-BitFieldColonSpacing: Both
-BraceWrapping:
-  AfterCaseLabel: false
-  AfterClass: true
-  AfterControlStatement: Always
-  AfterEnum: true
-  AfterFunction: true
-  AfterNamespace: true
-  AfterObjCDeclaration: true
-  AfterStruct: true
-  AfterUnion: false
-  AfterExternBlock: true
-  BeforeCatch: true
-  BeforeElse: true
-  BeforeLambdaBody: false
-  BeforeWhile: false
-  IndentBraces: false
-  SplitEmptyFunction: true
-  SplitEmptyRecord: true
-  SplitEmptyNamespace: true
-BreakAdjacentStringLiterals: true
-BreakAfterAttributes: Leave
-BreakAfterJavaFieldAnnotations: false
-BreakAfterReturnType: None
+BinPackParameters: OnePerLine
 BreakArrays: false
-BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Custom
-BreakBeforeConceptDeclarations: Always
-BreakBeforeInlineASMColon: OnlyMultiline
-BreakBeforeTernaryOperators: true
-BreakConstructorInitializers: BeforeColon
-BreakFunctionDefinitionParameters: false
-BreakInheritanceList: BeforeColon
-BreakStringLiterals: true
-BreakTemplateDeclarations: MultiLine
-ColumnLimit: 120
-CommentPragmas: ""
-CompactNamespaces: false
+CommentPragmas: ''
 ConstructorInitializerIndentWidth: 2
 ContinuationIndentWidth: 2
-Cpp11BracedListStyle: true
-DerivePointerAlignment: false
-DisableFormat: false
-EmptyLineAfterAccessModifier: Never
-EmptyLineBeforeAccessModifier: LogicalBlock
-ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: false
 IncludeBlocks: Regroup
-IncludeCategories:
-  - Regex: <spy/detail.hpp>
-    Priority: 1
-    CaseSensitive: true
-    SortPriority: 1
-  - Regex: <spy/.*>
-    Priority: 2
-    CaseSensitive: true
-    SortPriority: 2
-  - Regex: .*
-    Priority: 3
-    CaseSensitive: true
-    SortPriority: 3
-IncludeIsMainRegex: ""
-IncludeIsMainSourceRegex: ""
-IndentAccessModifiers: false
-IndentCaseBlocks: false
-IndentCaseLabels: false
-IndentExternBlock: AfterExternBlock
-IndentGotoLabels: true
-IndentPPDirectives: None
+IncludeIsMainRegex: ''
 IndentRequiresClause: false
 IndentWidth: 2
-IndentWrappedFunctionNames: false
-InsertBraces: false
 InsertNewlineAtEOF: true
-InsertTrailingCommas: None
-IntegerLiteralSeparator:
-  Binary: 0
-  BinaryMinDigits: 0
-  Decimal: 0
-  DecimalMinDigits: 0
-  Hex: 0
-  HexMinDigits: 0
-JavaScriptQuotes: Leave
-JavaScriptWrapImports: true
-KeepEmptyLines:
-  AtEndOfFile: false
-  AtStartOfBlock: true
-  AtStartOfFile: true
-LambdaBodyIndentation: Signature
 LineEnding: LF
-MacroBlockBegin: ""
-MacroBlockEnd: ""
 MainIncludeChar: AngleBracket
-MaxEmptyLinesToKeep: 1
 NamespaceIndentation: All
-ObjCBinPackProtocolList: Auto
-ObjCBlockIndentWidth: 2
-ObjCBreakBeforeNestedBlockParam: true
-ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: true
-PPIndentWidth: -1
-PackConstructorInitializers: BinPack
-PenaltyBreakAssignment: 2
-PenaltyBreakBeforeFirstCallParameter: 19
-PenaltyBreakComment: 300
-PenaltyBreakFirstLessLess: 120
-PenaltyBreakOpenParenthesis: 0
-PenaltyBreakScopeResolution: 500
-PenaltyBreakString: 1000
-PenaltyBreakTemplateDeclaration: 10
-PenaltyExcessCharacter: 1000000
-PenaltyIndentedWhitespace: 0
-PenaltyReturnTypeOnItsOwnLine: 1000
 PointerAlignment: Left
 QualifierAlignment: Custom
-ReferenceAlignment: Pointer
-ReflowComments: true
-RemoveBracesLLVM: false
-RemoveParentheses: Leave
-RemoveSemicolon: false
-RequiresClausePosition: OwnLine
-RequiresExpressionIndentation: OuterScope
+QualifierOrder: [inline, static, type, const]
 SeparateDefinitionBlocks: Always
-ShortNamespaceLines: 1
-SkipMacroDefinitionBody: false
-SortIncludes: Never
-SortJavaStaticImport: Before
-SortUsingDeclarations: LexicographicNumeric
-SpaceAfterCStyleCast: false
-SpaceAfterLogicalNot: false
+SortIncludes: {Enabled: false, IgnoreCase: false, IgnoreExtension: false}
 SpaceAfterTemplateKeyword: false
-SpaceAroundPointerQualifiers: Default
-SpaceBeforeAssignmentOperators: true
-SpaceBeforeCaseColon: false
-SpaceBeforeCpp11BracedList: false
-SpaceBeforeCtorInitializerColon: true
-SpaceBeforeInheritanceColon: true
-SpaceBeforeJsonColon: false
-SpaceBeforeParens: ControlStatements
-SpaceBeforeParensOptions:
-  AfterControlStatements: true
-  AfterForeachMacros: true
-  AfterFunctionDeclarationName: false
-  AfterFunctionDefinitionName: false
-  AfterIfMacros: true
-  AfterOverloadedOperator: false
-  AfterPlacementOperator: true
-  AfterRequiresInClause: false
-  AfterRequiresInExpression: false
-  BeforeNonEmptyParentheses: false
-SpaceBeforeRangeBasedForLoopColon: true
-SpaceBeforeSquareBrackets: false
-SpaceInEmptyBlock: false
-SpacesBeforeTrailingComments: 1
-SpacesInAngles: Never
-SpacesInContainerLiterals: true
-SpacesInLineCommentPrefix:
-  Minimum: 1
-  Maximum: -1
-SpacesInParens: Never
-SpacesInParensOptions:
-  ExceptDoubleParentheses: false
-  InConditionalStatements: false
-  InCStyleCasts: false
-  InEmptyParentheses: false
-  Other: false
-SpacesInSquareBrackets: false
 Standard: c++20
+StatementMacros: [TTS_CASE, TTS_CASE_TPL, TTS_CASE_WITH, TTS_WHEN, TTS_AND_THEN]
 TabWidth: 2
-TableGenBreakInsideDAGArg: DontBreak
-UseTab: Never
-VerilogBreakBetweenInstancePorts: true
-Language: Cpp
-QualifierOrder:
-  - inline
-  - static
-  - type
-  - const

--- a/test/unit/infra/concepts.cpp
+++ b/test/unit/infra/concepts.cpp
@@ -11,68 +11,70 @@
 #include <tuple>
 #include <array>
 
-TTS_CASE("Check generic concepts on product_types"){
-  TTS_WHEN("Initialize different product types"){using namespace kumi::literals;
-
-using empty_t = kumi::tuple<>;
-using empty_std = std::tuple<>;
-using empty_r = kumi::record<>;
-
-using tuple_2 = kumi::tuple<int, float>;
-using std_t_2 = std::tuple<int, float>;
-using std_a_2 = std::array<int, 2>;
-using std_p_2 = std::pair<int, float>;
-
-using tuple_3 = kumi::tuple<int, char, float>;
-using tuple_3_nc = kumi::tuple<int, char, tts::text>;
-
-using rec_ab = decltype(kumi::record{"a"_id = 1, "b"_id = 2.f});
-using rec_ab_alt = decltype(kumi::record{"a"_id = 10, "b"_id = 5.5f});
-using rec_ab_diff = decltype(kumi::record{"a"_id = 1, "b"_id = tts::text{"hi"}});
-using rec_ba = decltype(kumi::record{"b"_id = 2.f, "a"_id = 1});
-using rec_xyz = decltype(kumi::record{"x"_id = 1, "y"_id = 2, "z"_id = 3});
-
-TTS_AND_THEN("Check semantic requirements")
+TTS_CASE("Check generic concepts on product_types")
 {
-  TTS_EXPECT((kumi::concepts::follows_same_semantic<tuple_2, std_t_2, std_a_2, empty_t>));
-  TTS_EXPECT((kumi::concepts::follows_same_semantic<rec_ab, rec_ba, rec_xyz>));
+  TTS_WHEN("Initialize different product types")
+  {
+    using namespace kumi::literals;
 
-  TTS_EXPECT_NOT((kumi::concepts::follows_same_semantic<tuple_2, rec_ab>));
+    using empty_t = kumi::tuple<>;
+    using empty_std = std::tuple<>;
+    using empty_r = kumi::record<>;
 
-  TTS_EXPECT_NOT((kumi::concepts::follows_same_semantic<int, int>));
-  TTS_EXPECT_NOT((kumi::concepts::follows_same_semantic<tuple_2, int>));
-}
+    using tuple_2 = kumi::tuple<int, float>;
+    using std_t_2 = std::tuple<int, float>;
+    using std_a_2 = std::array<int, 2>;
+    using std_p_2 = std::pair<int, float>;
 
-TTS_AND_THEN("Check comparable for equality")
-{
-  TTS_EXPECT((kumi::concepts::equality_comparable<tuple_2, std_t_2>));
-  TTS_EXPECT((kumi::concepts::equality_comparable<std_a_2, std_t_2>));
+    using tuple_3 = kumi::tuple<int, char, float>;
+    using tuple_3_nc = kumi::tuple<int, char, tts::text>;
 
-  TTS_EXPECT_NOT((kumi::concepts::equality_comparable<tuple_3, tuple_3_nc>));
-  TTS_EXPECT_NOT((kumi::concepts::equality_comparable<tuple_2, tuple_3>));
+    using rec_ab = decltype(kumi::record{"a"_id = 1, "b"_id = 2.f});
+    using rec_ab_alt = decltype(kumi::record{"a"_id = 10, "b"_id = 5.5f});
+    using rec_ab_diff = decltype(kumi::record{"a"_id = 1, "b"_id = tts::text{"hi"}});
+    using rec_ba = decltype(kumi::record{"b"_id = 2.f, "a"_id = 1});
+    using rec_xyz = decltype(kumi::record{"x"_id = 1, "y"_id = 2, "z"_id = 3});
 
-  TTS_EXPECT((kumi::concepts::equality_comparable<rec_ab, rec_ba>));
-  TTS_EXPECT((kumi::concepts::equality_comparable<rec_ab, rec_ab_alt>));
+    TTS_AND_THEN("Check semantic requirements")
+    {
+      TTS_EXPECT((kumi::concepts::follows_same_semantic<tuple_2, std_t_2, std_a_2, empty_t>));
+      TTS_EXPECT((kumi::concepts::follows_same_semantic<rec_ab, rec_ba, rec_xyz>));
 
-  TTS_EXPECT_NOT((kumi::concepts::equality_comparable<rec_ab, rec_ab_diff>));
-  TTS_EXPECT_NOT((kumi::concepts::equality_comparable<rec_ab, rec_xyz>));
+      TTS_EXPECT_NOT((kumi::concepts::follows_same_semantic<tuple_2, rec_ab>));
 
-  TTS_EXPECT((kumi::concepts::equality_comparable<empty_t, empty_std>));
-  TTS_EXPECT((kumi::concepts::equality_comparable<empty_t, empty_r>));
-  TTS_EXPECT_NOT((kumi::concepts::equality_comparable<int, int>));
-}
+      TTS_EXPECT_NOT((kumi::concepts::follows_same_semantic<int, int>));
+      TTS_EXPECT_NOT((kumi::concepts::follows_same_semantic<tuple_2, int>));
+    }
 
-TTS_AND_THEN("Check Compatibility")
-{
-  TTS_EXPECT((kumi::concepts::compatible_product_types<tuple_2, std_t_2, std_p_2, std_a_2>));
-  TTS_EXPECT((kumi::concepts::compatible_product_types<empty_t, empty_std>));
+    TTS_AND_THEN("Check comparable for equality")
+    {
+      TTS_EXPECT((kumi::concepts::equality_comparable<tuple_2, std_t_2>));
+      TTS_EXPECT((kumi::concepts::equality_comparable<std_a_2, std_t_2>));
 
-  TTS_EXPECT((kumi::concepts::compatible_product_types<rec_ab, rec_ba, rec_ab_diff>));
+      TTS_EXPECT_NOT((kumi::concepts::equality_comparable<tuple_3, tuple_3_nc>));
+      TTS_EXPECT_NOT((kumi::concepts::equality_comparable<tuple_2, tuple_3>));
 
-  TTS_EXPECT_NOT((kumi::concepts::compatible_product_types<tuple_2, tuple_3>));
-  TTS_EXPECT_NOT((kumi::concepts::compatible_product_types<rec_ab, rec_xyz>));
-  TTS_EXPECT_NOT((kumi::concepts::compatible_product_types<std_a_2, rec_ab>));
-}
-}
-}
-;
+      TTS_EXPECT((kumi::concepts::equality_comparable<rec_ab, rec_ba>));
+      TTS_EXPECT((kumi::concepts::equality_comparable<rec_ab, rec_ab_alt>));
+
+      TTS_EXPECT_NOT((kumi::concepts::equality_comparable<rec_ab, rec_ab_diff>));
+      TTS_EXPECT_NOT((kumi::concepts::equality_comparable<rec_ab, rec_xyz>));
+
+      TTS_EXPECT((kumi::concepts::equality_comparable<empty_t, empty_std>));
+      TTS_EXPECT((kumi::concepts::equality_comparable<empty_t, empty_r>));
+      TTS_EXPECT_NOT((kumi::concepts::equality_comparable<int, int>));
+    }
+
+    TTS_AND_THEN("Check Compatibility")
+    {
+      TTS_EXPECT((kumi::concepts::compatible_product_types<tuple_2, std_t_2, std_p_2, std_a_2>));
+      TTS_EXPECT((kumi::concepts::compatible_product_types<empty_t, empty_std>));
+
+      TTS_EXPECT((kumi::concepts::compatible_product_types<rec_ab, rec_ba, rec_ab_diff>));
+
+      TTS_EXPECT_NOT((kumi::concepts::compatible_product_types<tuple_2, tuple_3>));
+      TTS_EXPECT_NOT((kumi::concepts::compatible_product_types<rec_ab, rec_xyz>));
+      TTS_EXPECT_NOT((kumi::concepts::compatible_product_types<std_a_2, rec_ab>));
+    }
+  }
+};

--- a/test/unit/record/algo/map_field.cpp
+++ b/test/unit/record/algo/map_field.cpp
@@ -53,9 +53,9 @@ TTS_CASE("Check map_field(f, {}) behavior")
   TTS_EXPECT_NOT(was_run);
 };
 
-TTS_CASE("Check map_name(f, record) behavior"){
-  {auto t = kumi::record{"boat"_id = 1, "biologic"_id = 2., "coat"_id = 3.4f, "dystopic"_id = '5',
-                         "whatever"_id = short{55}};
+TTS_CASE("Check map_name(f, record) behavior")
+{{auto t =
+    kumi::record{"boat"_id = 1, "biologic"_id = 2., "coat"_id = 3.4f, "dystopic"_id = '5', "whatever"_id = short{55}};
 
 {
   auto s = kumi::map_field(
@@ -105,8 +105,8 @@ TTS_CASE("Check map_name(f, record) behavior"){
 }
 ;
 
-TTS_CASE("Check map_field(f, record) constexpr behavior"){
-  {constexpr auto t = kumi::record{"a"_id = 1, "b"_id = 2., "c"_id = 3.4f, "d"_id = '5'};
+TTS_CASE("Check map_field(f, record) constexpr behavior")
+{{constexpr auto t = kumi::record{"a"_id = 1, "b"_id = 2., "c"_id = 3.4f, "d"_id = '5'};
 
 {
   constexpr auto s = kumi::map_field([](auto, auto m) { return sizeof(m); }, t);

--- a/test/unit/record/algo/reorder.cpp
+++ b/test/unit/record/algo/reorder.cpp
@@ -41,8 +41,8 @@ TTS_CASE("Check result::reorder_fields<record,Name...> behavior")
   TTS_TYPE_IS((kumi::result::reorder_t<record_t>), kumi::record<>);
 };
 
-TTS_CASE("Check reorder<I...>(record) behavior"){
-  {auto t = kumi::record{"a"_id = 1, "b"_id = 2., "c"_id = 3.4f, "d"_id = '5'};
+TTS_CASE("Check reorder<I...>(record) behavior")
+{{auto t = kumi::record{"a"_id = 1, "b"_id = 2., "c"_id = 3.4f, "d"_id = '5'};
 
 {
   auto s = kumi::reorder<0, 1, 2, 3>(t);
@@ -87,8 +87,8 @@ TTS_CASE("Check reorder<I...>(record) behavior"){
 }
 ;
 
-TTS_CASE("Check reorder_fields<Name...>(record) behavior"){
-  {auto t = kumi::record{"a"_id = 1, "b"_id = 2., "c"_id = 3.4f, "d"_id = '5'};
+TTS_CASE("Check reorder_fields<Name...>(record) behavior")
+{{auto t = kumi::record{"a"_id = 1, "b"_id = 2., "c"_id = 3.4f, "d"_id = '5'};
 
 {
   auto s = kumi::reorder_fields<"a"_id, "b"_id, "c"_id, "d"_id>(t);
@@ -133,8 +133,8 @@ TTS_CASE("Check reorder_fields<Name...>(record) behavior"){
 }
 ;
 
-TTS_CASE("Check reorder<I...>(record) constexpr behavior"){
-  {constexpr auto t = kumi::record{"a"_id = 1, "b"_id = 2., "c"_id = 3.4f, "d"_id = '5'};
+TTS_CASE("Check reorder<I...>(record) constexpr behavior")
+{{constexpr auto t = kumi::record{"a"_id = 1, "b"_id = 2., "c"_id = 3.4f, "d"_id = '5'};
 
 {
   constexpr auto s = kumi::reorder<0, 1, 2, 3>(t);
@@ -179,8 +179,8 @@ TTS_CASE("Check reorder<I...>(record) constexpr behavior"){
 }
 ;
 
-TTS_CASE("Check reorder_fields<Name...>(record) constexpr behavior"){
-  {constexpr auto t = kumi::record{"a"_id = 1, "b"_id = 2., "c"_id = 3.4f, "d"_id = '5'};
+TTS_CASE("Check reorder_fields<Name...>(record) constexpr behavior")
+{{constexpr auto t = kumi::record{"a"_id = 1, "b"_id = 2., "c"_id = 3.4f, "d"_id = '5'};
 
 {
   constexpr auto s = kumi::reorder_fields<"a"_id, "b"_id, "c"_id, "d"_id>(t);

--- a/test/unit/tuple/algo/map.cpp
+++ b/test/unit/tuple/algo/map.cpp
@@ -48,7 +48,8 @@ TTS_CASE("Check map(f, {}) behavior")
   TTS_EXPECT_NOT(was_run);
 };
 
-TTS_CASE("Check map(f, tuple) behavior"){{auto t = kumi::tuple{1, 2., 3.4f, '5'};
+TTS_CASE("Check map(f, tuple) behavior")
+{{auto t = kumi::tuple{1, 2., 3.4f, '5'};
 
 {
   auto s = kumi::map([](auto m) { return sizeof(m); }, t);
@@ -108,7 +109,8 @@ TTS_CASE("Check map(f, tuple) behavior"){{auto t = kumi::tuple{1, 2., 3.4f, '5'}
 }
 ;
 
-TTS_CASE("Check map(f, tuple) constexpr behavior"){{constexpr auto t = kumi::tuple{1, 2., 3.4f, '5'};
+TTS_CASE("Check map(f, tuple) constexpr behavior")
+{{constexpr auto t = kumi::tuple{1, 2., 3.4f, '5'};
 
 {
   constexpr auto s = kumi::map([](auto m) { return sizeof(m); }, t);

--- a/test/unit/tuple/algo/map_index.cpp
+++ b/test/unit/tuple/algo/map_index.cpp
@@ -43,7 +43,8 @@ TTS_CASE("Check map_index(f, {}) behavior")
   TTS_EXPECT_NOT(was_run);
 };
 
-TTS_CASE("Check map_index(f, tuple) behavior"){{auto t = kumi::tuple{1, 2., 3.4f, '5'};
+TTS_CASE("Check map_index(f, tuple) behavior")
+{{auto t = kumi::tuple{1, 2., 3.4f, '5'};
 
 {
   auto s = kumi::map_index([](auto i, auto m) { return i + sizeof(m); }, t);


### PR DESCRIPTION
The file was a full clang-format --dump-config, so most of it only restated the defaults of the style it is based on. What is left is BasedOnStyle plus the options that actually differ from it.

Five test files move, and they move because kumi declared no StatementMacros at all: clang-format did not know TTS_CASE and TTS_WHEN open a block, so it glued the brace to the macro and left the whole body at indentation zero. Adding the list puts them back where they belong. Every other file in the repository formats byte-identically under the old and the new config.

The IncludeCategories are gone as well: SortIncludes is off, so they sorted nothing, and the ones that were there matched spy headers.