### PR TITLE
Rename doxygen groups to avoid collision with external projects

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -2833,15 +2833,6 @@ DOT_GRAPH_MAX_NODES    = 50
 
 MAX_DOT_GRAPH_DEPTH    = 0
 
-# Set the DOT_MULTI_TARGETS tag to YES to allow dot to generate multiple output
-# files in one run (i.e. multiple -o and -T options on the command line). This
-# makes dot run faster, but since only newer versions of dot (>1.8.10) support
-# this, this feature is disabled by default.
-# The default value is: NO.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_MULTI_TARGETS      = NO
-
 # If the GENERATE_LEGEND tag is set to YES doxygen will generate a legend page
 # explaining the meaning of the various boxes and arrows in the dot generated
 # graphs.

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,4 +1,4 @@
-Change Log {#changelog}
+Change Log {#kumi_changelog}
 ==========
 
 # Version 4.0 - Flawless Fluorite

--- a/doc/glossary/cpp_vocabulary.md
+++ b/doc/glossary/cpp_vocabulary.md
@@ -1,4 +1,4 @@
-C++ Specific Terms {#cpp_spec}
+C++ Specific Terms {#kumi_cpp_spec}
 ==========
 
 ## Empty Base Optimization

--- a/doc/glossary/identities.hpp
+++ b/doc/glossary/identities.hpp
@@ -1,7 +1,7 @@
 #error This file is for documentation only - DO NOT INCLUDE
 /**
 
-@page identity The Identity Elements (The "0" and "1" of Types)
+@page kumi_identity The Identity Elements (The "0" and "1" of Types)
 
 Just as there are neutral elements for mathematical operations, there are neutral elements for types. The neutral is a 
 mathematical element that has no effect on the computation such that using it results in the identity. The  simplest 
@@ -10,7 +10,7 @@ neutrals that govern type algebra. These types are the foundational "identity" e
 
 ---
 
-@section empty Empty Type : \f$ (0 / \bot) \f$
+@section kumi_empty Empty Type : \f$ (0 / \bot) \f$
 
 The **Empty Type** is the identity element for **Sums** \f$ (A + 0 \cong A ) \f$. It represents a type with no 
 inhabitants.
@@ -36,7 +36,7 @@ types and their associated algebra.
 
 ---
 
-@section unit Unit Type : \f$ (1 / \top) \f$
+@section kumi_unit Unit Type : \f$ (1 / \top) \f$
 
 The **Unit Type** is the identity element for **Products** \f$ (A \times 1 \cong A) \f$. It represents a type with
 exactly one inhabitant.
@@ -63,9 +63,9 @@ complex types.
 
 <div class="section_buttons">
  
-| Previous                          |                              Next |
-|:----------------------------------|----------------------------------:|
-| [Introduction](@ref introduction) | [Product Types](@ref product)     |
+| Previous                                |                              Next   |
+|:----------------------------------------|------------------------------------:|
+| [Introduction](@ref kumi_introduction)  | [Product Types](@ref kumi_product)  |
  
 </div>
 

--- a/doc/glossary/introduction.hpp
+++ b/doc/glossary/introduction.hpp
@@ -1,12 +1,12 @@
 #error This file is for documentation only - DO NOT INCLUDE
 /**
 
-@page introduction Type Theoretic Foundations
+@page kumi_introduction Type Theoretic Foundations
 
 This introduction does not aim at providing full understanding of type theory, but is more focused on giving a brief yet
 extensive overview of the basis that might be of interest to any new or even experienced programmer. **Kumi** makes 
 extensive use of some concepts that will be detailed in the following sections. In the current state, the **Kumi** 
-library focuses on handling [product types](@ref product_type).
+library focuses on handling [product types](@ref kumi_product_type).
 
 ---
 
@@ -82,9 +82,9 @@ operations.
 
 <div class="section_buttons">
  
-|                              Next |
-|----------------------------------:|
-| [Identity Types](@ref identity)   |
+|                              Next     |
+|--------------------------------------:|
+| [Identity Types](@ref kumi_identity)  |
  
 </div>
 

--- a/doc/glossary/nomenclature.hpp
+++ b/doc/glossary/nomenclature.hpp
@@ -1,7 +1,7 @@
 #error This file is for ducomentation only - DO NOT INCLUDE
 /**
 
-  @page nomenclature Nomenclature
+  @page kumi_nomenclature Nomenclature
 
   This document establishes the formal vocabulary used throughout the KUMI library
   to ensure consistency across API documentation, error messages, and internal

--- a/doc/glossary/product.hpp
+++ b/doc/glossary/product.hpp
@@ -1,7 +1,7 @@
 #error This file is for documentation only - DO NOT INCLUDE
 /**
 
-@page product Product Types 
+@page kumi_product Product Types 
 
 @section product_construction Product Constructions (The Logic of "AND")
 
@@ -11,7 +11,7 @@ The structure of a product type is determined by the fixed order of the operands
 
 ---
 
-@section product_type Product Type \f$ (A \times B) \f$
+@section kumi_product_type Product Type \f$ (A \times B) \f$
 
 A **Product Type** is a compound type formed by combining multiple types. 
 
@@ -65,7 +65,7 @@ yet optimized representation of them. Each type provided in the standard can be 
 
 ---
 
-@section record_type Record Type \f$ (\{l_A: A\} \times \{l_B: B\}) \f$
+@section kumi_record_type Record Type \f$ (\{l_A: A\} \times \{l_B: B\}) \f$
 
 A **Record Type** identifies its components by a **unique label** rather than a position. 
 
@@ -116,9 +116,9 @@ whereas for a programmer that has to consider memory representation, this is pot
 
 <div class="section_buttons">
  
-| Previous                        |
-|:--------------------------------|
-| [Identity Types](@ref identity) | 
+| Previous                              |
+|:--------------------------------------|
+| [Identity Types](@ref kumi_identity)  | 
  
 </div>
 

--- a/doc/index.hpp
+++ b/doc/index.hpp
@@ -1,7 +1,7 @@
 #error This file is for documentation only - DO NOT INCLUDE
 /**
 
-  \mainpage The C++20 Compact Tuple Tools
+  @mainpage The C++20 Compact Tuple Tools
 
   <strong>KUMI</strong> is a fancy C++20 implementation of a tuple-like class. It tries to be as close to
   `std::tuple` as possible but also wants to compile faster, uses a better C++20 oriented interface,
@@ -13,93 +13,99 @@
     -  Algorithm on tuples
     -  Record type handling
 
-  # Examples
+  @section Examples
 
-  ## Tuple
-  @code
-  #include <iostream>
-  #include <kumi/kumi.hpp>
+  @tab_begin
 
-  auto get_student(int id)
-  {
-          if (id == 0)  return kumi::make_tuple(3.8, 'A', "Lisa Simpson");
-    else  if (id == 1)  return kumi::make_tuple(2.9, 'C', "Milhouse Van Houten");
-    else  if (id == 2)  return kumi::make_tuple(1.7, 'D', "Ralph Wiggum");
-    else                return kumi::make_tuple(0. , 'F', "Unknown");
-  }
+  @tab{Tuple}
+    
+    @code
+    #include <iostream>
+    #include <kumi/kumi.hpp>
 
-  int main()
-  {
-    auto student0 = get_student(0);
+    auto get_student(int id)
+    {
+            if (id == 0)  return kumi::make_tuple(3.8, 'A', "Lisa Simpson");
+      else  if (id == 1)  return kumi::make_tuple(2.9, 'C', "Milhouse Van Houten");
+      else  if (id == 2)  return kumi::make_tuple(1.7, 'D', "Ralph Wiggum");
+      else                return kumi::make_tuple(0. , 'F', "Unknown");
+    }
 
-    std::cout << "ID: 0, "
-              << "GPA:   " << kumi::get<0>(student0) << ", "
-              << "grade: " << kumi::get<1>(student0) << ", "
-              << "name:  " << kumi::get<2>(student0) << '\n';
+    int main()
+    {
+      auto student0 = get_student(0);
 
-    auto [ gpa1, grade1, name1 ] = get_student(1);
-    std::cout << "ID: 1, "
-              << "GPA: "   << gpa1   << ", "
-              << "grade: " << grade1 << ", "
-              << "name: "  << name1  << '\n';
-    std::cout << "\n";
+      std::cout << "ID: 0, "
+                << "GPA:   " << kumi::get<0>(student0) << ", "
+                << "grade: " << kumi::get<1>(student0) << ", "
+                << "name:  " << kumi::get<2>(student0) << '\n';
 
-    auto all_students = kumi::make_tuple(get_student(0),get_student(1),get_student(2));
+      auto [ gpa1, grade1, name1 ] = get_student(1);
+      std::cout << "ID: 1, "
+                << "GPA: "   << gpa1   << ", "
+                << "grade: " << grade1 << ", "
+                << "name: "  << name1  << '\n';
+      std::cout << "\n";
 
-    kumi::for_each_index( [](auto i, auto const& m) {
-                          std::cout << "Data #" << i << " : " << m << "\n";
-                        }
-                        , all_students
-                        );
-    std::cout << "\n";
+      auto all_students = kumi::make_tuple(get_student(0),get_student(1),get_student(2));
 
-    auto grades = kumi::get<0>(kumi::transpose(all_students));
-    std::cout << grades << "\n";
-  }
-  @endcode
+      kumi::for_each_index( [](auto i, auto const& m) {
+                            std::cout << "Data #" << i << " : " << m << "\n";
+                          }
+                          , all_students
+                          );
+      std::cout << "\n";
 
-  ## Record
-  @code
-  #include <iostream>
-  #include <kumi/kumi.hpp>
+      auto grades = kumi::get<0>(kumi::transpose(all_students));
+      std::cout << grades << "\n";
+    }
+    @endcode
 
-  using namespace kumi::literals;
-  auto get_student(int id)
-  {
-          if (id == 0)  return kumi::make_record("GPA"_id = 3.8, "grade"_id = 'A');
-    else  if (id == 1)  return kumi::make_record("GPA"_id = 2.9, "grade"_id = 'C');
-    else  if (id == 2)  return kumi::make_record("GPA"_id = 1.7, "grade"_id = 'D');
-    else                return kumi::make_record("GPA"_id = 0. , "grade"_id = 'F');
-  }
+  @tab{Record}
+  
+    @code
+    #include <iostream>
+    #include <kumi/kumi.hpp>
 
-  int main()
-  {
-    auto student0 = get_student(0);
+    using namespace kumi::literals;
+    auto get_student(int id)
+    {
+            if (id == 0)  return kumi::make_record("GPA"_id = 3.8, "grade"_id = 'A');
+      else  if (id == 1)  return kumi::make_record("GPA"_id = 2.9, "grade"_id = 'C');
+      else  if (id == 2)  return kumi::make_record("GPA"_id = 1.7, "grade"_id = 'D');
+      else                return kumi::make_record("GPA"_id = 0. , "grade"_id = 'F');
+    }
 
-    std::cout << "ID: 0, "
-              << "GPA:   "  << kumi::get<"GPA">(student0)   << ", "
-              << "grade: "  << kumi::get<"grade">(student0) << '\n';
+    int main()
+    {
+      auto student0 = get_student(0);
 
-    auto [ gpa1, grade1 ] = get_student(1);
-    std::cout << "ID: 1, "
-              << gpa1   << ", "
-              << grade1 << '\n';
-    std::cout << "\n";
+      std::cout << "ID: 0, "
+                << "GPA:   "  << kumi::get<"GPA">(student0)   << ", "
+                << "grade: "  << kumi::get<"grade">(student0) << '\n';
 
-    auto all_students = kumi::make_record(
-                        "Lisa Simpson"_id         = get_student(0),
-                        "Milhouse Van Houten"_id  = get_student(1),
-                        "Ralph Wiggum"_id         = get_student(2)
-                        );
+      auto [ gpa1, grade1 ] = get_student(1);
+      std::cout << "ID: 1, "
+                << gpa1   << ", "
+                << grade1 << '\n';
+      std::cout << "\n";
 
-    kumi::for_each_field( [](auto name, auto const& m) {
-                          std::cout << "Student: " << name << ", Data : " << m << "\n";
-                        }
-                        , all_students
-                        );
-    std::cout << "\n";
-  }
-  @endcode
+      auto all_students = kumi::make_record(
+                          "Lisa Simpson"_id         = get_student(0),
+                          "Milhouse Van Houten"_id  = get_student(1),
+                          "Ralph Wiggum"_id         = get_student(2)
+                          );
+
+      kumi::for_each_field( [](auto name, auto const& m) {
+                            std::cout << "Student: " << name << ", Data : " << m << "\n";
+                          }
+                          , all_students
+                          );
+      std::cout << "\n";
+    }
+    @endcode
+
+  @tab_end
 
   # Licence
 

--- a/doc/layout.xml
+++ b/doc/layout.xml
@@ -4,36 +4,36 @@
   <navindex>
     <tab type="mainpage" visible="yes" title=""/>
     <tab type="usergroup" visible="yes" title="About The Library">
-      <tab type="user" url="@ref setup"     title="Setup"/>
-      <tab type="user" url="@ref changelog" title="Changelog"/>
-      <tab type="user" url="@ref licence"   title="Licence"/>
+      <tab type="user" url="@ref kumi_setup"     title="Setup"/>
+      <tab type="user" url="@ref kumi_changelog" title="Changelog"/>
+      <tab type="user" url="@ref kumi_licence"   title="Licence"/>
     </tab>
     <tab type="usergroup" visible="yes" title="Glossary">
       <tab type="usergroup" visible="yes" title="Type Theory">
-        <tab type="user" url="@ref introduction" title="Introduction"/>
-        <tab type="user" url="@ref identity" title="Identity Types"/>
-        <tab type="user" url="@ref product" title="Product Types"/>
+        <tab type="user" url="@ref kumi_introduction" title="Introduction"/>
+        <tab type="user" url="@ref kumi_identity" title="Identity Types"/>
+        <tab type="user" url="@ref kumi_product" title="Product Types"/>
       </tab>
-      <tab type="user" url="@ref cpp_spec" title="C++ Vocabulary"/>
-      <tab type="user" url="@ref nomenclature" title="Nomenclature"/>
+      <tab type="user" url="@ref kumi_cpp_spec" title="C++ Vocabulary"/>
+      <tab type="user" url="@ref kumi_nomenclature" title="Nomenclature"/>
     </tab>
     <tab type="usergroup" visible="yes"   title="Reference Documentation">
       <tab type="usergroup" visible="yes"   title="Types">
-        <tab type="user" url="@ref tuple_related"   title="Product Types and Functions"/>
-        <tab type="user" url="@ref record_related"  title="Record Types and Functions"/>
-        <tab type="user" url="@ref types"   title="Types"/>
+        <tab type="user" url="@ref kumi_tuple_related"   title="Product Types and Functions"/>
+        <tab type="user" url="@ref kumi_record_related"  title="Record Types and Functions"/>
+        <tab type="user" url="@ref kumi_types"   title="Types"/>
       </tab>
       <tab type="usergroup" visible="yes" title="Algorithms">
-        <tab type="user" url="@ref transforms"  title="Transformations"/>
-        <tab type="user" url="@ref queries"     title="Queries"/>
-        <tab type="user" url="@ref generators"  title="Generators"/>
-        <tab type="user" url="@ref reductions"  title="Reductions"/>
+        <tab type="user" url="@ref kumi_transforms"  title="Transformations"/>
+        <tab type="user" url="@ref kumi_queries"     title="Queries"/>
+        <tab type="user" url="@ref kumi_generators"  title="Generators"/>
+        <tab type="user" url="@ref kumi_reductions"  title="Reductions"/>
       </tab>
       <tab type="usergroup" visible="yes" title="Helpers">
-        <tab type="user" url="@ref traits"    title="Traits"/>
-        <tab type="user" url="@ref concepts"  title="Concepts"/>
-        <tab type="user" url="@ref utility"   title="Utility"/>
-        <tab type="user" url="@ref functional" title="Functional"/>
+        <tab type="user" url="@ref kumi_traits"    title="Traits"/>
+        <tab type="user" url="@ref kumi_concepts"  title="Concepts"/>
+        <tab type="user" url="@ref kumi_utility"   title="Utility"/>
+        <tab type="user" url="@ref kumi_functional" title="Functional"/>
       </tab>
       <tab type="user" url="@ref kumi"    title="Kumi Namespace"/>
     </tab>

--- a/doc/licence.md
+++ b/doc/licence.md
@@ -1,9 +1,8 @@
-Licence {#licence}
+Licence {#kumi_licence}
 =======
 
 This library is licensed under the [Boost Software License](http://opensource.org/licenses/BSL):
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Copyright : KUMI Project Contributors
 
 Boost Software License - Version 1.0 - August 17th, 2003
@@ -30,4 +29,3 @@ FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/setup.hpp
+++ b/doc/setup.hpp
@@ -1,7 +1,7 @@
 #error This file is for documentation only - DO NOT INCLUDE
 /**
 
-  @page  setup  Setup
+  @page kumi_setup Setup
 
   @tableofcontents
 

--- a/include/kumi/algorithm.hpp
+++ b/include/kumi/algorithm.hpp
@@ -11,27 +11,27 @@ namespace kumi
 {
   //====================================================================================================================
   /**
-    @defgroup algorithm Product Type Algorithms
+    @defgroup kumi_algorithm Product Type Algorithms
     @brief    Algorithms for manipulating Product types
 
     @{
-      @defgroup transforms Product Type Transformations
+      @defgroup kumi_transforms Product Type Transformations
       @brief Algorithms applying transformation to product types
       @{
-        @defgroup tuple_transforms Tuple Type Specific Transformations
+        @defgroup kumi_tuple_transforms Tuple Type Specific Transformations
         @brief Algorithms applying transformation to tuples
 
-        @defgroup record_transforms Record Type Specific Transformations
+        @defgroup kumi_record_transforms Record Type Specific Transformations
         @brief Algorithms applying transformation to records
       @}
 
-      @defgroup queries Product Type Queries
+      @defgroup kumi_queries Product Type Queries
       @brief    Algorithms querying properties from product types
 
-      @defgroup reductions Product Type Generalized Reductions
+      @defgroup kumi_reductions Product Type Generalized Reductions
       @brief    Algorithms performing reductions over product types
 
-      @defgroup generators Product Type Generators
+      @defgroup kumi_generators Product Type Generators
       @brief    Algorithms generating product types
     @}
   **/

--- a/include/kumi/algorithm/apply.hpp
+++ b/include/kumi/algorithm/apply.hpp
@@ -42,7 +42,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup transforms
+    @ingroup kumi_transforms
 
     @var apply
     @brief Callable object invoking the callable object f with the elements of the product type unrolled as arguments.
@@ -100,7 +100,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup transforms
+    @ingroup kumi_transforms
 
     @var apply_field
     @brief Callable object invoking the callable object f with the elements of the product type unrolled as arguments.

--- a/include/kumi/algorithm/back_front.hpp
+++ b/include/kumi/algorithm/back_front.hpp
@@ -31,7 +31,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup queries
+    @ingroup kumi_queries
 
     @var front
     @brief Callable object used to retrieve the front of a product type
@@ -85,7 +85,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup queries
+    @ingroup kumi_queries
 
     @var back
     @brief Callable object used to retrieve the back of a product type

--- a/include/kumi/algorithm/cartesian_product.hpp
+++ b/include/kumi/algorithm/cartesian_product.hpp
@@ -37,7 +37,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
     @brief  Callable object returning the Cartesian Product of all elements of its arguments product types
 
     @var cartesian_product

--- a/include/kumi/algorithm/cast.hpp
+++ b/include/kumi/algorithm/cast.hpp
@@ -35,7 +35,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var member_cast
     @brief Callable object converting a product_type<Ts...> to an instance of a product_type<Target...>

--- a/include/kumi/algorithm/cat.hpp
+++ b/include/kumi/algorithm/cat.hpp
@@ -26,7 +26,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var cat
     @brief Callable object concatenating multiple product types into a single one

--- a/include/kumi/algorithm/contains.hpp
+++ b/include/kumi/algorithm/contains.hpp
@@ -77,7 +77,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup queries
+    @ingroup kumi_queries
 
     @var contains
     @brief Callable object checking if a product type contains a given identifier
@@ -131,7 +131,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup queries
+    @ingroup kumi_queries
 
     @var contains_any
     @brief Callable object checking if a product type contains at least one of many identifier
@@ -185,7 +185,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup queries
+    @ingroup kumi_queries
 
     @var contains_only
     @brief Callable object checking if a product type contains fields based on on selected identifier
@@ -239,7 +239,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup queries
+    @ingroup kumi_queries
 
     @var contains_none
     @brief Callable object checking if a product type contains no fields based on any of the selected identifier

--- a/include/kumi/algorithm/extract.hpp
+++ b/include/kumi/algorithm/extract.hpp
@@ -77,7 +77,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var extract
     @brief Callable object extracting a sub product type from a product type
@@ -144,7 +144,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var remove
     @brief Callable object removing a sub product type from a product type
@@ -211,7 +211,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var split
     @brief Callable object splitting a product type into two

--- a/include/kumi/algorithm/find.hpp
+++ b/include/kumi/algorithm/find.hpp
@@ -34,7 +34,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup queries
+    @ingroup kumi_queries
 
     @var locate
     @brief Callable object Returning the index of a value which type satisfies a given predicate

--- a/include/kumi/algorithm/flatten.hpp
+++ b/include/kumi/algorithm/flatten.hpp
@@ -145,7 +145,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var compress
     @brief Callable object converting a product type of product type into a single product type recursively, or returns
@@ -205,7 +205,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var flatten
     @brief Callable object converting a product type of product types into a product type of all elements.
@@ -261,7 +261,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var flatten_all
     @brief Callable object converting recursively a product type of product types into a product type of all elements.
@@ -329,7 +329,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var as_flat_ptr
     @brief Callable object converting recursively a product type of product types into a flat product type of pointers

--- a/include/kumi/algorithm/fold.hpp
+++ b/include/kumi/algorithm/fold.hpp
@@ -68,7 +68,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup reductions
+    @ingroup kumi_reductions
 
     @var fold_left
     @brief Callable object computing the generalized combination of all elements using a tail recursive call.
@@ -129,7 +129,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup reductions
+    @ingroup kumi_reductions
 
     @var fold_right
     @brief Callable object computing the generalized combination of all elements using a non-tail recursive call.

--- a/include/kumi/algorithm/for_each.hpp
+++ b/include/kumi/algorithm/for_each.hpp
@@ -83,7 +83,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup transforms
+    @ingroup kumi_transforms
 
     @var for_each
     @brief Callable object applying the Callable object f on each element of a product type.
@@ -134,7 +134,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup tuple_transforms
+    @ingroup kumi_tuple_transforms
 
     @var for_each
     @brief Callable object applying the Callable object f on each element of a product type and its index.
@@ -176,7 +176,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup record_transforms
+    @ingroup kumi_record_transforms
 
     @var for_each
     @brief Callable object applying the Callable object f on each element of a product type and its field.

--- a/include/kumi/algorithm/generate.hpp
+++ b/include/kumi/algorithm/generate.hpp
@@ -50,7 +50,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var generate
     @brief Callable object creating a kumi::tuple containing `N` applications of the `f` Callable.
@@ -100,7 +100,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var fill
     @brief Callable object creating a kumi::tuple containing `N` copies of `v`.
@@ -150,7 +150,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var iota
     @brief Callable object creating a kumi::tuple containing an increasing ramp of values.

--- a/include/kumi/algorithm/inner_product.hpp
+++ b/include/kumi/algorithm/inner_product.hpp
@@ -66,7 +66,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup reductions
+    @ingroup kumi_reductions
 
     @var apply
     @brief Callable object computing the inner product (i.e. sum of products)

--- a/include/kumi/algorithm/map.hpp
+++ b/include/kumi/algorithm/map.hpp
@@ -86,7 +86,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup transforms
+    @ingroup kumi_transforms
 
     @var map
     @brief Callable object applying the Callable object `f` on each product types' elements
@@ -151,7 +151,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup tuple_transforms
+    @ingroup kumi_tuple_transforms
 
     @var map_index
     @brief Callable object applying the Callable object `f` on each product types elements and their indexes
@@ -206,7 +206,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup record_transforms
+    @ingroup kumi_record_transforms
 
     @var map_field
     @brief Callable object applying the Callable object `f` on each product types elements and their associated labels.

--- a/include/kumi/algorithm/minmax.hpp
+++ b/include/kumi/algorithm/minmax.hpp
@@ -123,7 +123,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup reductions
+    @ingroup kumi_reductions
 
     @var max
     @brief Callable object computing the maximum value of all elements of `t`.
@@ -182,7 +182,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup reductions
+    @ingroup kumi_reductions
 
     @var min
     @brief Callable object computing the maximum value of applications of `f` to all elements of kumi::flatten_all(t).
@@ -236,7 +236,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup reductions
+    @ingroup kumi_reductions
 
     @var min
     @brief Callable object computing the minimum value of all elements of `t`.
@@ -295,7 +295,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup reductions
+    @ingroup kumi_reductions
 
     @var min
     @brief Callable object computing the minimum value of applications of `f` to all elements of kumi::flatten_all(t).

--- a/include/kumi/algorithm/partition.hpp
+++ b/include/kumi/algorithm/partition.hpp
@@ -59,7 +59,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var partition
     @brief Callable object partitionning a product type over a predicate
@@ -119,7 +119,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var filter
     @brief Callable object filtering a product type over a predicate
@@ -178,7 +178,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var filter_not
     @brief Callable object filtering a product type over a predicate

--- a/include/kumi/algorithm/predicates.hpp
+++ b/include/kumi/algorithm/predicates.hpp
@@ -108,7 +108,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup queries
+    @ingroup kumi_queries
 
     @var all_of
     @brief Callable object checking if a unary predicate p returns true for every element of t.
@@ -162,7 +162,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup queries
+    @ingroup kumi_queries
 
     @var any_of
     @brief Callable object checking if a unary predicate p returns true for any element of t.
@@ -216,7 +216,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup queries
+    @ingroup kumi_queries
 
     @var none_of
     @brief Callable object checking if a unary predicate p does not returns true for any element in t.
@@ -270,7 +270,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup queries
+    @ingroup kumi_queries
 
     @var count_if
     @brief Callable object counting the number of elements of t satisfying predicates p.
@@ -319,7 +319,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup queries
+    @ingroup kumi_queries
 
     @var count
     @brief Callable object counting the number of elements of t not equivalent to false.

--- a/include/kumi/algorithm/push_pop.hpp
+++ b/include/kumi/algorithm/push_pop.hpp
@@ -63,7 +63,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var push_front
     @brief Callable object constructing a product type by adding a value `v` at the beginning of `t`.
@@ -119,7 +119,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var pop_front
     @brief Callable object removing the first (if any) element of `t`.
@@ -174,7 +174,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var push_front
     @brief Callable object constructing a product type by adding a value `v` at the end of `t`.
@@ -230,7 +230,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var pop_front
     @brief Callable object removing the last(if any) element of `t`.

--- a/include/kumi/algorithm/reduce.hpp
+++ b/include/kumi/algorithm/reduce.hpp
@@ -162,7 +162,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup reductions
+    @ingroup kumi_reductions
 
     @var reduce
     @brief Callable object performing a tree-like reduction of all elements of a product type.
@@ -237,7 +237,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup reductions
+    @ingroup kumi_reductions
 
     @var map_reduce
     @brief Callable object performing a tree-like reduction of all elements of a product type. The given map
@@ -316,7 +316,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup reductions
+    @ingroup kumi_reductions
 
     @var sum
     @brief Callable object computing the sum of all elements.
@@ -385,7 +385,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup reductions
+    @ingroup kumi_reductions
 
     @var prod
     @brief Callable object computing the product of all elements.
@@ -454,7 +454,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup reductions
+    @ingroup kumi_reductions
 
     @var bit_and
     @brief Callable object computing the bitwise AND of all elements.
@@ -523,7 +523,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup reductions
+    @ingroup kumi_reductions
 
     @var bit_or
     @brief Callable object computing the bitwise OR of all elements.
@@ -592,7 +592,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup reductions
+    @ingroup kumi_reductions
 
     @var bit_xor
     @brief Callable object computing the bitwise XOR of all elements.

--- a/include/kumi/algorithm/reorder.hpp
+++ b/include/kumi/algorithm/reorder.hpp
@@ -66,7 +66,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var reorder
     @brief Callable object reordering elements of a product type
@@ -132,7 +132,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var reorder_fields
     @brief Callable object reordering elements of a Record Type
@@ -190,7 +190,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var reindex
     @brief Callable object reindex elements of a Product Type

--- a/include/kumi/algorithm/reverse.hpp
+++ b/include/kumi/algorithm/reverse.hpp
@@ -24,7 +24,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var apply
     @brief Callable object reversing elements of a product type

--- a/include/kumi/algorithm/rotate.hpp
+++ b/include/kumi/algorithm/rotate.hpp
@@ -40,7 +40,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var rotate_left
     @brief Callable object
@@ -98,7 +98,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var rotate_right
     @brief Callable object

--- a/include/kumi/algorithm/scan.hpp
+++ b/include/kumi/algorithm/scan.hpp
@@ -143,7 +143,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup reductions
+    @ingroup kumi_reductions
 
     @var inclusive_scan_left
     @brief Callable object computing the inclusive prefix scan of all elements of a product type using a tail recursive
@@ -210,7 +210,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup reductions
+    @ingroup kumi_reductions
 
     @var exclusive_scan_left
     @brief Callable object computing the exclusive prefix scan of all elements of a product type using a tail recursive
@@ -277,7 +277,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup reductions
+    @ingroup kumi_reductions
 
     @var inclusive_scan_right
     @brief Callable object computing the inclusive suffix scan of all elements of a product type using a non-tail
@@ -344,7 +344,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup reductions
+    @ingroup kumi_reductions
 
     @var exclusive_scan_right
     @brief Callable object computing the exclusive suffix scan of all elements of a product type using a non-tail

--- a/include/kumi/algorithm/tiler.hpp
+++ b/include/kumi/algorithm/tiler.hpp
@@ -40,7 +40,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var tiles
     @brief Callable object creating a tuple of product types, each containing `N` consecutive elements from `t`.
@@ -105,7 +105,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var windows
     @brief Callable object creating a tuple of product types, each containing `N` consecutive elements from `t`.
@@ -168,7 +168,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var chunks
     @brief Callable object creating a tuple of product types, each containing `N` consecutive elements from `t`.

--- a/include/kumi/algorithm/transpose.hpp
+++ b/include/kumi/algorithm/transpose.hpp
@@ -41,7 +41,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var transpose
     @brief Callable object transposing a product type of product types by shifting elements in their

--- a/include/kumi/algorithm/unique.hpp
+++ b/include/kumi/algorithm/unique.hpp
@@ -64,7 +64,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var unique
     @brief Callable object returning a product type with consecutive duplicate types removed (pairwise uniqueness).
@@ -118,7 +118,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var all_unique
     @brief Callable object returning a product type containing the values of the first occurence of each type in `t`.

--- a/include/kumi/algorithm/zip.hpp
+++ b/include/kumi/algorithm/zip.hpp
@@ -90,7 +90,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var zip
     @brief Callable object constructing a tuple where the ith element is the product type of all ith elements of
@@ -153,7 +153,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var zip_min
     @brief Callable object constructing a tuple where the ith element is the product type of all ith elements of
@@ -218,7 +218,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup generators
+    @ingroup kumi_generators
 
     @var zip_max
     @brief Callable object constructing a tuple where the ith element is the product type of all ith elements of

--- a/include/kumi/detail/detail.hpp
+++ b/include/kumi/detail/detail.hpp
@@ -17,7 +17,7 @@ namespace kumi
 {
   //====================================================================================================================
   /**
-    @defgroup details Helper Types and Functions
+    @defgroup kumi_details Helper Types and Functions
     @brief    Tools for interacting with kumi::tuple
   **/
   //====================================================================================================================

--- a/include/kumi/detail/field.hpp
+++ b/include/kumi/detail/field.hpp
@@ -11,7 +11,7 @@ namespace kumi
 {
   //====================================================================================================================
   /**
-    @ingroup  types
+    @ingroup kumi_types
     @class    field
     @brief    Named wrapper over a type.
 
@@ -59,7 +59,7 @@ namespace kumi
     KUMI_ABI constexpr T const&& operator()(label_type) const&& noexcept { return static_cast<T const&&>(value); }
 
     //==================================================================================================================
-    /// @ingroup utility
+    /// @ingroup kumi_utility
     //! @related kumi::field
     //! @brief Inserts a kumi::field in an output stream
     //==================================================================================================================
@@ -108,7 +108,7 @@ namespace kumi
     KUMI_ABI constexpr T const&& operator()(label_type) const&& noexcept { return static_cast<T const&&>(*this); }
 
     //==================================================================================================================
-    /// @ingroup utility
+    /// @ingroup kumi_utility
     //! @related kumi::field
     //! @brief Inserts a kumi::field in an output stream
     //==================================================================================================================
@@ -131,7 +131,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup  utility
+    @ingroup kumi_utility
     @brief    Extracts the identifiers from a kumi::concepts::field or returns the parameter.
 
     @note     If the unqualified type of input does not model kumi::concepts::field, returns kumi::unkown.
@@ -162,7 +162,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup  utility
+    @ingroup kumi_utility
     @brief    Extracts the label from a kumi::concepts::field or returns the parameter.
 
     @note     If the unqualified type of input does not model kumi::concepts::field, returns kumi::unkown.
@@ -193,7 +193,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup  utility
+    @ingroup kumi_utility
     @brief    Extracts the value from a kumi::concepts::field or returns the parameter
 
     @note     If the unqualified type of input does not model kumi::concepts::field, simply forwards the parameter
@@ -225,7 +225,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup  utility
+    @ingroup kumi_utility
     @brief    Creates a field from a given value keeping the qualifiers.
 
     @tparam   Name The label to associate to the field.
@@ -257,7 +257,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup  utility
+    @ingroup kumi_utility
     @brief    Casts the provided value to the target type using `static_cast`.
 
     @note If the type to convert models kumi::concepts::field, the function does not rename the input parameter.

--- a/include/kumi/detail/str.hpp
+++ b/include/kumi/detail/str.hpp
@@ -11,7 +11,7 @@ namespace kumi
 {
   //====================================================================================================================
   /**
-    @ingroup  types
+    @ingroup kumi_types
     @class    str
     @brief    Static string used to create named fields.
 
@@ -274,7 +274,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup  types
+    @ingroup kumi_types
     @class    unknown
     @brief    Type indicating a identifier was not found in a given kumi::product_type
   **/

--- a/include/kumi/detail/streamable.hpp
+++ b/include/kumi/detail/streamable.hpp
@@ -10,7 +10,7 @@
 #ifdef KUMI_DOXYGEN_INVOKED
 //======================================================================================================================
 /**
-  @ingroup  utility
+  @ingroup kumi_utility
   @brief    Provides an extension point `as_streamable` in order to output types with no stream
             operator defined.
 
@@ -28,7 +28,7 @@ auto as_streamable(auto e);
 
 //======================================================================================================================
 /**
-  @ingroup utility
+  @ingroup kumi_utility
   @brief Provides an extension point `to_str` in order to output types with no textual
          representation defined.
 

--- a/include/kumi/functional.hpp
+++ b/include/kumi/functional.hpp
@@ -14,7 +14,7 @@
 namespace kumi
 {
   //================================================================================================
-  //! @defgroup functional Helper Types and function
+  //! @defgroup kumi_functional Helper Types and function
   //! @brief    Utilities to manipulate functions and types in a functional way
   //================================================================================================
 }

--- a/include/kumi/functional/bind.hpp
+++ b/include/kumi/functional/bind.hpp
@@ -68,7 +68,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup  functional
+    @ingroup kumi_functional
     @brief    Binds a certain amount of values into a callable reducing it's arity.
 
     @param c	Callable object to be bound.
@@ -89,7 +89,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup  functional
+    @ingroup kumi_functional
     @brief    Binds a certain amount of values into a callable reducing it's arity.
 
     @param c	Callable object to be bound.

--- a/include/kumi/functional/indexable.hpp
+++ b/include/kumi/functional/indexable.hpp
@@ -14,7 +14,7 @@ namespace kumi::function
 {
   //====================================================================================================================
   /**
-    @ingroup functional
+    @ingroup kumi_functional
 
     @var cartesian_producer
     @brief Callable object computing the index map associated to the cartesian product operation.
@@ -60,7 +60,7 @@ namespace kumi::function
 
   //====================================================================================================================
   /**
-    @ingroup functional
+    @ingroup kumi_functional
 
     @var concatenater
     @brief Callable object computing the index map associated to the concatenation operation.
@@ -106,7 +106,7 @@ namespace kumi::function
 
   //====================================================================================================================
   /**
-    @ingroup functional
+    @ingroup kumi_functional
 
     @var extractor
     @brief Callable object computing the index map associated to the extraction operation.
@@ -163,7 +163,7 @@ namespace kumi::function
 
   //====================================================================================================================
   /**
-    @ingroup functional
+    @ingroup kumi_functional
 
     @var rotater
     @brief Callable object computing the index map associated to the rotation operation.
@@ -209,7 +209,7 @@ namespace kumi::function
 
   //====================================================================================================================
   /**
-    @ingroup functional
+    @ingroup kumi_functional
 
     @var reducer
     @brief Callable object computing the index map associated to the reduction operation.
@@ -256,7 +256,7 @@ namespace kumi::function
 
   //====================================================================================================================
   /**
-    @ingroup functional
+    @ingroup kumi_functional
 
     @var repeater
     @brief Callable object generating an index sequence repeating a constant index.
@@ -302,7 +302,7 @@ namespace kumi::function
 
   //====================================================================================================================
   /**
-    @ingroup functional
+    @ingroup kumi_functional
 
     @var reverser
     @brief Callable object computing the reversed index sequence.
@@ -345,7 +345,7 @@ namespace kumi::function
 
   //====================================================================================================================
   /**
-    @ingroup functional
+    @ingroup kumi_functional
 
     @var shifter
     @brief Callable object computing linear indexing translations.
@@ -391,7 +391,7 @@ namespace kumi::function
 
   //====================================================================================================================
   /**
-    @ingroup functional
+    @ingroup kumi_functional
 
     @var splitter
     @brief Callable object computing underlying index sequences of the input domain divided in two parts.
@@ -438,7 +438,7 @@ namespace kumi::function
 
   //====================================================================================================================
   /**
-    @ingroup functional
+    @ingroup kumi_functional
 
     @var tiler
     @brief Callable object computing multi-dimensional window block layout configurations.
@@ -494,7 +494,7 @@ namespace kumi::function
 
   //====================================================================================================================
   /**
-    @ingroup functional
+    @ingroup kumi_functional
 
     @var zipper
     @brief Callable object creating the index sequence corresponding to the zip operation.
@@ -532,7 +532,7 @@ namespace kumi::function
 
   //====================================================================================================================
   /**
-    @ingroup functional
+    @ingroup kumi_functional
 
     @var slicer
     @brief Callable object computing the index map associated to a slicing (begin, end, step) operation.

--- a/include/kumi/functional/invoke.hpp
+++ b/include/kumi/functional/invoke.hpp
@@ -34,7 +34,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup  functional
+    @ingroup kumi_functional
     @brief    Invoke the Callable object c with a pack of arguments.
 
     @param c	Callable object to be invoked
@@ -52,7 +52,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup  functional
+    @ingroup kumi_functional
     @brief    Invoke the Callable object c with a pack of arguments with return type R.
 
     @tparam R the return type of the callable

--- a/include/kumi/functional/monadic.hpp
+++ b/include/kumi/functional/monadic.hpp
@@ -11,7 +11,7 @@ namespace kumi::function
 {
   //====================================================================================================================
   /**
-    @ingroup  functional
+    @ingroup kumi_functional
     @brief    If T is a kumi::product_type, returns its number of elements otherwise returns V;
 
     @tparam T type to inspect
@@ -36,7 +36,7 @@ namespace kumi::function
 
   //====================================================================================================================
   /**
-    @ingroup  functional
+    @ingroup kumi_functional
     @brief    If T is a kumi::product_type, returns it's Ith element, returns an instance of V otherwise.
 
     @note Does not participate in overload resolution if `I` is not in [0, sizeof...(Ts)).
@@ -54,7 +54,7 @@ namespace kumi::function
 
   //====================================================================================================================
   /**
-    @ingroup  functional
+    @ingroup kumi_functional
     @brief    If T is a kumi::product_type and I is within it's size, returns element_t<I,T>, returns U otherwise
 
     @tparam I Index of the type to retrieve
@@ -81,7 +81,7 @@ namespace kumi::function
   //====================================================================================================================
   /**
     @class    foldable
-    @ingroup  functional
+    @ingroup kumi_functional
     @brief    Functional wrapper for values to facilitate pipelined transformations.
 
     kumi::function::foldable provides a lightweight wrapper that enables functional-style chaining of operations
@@ -137,7 +137,7 @@ namespace kumi::function
   //====================================================================================================================
   /**
     @class    scannable
-    @ingroup  functional
+    @ingroup kumi_functional
     @brief    Functional wrapper that accumulates state during a transformation chain.
 
     kumi::scannable tracks both a current value and a transformation history. As the value is

--- a/include/kumi/functional/monoid.hpp
+++ b/include/kumi/functional/monoid.hpp
@@ -11,7 +11,7 @@ namespace kumi::function
 {
   //====================================================================================================================
   /**
-    @ingroup functional
+    @ingroup kumi_functional
     @class numeric_add
     @brief A type representing the addition monoid with it's associated identity. The identity of
            the addition is `0`.
@@ -34,7 +34,7 @@ namespace kumi::function
 
   //====================================================================================================================
   /**
-    @ingroup functional
+    @ingroup kumi_functional
     @class numeric_prod
     @brief A type representing the multiplication monoid with it's associated identity.
            The identity of the multiplication is `1`.
@@ -57,7 +57,7 @@ namespace kumi::function
 
   //====================================================================================================================
   /**
-    @ingroup functional
+    @ingroup kumi_functional
     @class boolean_and
     @brief A type representing the `logical and` monoid and it's associated identity. The identity
            of the `boolean_and` is `true`.
@@ -80,7 +80,7 @@ namespace kumi::function
 
   //====================================================================================================================
   /**
-    @ingroup functional
+    @ingroup kumi_functional
     @class boolean_or
     @brief A type representing the `logical or` monoid and it's associated identity. The identity
            of `boolean_or` is `false`.
@@ -103,7 +103,7 @@ namespace kumi::function
 
   //====================================================================================================================
   /**
-    @ingroup functional
+    @ingroup kumi_functional
     @class boolean_xor
     @brief A type representing the `logical xor` monoid and it's associated identity. The identity
            of `boolean_xor` is `false`.
@@ -126,7 +126,7 @@ namespace kumi::function
 
   //==================================================================================================================
   /**
-    @ingroup functional
+    @ingroup kumi_functional
     @brief Forms a binary monoid callable that can be used in kumi::algoritm. It represents the
            addition.
   **/
@@ -135,7 +135,7 @@ namespace kumi::function
 
   //==================================================================================================================
   /**
-    @ingroup functional
+    @ingroup kumi_functional
     @brief Forms a binary monoid callable that can be used in kumi::algoritm. It represents the
            multiplication.
   **/
@@ -144,7 +144,7 @@ namespace kumi::function
 
   //==================================================================================================================
   /**
-    @ingroup functional
+    @ingroup kumi_functional
     @brief Forms a binary monoid callable that can be used in kumi::algoritm. It represents the
            logical and operation.
   **/
@@ -153,7 +153,7 @@ namespace kumi::function
 
   //==================================================================================================================
   /**
-    @ingroup functional
+    @ingroup kumi_functional
     @brief Forms a binary monoid callable that can be used in kumi::algoritm. It represents the
            logical or operation.
   **/
@@ -162,7 +162,7 @@ namespace kumi::function
 
   //==================================================================================================================
   /**
-    @ingroup functional
+    @ingroup kumi_functional
     @brief Forms a binary monoid callable that can be used in kumi::algoritm. It represents the
            logical xor operation.
   **/

--- a/include/kumi/functional/set.hpp
+++ b/include/kumi/functional/set.hpp
@@ -40,7 +40,7 @@ namespace kumi
   {
     //==================================================================================================================
     /**
-      @ingroup  functional
+      @ingroup kumi_functional
       @brief    Logic provider to compute the index map associated to the all_unique operation.
 
       ## Callable object
@@ -67,7 +67,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup  functional
+      @ingroup kumi_functional
       @brief    Logic provider to compute the index map associated to the partition operation.
 
       ## Callable object
@@ -98,7 +98,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup  functional
+      @ingroup kumi_functional
       @brief    Logic provider to compute the index map associated to the adjacent unicity operation.
 
       ## Callable object
@@ -125,7 +125,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup  functional
+      @ingroup kumi_functional
       @brief    Callable object computing the index map associated to the adjactent unicity operation.
     **/
     //==================================================================================================================
@@ -133,7 +133,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup  functional
+      @ingroup kumi_functional
       @brief    Callable object computing the index map associated to the deduplication operation.
     **/
     //==================================================================================================================
@@ -141,7 +141,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup  functional
+      @ingroup kumi_functional
       @brief    Callable object computing the index map associated to the selection operation.
     **/
     //==================================================================================================================

--- a/include/kumi/product_types.hpp
+++ b/include/kumi/product_types.hpp
@@ -11,13 +11,13 @@ namespace kumi
 {
   //====================================================================================================================
   /**
-    @defgroup types Kumi Types
+    @defgroup kumi_types Kumi Types
     @brief    Class definition and functions on kumi types
 
-    @defgroup tuple_related Product Types and associated Functions
+    @defgroup kumi_tuple_related Product Types and associated Functions
     @brief    Definition for kumi defined product type classes and functions
 
-    @defgroup record_related Record Types and associated Functions
+    @defgroup kumi_record_related Record Types and associated Functions
     @brief    Definition for kumi defined record type classes and functions
   **/
   //====================================================================================================================

--- a/include/kumi/product_types/record.hpp
+++ b/include/kumi/product_types/record.hpp
@@ -15,7 +15,7 @@ namespace kumi
   //====================================================================================================================
   /**
     @class record
-    @ingroup record_related
+    @ingroup kumi_record_related
     @brief Fixed-size collection of heterogeneous tagged fields, tags are unique.
 
     kumi::record provides an aggregate based implementation of a record. It provides algorithms and
@@ -26,7 +26,7 @@ namespace kumi
 
     @tparam Ts Sequence of fields stored inside kumi::record.
 
-    @see @ref record_type
+    @see @ref kumi_record_type
 
     ## Example:
     @include doc/record/api/introduction.cpp
@@ -439,7 +439,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup record_related
+    @ingroup kumi_record_related
     @brief Creates a kumi::record of lvalue references to its arguments.
 
     @tparam Fields Non type template parameters names to associate to the each element.
@@ -458,7 +458,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup record_related
+    @ingroup kumi_record_related
     @brief Creates a kumi::record of forwarding references to its arguments.
 
     Constructs a record of references to the arguments in args suitable for forwarding as an
@@ -485,7 +485,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup record_related
+    @ingroup kumi_record_related
     @brief Creates a record object, deducing the target type from the types of arguments.
 
     @param ts	Zero or more lvalue arguments to construct the record from.
@@ -504,7 +504,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup record_related
+    @ingroup kumi_record_related
     @brief Creates a kumi::record of references given a reference to a kumi::record_type.
 
     @param    r Record whose elements are to be referenced.
@@ -536,7 +536,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup record_related
+    @ingroup kumi_record_related
     @brief Converts a kumi::record to an instance of a type that models kumi::record_type
 
     Constructs an instance of `Type` by passing elements of `t` to the appropriate constructor.
@@ -562,7 +562,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup record_related
+    @ingroup kumi_record_related
     @brief Converts a kumi::record_type to an instance kumi::record
 
     Constructs an instance kumi::record from the elements of the kumi::product_type parameters

--- a/include/kumi/product_types/tuple.hpp
+++ b/include/kumi/product_types/tuple.hpp
@@ -13,7 +13,7 @@ namespace kumi
   //====================================================================================================================
   /**
     @class tuple
-    @ingroup tuple_related
+    @ingroup kumi_tuple_related
     @brief Fixed-size collection of heterogeneous values.
 
     kumi::tuple provides an aggregate based implementation of a tuple. It provides algorithms and
@@ -23,7 +23,7 @@ namespace kumi
 
     @tparam Ts Sequence of types stored inside kumi::tuple.
 
-    @see @ref product_type
+    @see @ref kumi_product_type
 
     ## Example:
     @include doc/tuple/api/introduction.cpp
@@ -511,7 +511,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup tuple_related
+    @ingroup kumi_tuple_related
     @brief Creates a kumi::tuple of lvalue references to its arguments.
     @param ts	Zero or more lvalue arguments to construct the tuple from.
     @return A kumi::tuple object containing lvalue references.
@@ -526,7 +526,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup tuple_related
+    @ingroup kumi_tuple_related
     @brief Creates a kumi::tuple of forwarding references to its arguments.
 
     Constructs a tuple of references to the arguments in args suitable for forwarding as an
@@ -549,7 +549,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup tuple_related
+    @ingroup kumi_tuple_related
     @brief Creates a tuple object, deducing the target type from the types of arguments.
 
     @param ts	Zero or more lvalue arguments to construct the tuple from.
@@ -567,7 +567,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup tuple_related
+    @ingroup kumi_tuple_related
     @brief Creates a kumi::tuple of references given a reference to a kumi::product_type.
 
     @param    t Tuple whose elements are to be referenced.
@@ -598,7 +598,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup tuple_related
+    @ingroup kumi_tuple_related
     @brief Converts a kumi::tuple to an instance of an arbitrary type
 
     Constructs an instance of `Type` by passing elements of `t` to the appropriate constructor.
@@ -622,7 +622,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup tuple_related
+    @ingroup kumi_tuple_related
     @brief Converts a kumi::product_type to an instance kumi::tuple
 
     Constructs an instance kumi::tuple from the elements of the kumi::product_type parameters
@@ -679,7 +679,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup tuple_related
+    @ingroup kumi_tuple_related
     @brief Generate a kumi::tuple type from a type
 
     If `T` is a @ref kumi::concepts::product_type, returns the kumi::tuple type containing the same element

--- a/include/kumi/utils.hpp
+++ b/include/kumi/utils.hpp
@@ -17,21 +17,21 @@ namespace kumi
 {
   //====================================================================================================================
   /**
-    @defgroup utility   Helper Types and Functions
+    @defgroup kumi_utility   Helper Types and Functions
     @brief    Tools for interacting with kumi::product_type
 
-    @defgroup concepts     Product Type Related Concepts
+    @defgroup kumi_concepts     Product Type Related Concepts
     @brief    Definition for product types related Concepts
 
-    @defgroup traits     Product Type Related Traits
+    @defgroup kumi_traits     Product Type Related Traits
     @brief    Definition for product types traits and extension points
 
-    @defgroup tuple_traits  Tuple Related Traits
-    @ingroup  traits
+    @defgroup kumi_tuple_traits  Tuple Related Traits
+    @ingroup  kumi_traits
     @brief    Definition for kumi::tuple traits and extension points
 
-    @defgroup record_traits Record Related Traits
-    @ingroup  traits
+    @defgroup kumi_record_traits Record Related Traits
+    @ingroup  kumi_traits
     @brief    Definition for kumi::record traits and extension points
   **/
   //====================================================================================================================

--- a/include/kumi/utils/as.hpp
+++ b/include/kumi/utils/as.hpp
@@ -11,7 +11,7 @@ namespace kumi
 {
   //====================================================================================================================
   /**
-     @ingroup types
+     @ingroup kumi_types
 
      @class as
      @brief Lightweight type-wrapper

--- a/include/kumi/utils/builder.hpp
+++ b/include/kumi/utils/builder.hpp
@@ -11,7 +11,7 @@ namespace kumi
 {
   //====================================================================================================================
   /**
-    @ingroup  utility
+    @ingroup kumi_utility
     @class    builder
     @brief    kumi::builder provides a generic way of defining a product type.
 

--- a/include/kumi/utils/concepts.hpp
+++ b/include/kumi/utils/concepts.hpp
@@ -58,7 +58,7 @@ namespace kumi
   {
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying a type follows the Product Type semantic
 
       A type `T` models `kumi::concepts::product_type` if it follows the standard tuple protocole and  provides
@@ -70,7 +70,7 @@ namespace kumi
       + `std::array<...>;`
       + `std::pair<...>;`
 
-      @see @ref product_type
+      @see @ref kumi_product_type
     **/
     //==================================================================================================================
     template<typename T>
@@ -78,7 +78,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying a type follows the Record Type semantic
 
       A type `T` models `kumi::concepts::record_type` if it models kumi::concepts::product_type and contains fields
@@ -87,7 +87,7 @@ namespace kumi
       ## Example types:
       + kumi::record<...>;
 
-      @see @ref record_type
+      @see @ref kumi_record_type
     **/
     //==================================================================================================================
     template<typename T>
@@ -95,7 +95,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying a type follows the Container Type semantic
 
       A type `T` models `kumi::concepts::static_container` if it is an homogeneous container of fixed size exposing
@@ -111,7 +111,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying a type follows the Container Type semantic
 
       A type `T` models `kumi::container` if it is a kumi::container of fixed size.
@@ -125,13 +125,13 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying a type represent a Unit Type
 
       A type `T` models `kumi::concepts::unit_type` if it is a kumi::concepts::product_type with a size of 0 or
       if std::is_null_pointer_v returns true.
 
-      @see @ref unit
+      @see @ref kumi_unit
     **/
     //==================================================================================================================
     template<typename T>
@@ -156,7 +156,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying a type represent a field
 
       A field type serves as a member of a kumi::record and can be retrieved by it's label later.
@@ -170,7 +170,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying a type represent an identifier
 
       An identifier type is able to be bound to a value to create a kumi::concepts::field. It represent a type that
@@ -185,7 +185,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying if a type can be used as sequence of projections in algorithms
 
       A type `T` models `kumi::projection_map` if it contains constant evaluable members which are themselves either
@@ -201,7 +201,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying if a type is suitable to be used as a projection
 
       A type `T` models `kumi::projection` if it models `kumi::projection_map` or `kumi::index`
@@ -213,7 +213,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying a type follows the Product Type semantic and has a known size
 
       A type `T` models `kumi::concepts::sized_product_type<N>` if it models `kumi::concepts::product_type` and has
@@ -225,7 +225,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying a type follows the Product Type semantic and has a size lower bound
 
       A type `T` models `kumi::concepts::sized_product_type<N>` if it models `kumi::concepts::product_type` and has
@@ -237,7 +237,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying a type follows the Product Type semantic and is empty
 
       A type `T` models `kumi::concepts::empty_product_type ` if it models `kumi::concepts::product_type` and has
@@ -249,7 +249,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying a type follows the Product Type semantic and is non-empty
 
       A type `T` models `kumi::concepts::non_empty_product_type ` if it models `kumi::concepts::product_type` and has
@@ -261,7 +261,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying is Product Type which types are all the same
 
       A type `T` models `kumi::cocnepts::homogenous_product_type` if it models `kumi::concepts::product_type` and
@@ -279,7 +279,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying if parameter pack contains a kumi::concepts::field.
     **/
     //==================================================================================================================
@@ -288,7 +288,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying if parameter pack is only composed of kumi::concepts::field.
     **/
     //==================================================================================================================
@@ -297,7 +297,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying if a parameter pack only holds distinct types.
     **/
     //==================================================================================================================
@@ -307,7 +307,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying if a parameter pack only holds kumi::concepts::field with no duplicate names.
     **/
     //==================================================================================================================
@@ -317,7 +317,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief  Concept specifying if a parameter pack only holds kumi::concepts::field with no duplicate kumi::str
               representation of their respective names.
     **/
@@ -330,7 +330,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying if a Type is present in a parameter pack.
     **/
     //==================================================================================================================
@@ -339,7 +339,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying if the label of a type modeling kumi::concepts::identifier is present in the parameter
       pack. The label is considered present if a type in Ts modeling kumi::concepts::field is labeled with the same
       tag as the given identifier.
@@ -351,7 +351,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying if the label of a type modeling kumi::concepts::identifier is present in the parameter
       pack. The label is considered present if a type in Ts modeling kumi::concepts::field is labeled with the same
       tag as the given identifier.
@@ -363,7 +363,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying if two types have matching named fields
 
       A type `T` models `kumi::concepts::equivalent<T,U>` if it is a kumi::concepts::product_type with the same number
@@ -377,7 +377,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying if a type is comparable for each of its components
 
       A type `T` models `kumi::concepts::equality_comparable<T,U>`if it's a kumi::concepts::product_type where each
@@ -390,7 +390,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying if a pack of types follows the same semantic.
 
       A pack of type `Ts` models `kumi::concepts::follows_same_semantic` if all of the types are following the
@@ -403,7 +403,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying if two product types are compatibles.
 
       A pack of types `Ts` models `kumi::concepts::compatible_product_types` if it models
@@ -417,7 +417,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying a type is a Monoid
 
       A type `T` models `kumi::concepts::monoid` if it's a binary associative callable equipped with an identity
@@ -440,7 +440,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying if a product type can be queried via a `get<type>`
 
       A type `T` models `kumi::concepts::queryable_by_type` if it's fields are uniquely typed.
@@ -454,7 +454,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying if a product type can be queried via a `get<identifier>`
 
       A type `T` models `queryable_by_identifier` if it's a kumi::concepts::product_type with it's element modeling
@@ -469,7 +469,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup concepts
+      @ingroup kumi_concepts
       @brief Concept specifying if a product type can be queried via a `get<label>`
 
       A type `T` models `queryable_by_label` if it's a kumi::concepts::product_type with it's element modeling

--- a/include/kumi/utils/ct_helpers.hpp
+++ b/include/kumi/utils/ct_helpers.hpp
@@ -21,7 +21,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup types
+    @ingroup kumi_types
     @class index_t
     @brief Integral constant type
 
@@ -42,7 +42,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup utility
+    @ingroup kumi_utility
     @brief Inline integral constant value for kumi::index_t
   **/
   //====================================================================================================================
@@ -50,7 +50,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup types
+    @ingroup kumi_types
     @class label_t
     @brief Literal constant type
 
@@ -76,7 +76,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup utility
+    @ingroup kumi_utility
     @brief Inline literal constant value for kumi::label_t
   **/
   //====================================================================================================================
@@ -92,7 +92,7 @@ namespace kumi
   {
     //==================================================================================================================
     /**
-      @ingroup utility
+      @ingroup kumi_utility
       @brief Forms a integral constant literal of the desired value.
       @return An instance of kumi::index_t for the specified integral value
       ## Example:
@@ -106,7 +106,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup utility
+      @ingroup kumi_utility
       @brief Forms a constant string literal of the desired value.
       @return An instance of kumi::name for the specified string
       ##Example:
@@ -120,7 +120,7 @@ namespace kumi
 
     //==================================================================================================================
     /**
-      @ingroup utility
+      @ingroup kumi_utility
       @brief Forms a constant string literal of the desired value.
       @return An instance of kumi::label for the specified string
 
@@ -139,7 +139,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup utility
+    @ingroup kumi_utility
     @brief Convert a unary template meta-program in a running predicate
     @tparam Pred Unary template meta-program to convert.
     @return A Callable Object applying Pred to the type of its arguments
@@ -152,7 +152,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup utility
+    @ingroup kumi_utility
     @brief Helper to retrive the index of a type in a product type by it s type
 
     @note This function does not participate in overload resolution if the product type has several instances of the
@@ -172,7 +172,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup utility
+    @ingroup kumi_utility
     @brief Helper to retrive the index of a type in a product type by it s identifier
 
     @note This function does not participate in overload resolution if the product type has several instances of the
@@ -192,7 +192,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup utility
+    @ingroup kumi_utility
     @brief Helper to retrive the index of a type in a product type by it s identifier
 
     @note This function does not participate in overload resolution if the product type has several instances of the

--- a/include/kumi/utils/identifier.hpp
+++ b/include/kumi/utils/identifier.hpp
@@ -21,7 +21,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup utility
+    @ingroup kumi_utility
     @brief  Option specifying the single type a identifier will accept.
     @tparam T Type that the parametrized identifier will accept.
 
@@ -32,7 +32,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup utility
+    @ingroup kumi_utility
     @brief  Option specifying a traits that type should verify for being used as a identifier value.
     @tparam Traits Traits that the parametrized identifier will use to validate its value.
 
@@ -66,7 +66,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup  types
+    @ingroup kumi_types
     @class    identifier
     @brief    identifier definition class
 
@@ -152,7 +152,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup  types
+    @ingroup kumi_types
     @class    name
     @brief Compile-time text based identifier
     @tparam ID Compile-time string representing an indentifier

--- a/include/kumi/utils/projections.hpp
+++ b/include/kumi/utils/projections.hpp
@@ -33,7 +33,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup utility
+    @ingroup kumi_utility
     @class   projection_map
     @brief   A stateless, compile-time schema for product type transformation.
 
@@ -125,7 +125,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup utility
+    @ingroup kumi_utility
     @brief kumi::projection_map deduction guide
     @tparam Ts  Type lists to build the projections with.
   **/
@@ -134,7 +134,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup utility
+    @ingroup kumi_utility
     @brief Creates a kumi::projection_map object, deducing the target type from the types of arguments.
 
     @note The arguments should model kumi::index
@@ -153,7 +153,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup utility
+    @ingroup kumi_utility
     @brief Creates a kumi::projection_map object, deducing the target type from the types of arguments.
 
     @note The arguments should model kumi::index
@@ -172,7 +172,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup utility
+    @ingroup kumi_utility
     @brief Creates a kumi::projection_map object, deducing the target type from the types of arguments.
 
     @note The arguments should model kumi::identifier

--- a/include/kumi/utils/traits.hpp
+++ b/include/kumi/utils/traits.hpp
@@ -11,7 +11,7 @@ namespace kumi
 {
   //====================================================================================================================
   /**
-    @ingroup traits
+    @ingroup kumi_traits
     @brief  Detects if a type follows the tuple protocol.
 
     @tparam T Type to inspect
@@ -39,7 +39,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup traits
+    @ingroup kumi_traits
     @brief Opt-in traits for types behaving like a kumi::record_type
 
     @tparam T Type to inspect
@@ -72,7 +72,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup traits
+    @ingroup kumi_traits
     @brief Computes the number of elements of a kumi::product_type
 
     @tparam T kumi::product_type to inspect
@@ -95,7 +95,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup traits
+    @ingroup kumi_traits
     @brief Provides indexed access to the types of the elements of a kumi::product_type.
 
     @tparam I Index of the type to retrieve
@@ -119,7 +119,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup traits
+    @ingroup kumi_traits
     @brief Computes the return type of a call to kumi::get
 
     @tparam I Index of the type to retrieve
@@ -147,7 +147,7 @@ namespace kumi
 {
   //====================================================================================================================
   /**
-    @ingroup traits
+    @ingroup kumi_traits
     @brief Traits detecting types behaving like a kumi::container.
 
     @tparam T Type to inspect
@@ -193,7 +193,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup traits
+    @ingroup kumi_traits
     @brief Returns the statically known number of elements of a kumi::container.
 
     @tparam T kumi::container to inspect
@@ -225,7 +225,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup traits
+    @ingroup kumi_traits
     @brief Provides access to the type of the elements of a kumi::concepts::container.
 
     @tparam T kumi::concepts::container to access
@@ -248,7 +248,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup traits
+    @ingroup kumi_traits
     @brief Detects if a given kumi::container instance size is static
 
     @tparam T kumi::container to inspect
@@ -287,7 +287,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup tuple_traits
+    @ingroup kumi_tuple_traits
     @brief Detects if a given kumi::product_type instance is homogeneous
 
     @tparam T kumi::product_type to inspect
@@ -319,7 +319,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup traits
+    @ingroup kumi_traits
     @brief Checks if a type can be used as a kumi::projection_map
 
     @tparam T The type to inspect
@@ -345,7 +345,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup traits
+    @ingroup kumi_traits
     @brief Computes the return type of a call to kumi::get on a kumi::tuple and unwrap the
            field returned by kumi::get on a kumi::record
 
@@ -378,7 +378,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup record_traits
+    @ingroup kumi_record_traits
     @brief  Provides indexed access to the types of the elements of a product type and
             unwraps the returned `field` for record type.
 
@@ -413,7 +413,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup traits
+    @ingroup kumi_traits
 
     @brief Checks if a type is an instance of a specific template.
 
@@ -444,7 +444,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup  traits
+    @ingroup kumi_traits
     @brief    Extracts the common product_type of a parameter pack.
 
     If all the types are record types then it returns an empty record type, otherwise returns an empty product type.
@@ -483,7 +483,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup traits
+    @ingroup kumi_traits
     @brief   Checks if a parameter pack only contains distinct types.
 
     @tparam Ts   The types to access
@@ -506,7 +506,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup traits
+    @ingroup kumi_traits
     @brief   Checks if a parameter pack only contains distinct kumi::field names.
              Evaluates to false if no type is a kumi::field.
 
@@ -542,7 +542,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup traits
+    @ingroup kumi_traits
     @brief   Checks if a two product types are equivalent.
 
     Two product types are considered equivalent in the following case : if the two product types are
@@ -599,7 +599,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup traits
+    @ingroup kumi_traits
     @brief   Checks if a two product types are comparable for equality.
 
     Two product types are comparable for equality uf each field in T have a corresponding field in U with each of their
@@ -632,7 +632,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup traits
+    @ingroup kumi_traits
     @brief   Unpacks a product type and applies its element types as arguments to a meta-function.
 
     ` apply_traits` takes a template meta-function (a template template parameter) and a product type. It expands the
@@ -676,7 +676,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup traits
+    @ingroup kumi_traits
     @brief   Applies a unary meta-function to each element of a product type.
 
     `map_traits` transforms a product type by applying a given meta-function `Traits` to every element type

--- a/include/kumi/utils/unit_type.hpp
+++ b/include/kumi/utils/unit_type.hpp
@@ -11,12 +11,12 @@ namespace kumi
 {
   //====================================================================================================================
   /**
-    @ingroup types
+    @ingroup kumi_types
     @class unit
     @brief A type representing the product of no type also called the unit type
 
     kumi::unit provides a way to define the unit type in a constexpr friendly manner.
-    @see @ref unit
+    @see @ref kumi_unit
   **/
   //====================================================================================================================
   struct unit
@@ -46,7 +46,7 @@ namespace kumi
 
   //====================================================================================================================
   /**
-    @ingroup utility
+    @ingroup kumi_utility
     @brief Inline constant representing a kumi::unit.
   **/
   //====================================================================================================================


### PR DESCRIPTION
This PR renames doxygen target from `target` to `kumi_target` to avoid collision, thus handling #237.

DOT_MULTI_TARGETS      = NO triggers a warning with doxygen last version, deprecated target

There are some issues in the documentation when we moved from type traits to direct inline variable/aliases.
This will need to be adressed.