### PR TITLE
Name the function each doc block documents

### DIFF
--- a/include/kumi/algorithm/inner_product.hpp
+++ b/include/kumi/algorithm/inner_product.hpp
@@ -68,7 +68,7 @@ namespace kumi
   /**
     @ingroup kumi_reductions
 
-    @var apply
+    @var inner_product
     @brief Callable object computing the inner product (i.e. sum of products)
 
     Computes the generalized sum of products of the elements of two product types. By default,

--- a/include/kumi/algorithm/reverse.hpp
+++ b/include/kumi/algorithm/reverse.hpp
@@ -26,7 +26,7 @@ namespace kumi
   /**
     @ingroup kumi_generators
 
-    @var apply
+    @var reverse
     @brief Callable object reversing elements of a product type
 
     On record types, this function operates on elements as if they were ordered. The considered order is the order


### PR DESCRIPTION
`inner_product.hpp` and `reverse.hpp` both opened their block with `@var apply`, a copy-paste from `apply.hpp` that no warning reports: the name exists, it is just not theirs. Neither function appears in the published tagfile, so neither is documented on the site, and `apply` carries three descriptions of which two are about something else.