### PR TITLE
Measure the compile cost, and run the unit workflow on a push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@
 ##======================================================================================================================
 name: Unit Tests
 on:
+  ## Also on a merge: nothing else says main is broken, and the matrix takes minutes here.
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/compile-cost.yml
+++ b/.github/workflows/compile-cost.yml
@@ -1,0 +1,28 @@
+##======================================================================================================================
+##  KUMI - Compact C++20 Tuple Toolbox
+##  Copyright : KUMI Project Contributors
+##  SPDX-License-Identifier: BSL-1.0
+##======================================================================================================================
+## What every test unit costs to compile: a push to main leaves the reference, a pull request reports the delta.
+name: KUMI Compile Cost
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: kumi-compile-cost-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compile-cost:
+    ## Reading the reference off another run asks more than the contents scope the token defaults to.
+    permissions:
+      actions: read
+      contents: read
+    uses: jfalcou/copacabana/.github/workflows/compile-cost.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    with:
+      project: kumi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ copa_add_option(KUMI_BUILD_TEST "Build tests using Kumi headers" ON LABEL "Unit 
 copa_add_option(KUMI_BUILD_DOCUMENTATION "Build Doxygen for Kumi" OFF LABEL "Doxygen")
 copa_add_option(KUMI_ENABLE_SANITIZERS "Build tests with AddressSanitizer + UndefinedBehaviorSanitizer" OFF LABEL "Sanitizers")
 copa_add_option(KUMI_ENABLE_COVERAGE "Build tests with code coverage instrumentation" OFF LABEL "Coverage")
+copa_add_option(KUMI_COMPILE_COST "Measure what every test unit costs to compile" OFF)
 
 if(KUMI_BUILD_TEST)
   include(${PROJECT_SOURCE_DIR}/cmake/compiler.cmake)
@@ -95,5 +96,10 @@ if(KUMI_BUILD_TEST)
   # After the test targets exist, so the coverage targets can depend on them
   if(KUMI_ENABLE_COVERAGE)
     copa_setup_coverage(kumi_opts)
+  endif()
+
+  # clang only: -fproc-stat-report is its flag. After the test targets, as the measurement rebuilds them.
+  if(KUMI_COMPILE_COST)
+    copa_setup_compile_cost(kumi_opts)
   endif()
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -68,6 +68,13 @@
       }
     },
     {
+      "name": "compile-cost",
+      "hidden": true,
+      "cacheVariables": {
+        "KUMI_COMPILE_COST": "ON"
+      }
+    },
+    {
       "name": "gcc",
       "inherits": ["unix-base"],
       "cacheVariables": {
@@ -103,6 +110,10 @@
     {
       "name": "clang-coverage",
       "inherits": ["clang", "coverage"]
+    },
+    {
+      "name": "clang-compile-cost",
+      "inherits": ["clang", "compile-cost"]
     },
     {
       "name": "clang-cuda",
@@ -174,6 +185,7 @@
     { "name": "gcc-coverage"    , "inherits": "base-build", "configurePreset": "gcc-coverage"   },
     { "name": "clang-sanitize"  , "inherits": "base-build", "configurePreset": "clang-sanitize" },
     { "name": "clang-coverage"  , "inherits": "base-build", "configurePreset": "clang-coverage" },
+    { "name": "clang-compile-cost", "inherits": "base-build", "configurePreset": "clang-compile-cost" },
     { "name": "icpx"            , "inherits": "base-build", "configurePreset": "icpx"           },
     { "name": "wasm"            , "inherits": "base-build", "configurePreset": "wasm"           },
     { "name": "android-arm64"   , "inherits": "base-build", "configurePreset": "android-arm64"  },
@@ -194,6 +206,7 @@
     { "name": "gcc-coverage"    , "inherits": "base-test", "configurePreset": "gcc-coverage"    },
     { "name": "clang-sanitize"  , "inherits": "base-test", "configurePreset": "clang-sanitize"  },
     { "name": "clang-coverage"  , "inherits": "base-test", "configurePreset": "clang-coverage"  },
+    { "name": "clang-compile-cost", "inherits": "base-test", "configurePreset": "clang-compile-cost" },
     { "name": "icpx"            , "inherits": "base-test", "configurePreset": "icpx"            },
     { "name": "wasm"            , "inherits": "base-test", "configurePreset": "wasm"            },
     { "name": "android-arm64"   , "inherits": "base-test", "configurePreset": "android-arm64"   },


### PR DESCRIPTION
The measurement needs clang, `-fproc-stat-report` being its flag, and the `clang-compile-cost` preset
that turns it on. A push to main leaves the reference artifact that later pull requests subtract
against, so the first run after this merge reports no delta and says so.

`ci.yml` now also triggers on a push to main. Nothing else tells us main is broken, and the matrix
takes minutes here, which makes the extra run cheap enough to pay on every merge.
