### PR TITLE
Test kumi inside CUDA kernels

### DIFF
--- a/.github/matrices/nvidia-device.yml
+++ b/.github/matrices/nvidia-device.yml
@@ -1,0 +1,12 @@
+##======================================================================================================================
+##  KUMI - Compact C++20 Tuple Toolbox
+##  Copyright : KUMI Project Contributors
+##  SPDX-License-Identifier: BSL-1.0
+##======================================================================================================================
+## Read by copacabana's matrix.yml: kumi inside real kernels, on the card the runner carries. Clang only, see #192.
+runs-on: cuda
+configs: [Debug, Release]
+build-targets: cuda.exe
+test-targets: cuda
+rows:
+  - { preset: "clang-cuda" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,3 +168,13 @@ jobs:
     uses: jfalcou/copacabana/.github/workflows/matrix.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       file: .github/matrices/nvidia-release.yml
+
+  ##################################################################################################
+  ## Device tests - kumi inside real kernels, on the card the self-hosted runner carries
+  ##################################################################################################
+  nvidia-device-tests:
+    name: Device
+    needs: [precommit, standalone-generation, sanitizer-tests]
+    uses: jfalcou/copacabana/.github/workflows/matrix.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    with:
+      file: .github/matrices/nvidia-device.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,6 @@ jobs:
   nvidia-device-tests:
     name: Device
     needs: [precommit, standalone-generation, sanitizer-tests]
-    uses: jfalcou/copacabana/.github/workflows/matrix.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/matrix.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       file: .github/matrices/nvidia-device.yml

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -41,6 +41,7 @@
         "generator": "Ninja Multi-Config",
         "cacheVariables": {
             "CMAKE_CUDA_COMPILER": "nvcc",
+            "CMAKE_CUDA_ARCHITECTURES": "75",
             "CMAKE_DEFAULT_BUILD_TYPE": "Debug"
         }
     },

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -15,6 +15,8 @@ if(CMAKE_CUDA_COMPILER_ID MATCHES "NVIDIA")
   target_compile_features( kumi_opts INTERFACE cuda_std_20 )
   target_compile_options( kumi_opts INTERFACE $<$<COMPILE_LANGUAGE:CUDA>:--Werror all-warnings -Xcompiler -Wno-deprecated-literal-operator> )
   # The literal warning is set at the moment when using nvcc13.2.5 with clang20
+  # A kernel calling kumi with a lambda goes through kumi::invoke, host and device both, which nvcc refuses without it
+  target_compile_options( kumi_opts INTERFACE $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr> )
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "NVHPC")

--- a/include/kumi/detail/abi.hpp
+++ b/include/kumi/detail/abi.hpp
@@ -41,6 +41,13 @@
 // Functions in namespace detail should not be forceinline and have a different abi
 #define KUMI_HIDDEN_ABI KUMI_CUDA inline
 
+// Device code has no exceptions: the same misuse aborts the kernel there.
+#if defined(__CUDA_ARCH__)
+#define KUMI_ERROR(MESSAGE) __trap()
+#else
+#define KUMI_ERROR(MESSAGE) throw MESSAGE
+#endif
+
 #if defined(__clang__)
 #pragma clang diagnostic ignored "-Wmissing-braces"
 #endif

--- a/include/kumi/detail/str.hpp
+++ b/include/kumi/detail/str.hpp
@@ -35,28 +35,28 @@ namespace kumi
     // -1 to be on par with std::string
     template<std::size_t N, std::size_t... Is>
     requires(N <= max_size)
-    constexpr str(char const (&s)[N], std::index_sequence<Is...>) : data_{s[Is]...}, size_(N - 1)
+    KUMI_ABI constexpr str(char const (&s)[N], std::index_sequence<Is...>) : data_{s[Is]...}, size_(N - 1)
     {
     }
 
     template<std::size_t N, std::size_t O, std::size_t... Is>
     requires(sizeof...(Is) <= max_size)
-    constexpr str(char const (&s)[N], std::integral_constant<std::size_t, O>, std::index_sequence<Is...>)
+    KUMI_ABI constexpr str(char const (&s)[N], std::integral_constant<std::size_t, O>, std::index_sequence<Is...>)
       : data_{s[Is + O]...}, size_(sizeof...(Is))
     {
     }
 
     template<std::size_t N>
     requires(N <= max_size)
-    constexpr str(char const (&s)[N]) : str{s, std::make_index_sequence<N>{}}
+    KUMI_ABI constexpr str(char const (&s)[N]) : str{s, std::make_index_sequence<N>{}}
     {
     }
 
     template<std::size_t N, std::size_t P, std::size_t S>
     requires((N >= P + S) && ((N - P - S) <= max_size))
-    constexpr str(char const (&s)[N],
-                  std::integral_constant<std::size_t, P> prefix,
-                  std::integral_constant<std::size_t, S>)
+    KUMI_ABI constexpr str(char const (&s)[N],
+                           std::integral_constant<std::size_t, P> prefix,
+                           std::integral_constant<std::size_t, S>)
       : str{s, prefix, std::make_index_sequence<(N - 1) - P - S>{}}
     {
     }
@@ -82,13 +82,13 @@ namespace kumi
 
     KUMI_ABI constexpr str remove_prefix(size_type n) const
     {
-      if (n > size_) throw "Out of range";
+      if (n > size_) KUMI_ERROR("Out of range");
       return substr(n, size_ - n);
     }
 
     KUMI_ABI constexpr str remove_suffix(size_type n) const
     {
-      if (n > size_) throw "Out of range";
+      if (n > size_) KUMI_ERROR("Out of range");
       return substr(0, size_ - n);
     }
 
@@ -119,7 +119,7 @@ namespace kumi
 
     KUMI_ABI constexpr bool contains(str const& s) const { return find(s) != npos; }
 
-    constexpr size_type find(str const& s, size_type pos = 0) const
+    KUMI_ABI constexpr size_type find(str const& s, size_type pos = 0) const
     {
       if (s.size_ == 0) return pos <= size_ ? pos : npos;
       if (s.size_ > size_) return npos;
@@ -137,7 +137,7 @@ namespace kumi
       return npos;
     }
 
-    constexpr int compare(str const& other) const noexcept
+    KUMI_ABI constexpr int compare(str const& other) const noexcept
     {
       size_type min_size = (size_ < other.size_) ? size_ : other.size_;
 
@@ -151,19 +151,19 @@ namespace kumi
       return 0;
     }
 
-    friend constexpr bool operator==(str const& lhs, str const& rhs) noexcept { return lhs.compare(rhs) == 0; }
+    KUMI_ABI friend constexpr bool operator==(str const& lhs, str const& rhs) noexcept { return lhs.compare(rhs) == 0; }
 
-    friend constexpr bool operator!=(str const& lhs, str const& rhs) noexcept { return lhs.compare(rhs) != 0; }
+    KUMI_ABI friend constexpr bool operator!=(str const& lhs, str const& rhs) noexcept { return lhs.compare(rhs) != 0; }
 
-    friend constexpr bool operator<(str const& lhs, str const& rhs) noexcept { return lhs.compare(rhs) < 0; }
+    KUMI_ABI friend constexpr bool operator<(str const& lhs, str const& rhs) noexcept { return lhs.compare(rhs) < 0; }
 
-    friend constexpr bool operator<=(str const& lhs, str const& rhs) noexcept { return lhs.compare(rhs) <= 0; }
+    KUMI_ABI friend constexpr bool operator<=(str const& lhs, str const& rhs) noexcept { return lhs.compare(rhs) <= 0; }
 
-    friend constexpr bool operator>(str const& lhs, str const& rhs) noexcept { return lhs.compare(rhs) > 0; }
+    KUMI_ABI friend constexpr bool operator>(str const& lhs, str const& rhs) noexcept { return lhs.compare(rhs) > 0; }
 
-    friend constexpr bool operator>=(str const& lhs, str const& rhs) noexcept { return lhs.compare(rhs) >= 0; }
+    KUMI_ABI friend constexpr bool operator>=(str const& lhs, str const& rhs) noexcept { return lhs.compare(rhs) >= 0; }
 
-    constexpr size_type rfind(str const& s, size_type pos = npos) const
+    KUMI_ABI constexpr size_type rfind(str const& s, size_type pos = npos) const
     {
       if (s.size_ == 0) return (pos > size_ ? size_ : pos);
       if (s.size_ > size_) return npos;
@@ -236,10 +236,10 @@ namespace kumi
       return npos;
     }
 
-    constexpr str operator+(str const& other) const
+    KUMI_ABI constexpr str operator+(str const& other) const
     {
       size_type new_size = size_ + 1 + other.size_;
-      if (new_size > max_size) throw "Overflow";
+      if (new_size > max_size) KUMI_ERROR("Overflow");
 
       str res{};
       res.size_ = static_cast<unsigned int>(new_size);
@@ -254,10 +254,10 @@ namespace kumi
       return res;
     }
 
-    static constexpr str from(char const* s, size_type n)
+    KUMI_ABI static constexpr str from(char const* s, size_type n)
     {
       str res{};
-      if (n > str::max_size) throw "Overflow";
+      if (n > str::max_size) KUMI_ERROR("Overflow");
       for (size_type i = 0; i < n; ++i) res.data_[i] = s[i];
       res.size_ = static_cast<unsigned int>(n);
       return res;
@@ -266,7 +266,7 @@ namespace kumi
 
   inline namespace literals
   {
-    constexpr auto operator""_str(char const* s, std::size_t n)
+    KUMI_ABI constexpr auto operator""_str(char const* s, std::size_t n)
     {
       return kumi::str::from(s, kumi::str::size_type(n));
     }

--- a/include/kumi/product_types/record.hpp
+++ b/include/kumi/product_types/record.hpp
@@ -424,7 +424,7 @@ namespace kumi
     @tparam Ts  Type lists to build the record with.
   **/
   //====================================================================================================================
-  template<typename... Ts> KUMI_CUDA record(Ts&&...) -> record<std::unwrap_ref_decay_t<Ts>...>;
+  template<typename... Ts> record(Ts&&...) -> record<std::unwrap_ref_decay_t<Ts>...>;
 
   //====================================================================================================================
   //! @}

--- a/include/kumi/product_types/tuple.hpp
+++ b/include/kumi/product_types/tuple.hpp
@@ -497,7 +497,7 @@ namespace kumi
     @tparam Ts  Type lists to build the tuple with.
   **/
   //====================================================================================================================
-  template<typename... Ts> KUMI_CUDA tuple(Ts&&...) -> tuple<std::unwrap_ref_decay_t<Ts>...>;
+  template<typename... Ts> tuple(Ts&&...) -> tuple<std::unwrap_ref_decay_t<Ts>...>;
 
   //====================================================================================================================
   //! @}

--- a/include/kumi/utils/projections.hpp
+++ b/include/kumi/utils/projections.hpp
@@ -130,7 +130,7 @@ namespace kumi
     @tparam Ts  Type lists to build the projections with.
   **/
   //====================================================================================================================
-  template<kumi::concepts::projection... Ts> KUMI_CUDA projection_map(Ts...) -> projection_map<Ts{}...>;
+  template<kumi::concepts::projection... Ts> projection_map(Ts...) -> projection_map<Ts{}...>;
 
   //====================================================================================================================
   /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,3 +18,14 @@ copa_glob_unit( QUIET
                 PATTERN "unit/*.cpp" INTERFACE kumi_test
                 RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
               )
+
+##======================================================================================================================
+## Device tests - they need a card at run time. Clang only: under nvcc, a kernel cannot name a kumi entry point, #192
+##======================================================================================================================
+if(CMAKE_CUDA_COMPILER_ID MATCHES "Clang")
+  copa_glob_unit( QUIET
+                  PATTERN "cuda/*.cu" INTERFACE kumi_test
+                  RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+                  DESTINATION "cuda"
+                )
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,7 +20,8 @@ copa_glob_unit( QUIET
               )
 
 ##======================================================================================================================
-## Device tests - they need a card at run time. Clang only: under nvcc, a kernel cannot name a kumi entry point, #192
+## Device tests - they need a GPU at run time.
+## Clang only: under nvcc, a kernel cannot name a kumi entry point
 ##======================================================================================================================
 if(CMAKE_CUDA_COMPILER_ID MATCHES "Clang")
   copa_glob_unit( QUIET

--- a/test/cuda/record/algo/flatten.cu
+++ b/test/cuda/record/algo/flatten.cu
@@ -1,0 +1,37 @@
+//==================================================================================================
+/*
+  KUMI - Compact Tuple Tools
+  Copyright : KUMI Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#define TTS_MAIN
+#include <kumi/record.hpp>
+#include <kumi/algorithm/flatten.hpp>
+#include <tts/tts.hpp>
+#include "device.hpp"
+#include "test.hpp"
+
+namespace
+{
+  // Issue #192: flatten on a record.
+  __global__ void flatten_nested(char* flags)
+  {
+    auto inner = kumi::record{"a"_id = 1, "b"_id = 2};
+    auto flat  = kumi::flatten(kumi::record{"x"_id = 0, "y"_id = inner});
+
+    flags[0] = (flat.size() == 3);
+    flags[1] = (flat["x"_id] == 0);
+    flags[2] = (flat["y.a"_id] == 1) && (flat["y.b"_id] == 2);
+  }
+}
+
+TTS_CASE("Check record::flatten device behavior")
+{
+  auto r = run_on_device(flatten_nested, 3);
+
+  TTS_EXPECT(r.ran);
+  TTS_EXPECT(r[0]);
+  TTS_EXPECT(r[1]);
+  TTS_EXPECT(r[2]);
+};

--- a/test/cuda/tuple/algo/apply.cu
+++ b/test/cuda/tuple/algo/apply.cu
@@ -1,0 +1,33 @@
+//==================================================================================================
+/*
+  KUMI - Compact Tuple Tools
+  Copyright : KUMI Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#define TTS_MAIN
+#include <kumi/tuple.hpp>
+#include <kumi/algorithm/apply.hpp>
+#include <tts/tts.hpp>
+#include "device.hpp"
+
+namespace
+{
+  // Issue #192: a lambda through the requires clause of kumi::apply.
+  __global__ void sum(char* flags)
+  {
+    auto t = kumi::make_tuple(1, 2, 3);
+
+    flags[0] = (kumi::apply([](auto... v) { return (v + ...); }, t) == 6);
+    flags[1] = (kumi::apply([](auto... v) { return sizeof...(v); }, t) == 3);
+  }
+}
+
+TTS_CASE("Check apply device behavior")
+{
+  auto r = run_on_device(sum, 2);
+
+  TTS_EXPECT(r.ran);
+  TTS_EXPECT(r[0]);
+  TTS_EXPECT(r[1]);
+};

--- a/test/cuda/tuple/algo/fold.cu
+++ b/test/cuda/tuple/algo/fold.cu
@@ -1,0 +1,32 @@
+//==================================================================================================
+/*
+  KUMI - Compact Tuple Tools
+  Copyright : KUMI Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#define TTS_MAIN
+#include <kumi/tuple.hpp>
+#include <kumi/algorithm/fold.hpp>
+#include <tts/tts.hpp>
+#include "device.hpp"
+
+namespace
+{
+  __global__ void sums(char* flags)
+  {
+    auto t = kumi::make_tuple(1, 2, 3);
+
+    flags[0] = (kumi::fold_left([](auto a, auto b) { return a + b; }, t, 0) == 6);
+    flags[1] = (kumi::fold_right([](auto a, auto b) { return a + b; }, t, 0) == 6);
+  }
+}
+
+TTS_CASE("Check tuple::fold_left device behavior")
+{
+  auto r = run_on_device(sums, 2);
+
+  TTS_EXPECT(r.ran);
+  TTS_EXPECT(r[0]);
+  TTS_EXPECT(r[1]);
+};

--- a/test/cuda/tuple/algo/for_each.cu
+++ b/test/cuda/tuple/algo/for_each.cu
@@ -1,0 +1,32 @@
+//==================================================================================================
+/*
+  KUMI - Compact Tuple Tools
+  Copyright : KUMI Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#define TTS_MAIN
+#include <kumi/tuple.hpp>
+#include <kumi/algorithm/for_each.hpp>
+#include <tts/tts.hpp>
+#include "device.hpp"
+
+namespace
+{
+  __global__ void accumulate(char* flags)
+  {
+    auto t     = kumi::make_tuple(1, 2, 3);
+    int  count = 0;
+
+    kumi::for_each([&](auto v) { count += v; }, t);
+    flags[0] = (count == 6);
+  }
+}
+
+TTS_CASE("Check for_each device behavior")
+{
+  auto r = run_on_device(accumulate, 1);
+
+  TTS_EXPECT(r.ran);
+  TTS_EXPECT(r[0]);
+};

--- a/test/cuda/tuple/algo/map.cu
+++ b/test/cuda/tuple/algo/map.cu
@@ -1,0 +1,35 @@
+//==================================================================================================
+/*
+  KUMI - Compact Tuple Tools
+  Copyright : KUMI Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#define TTS_MAIN
+#include <kumi/tuple.hpp>
+#include <kumi/algorithm/map.hpp>
+#include <tts/tts.hpp>
+#include "device.hpp"
+
+namespace
+{
+  __global__ void twice(char* flags)
+  {
+    auto t = kumi::make_tuple(1, 2, 3);
+    auto u = kumi::map([](auto v) { return v * 2; }, t);
+
+    flags[0] = (kumi::get<0>(u) == 2);
+    flags[1] = (kumi::get<1>(u) == 4);
+    flags[2] = (kumi::get<2>(u) == 6);
+  }
+}
+
+TTS_CASE("Check map(f, tuple) device behavior")
+{
+  auto r = run_on_device(twice, 3);
+
+  TTS_EXPECT(r.ran);
+  TTS_EXPECT(r[0]);
+  TTS_EXPECT(r[1]);
+  TTS_EXPECT(r[2]);
+};

--- a/test/cuda/tuple/api/convert.cu
+++ b/test/cuda/tuple/api/convert.cu
@@ -1,0 +1,46 @@
+//==================================================================================================
+/*
+  KUMI - Compact Tuple Tools
+  Copyright : KUMI Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#define TTS_MAIN
+#include <kumi/tuple.hpp>
+#include <tts/tts.hpp>
+#include "device.hpp"
+
+namespace
+{
+  // Issue #192: a member whose constructor is explicit.
+  struct ExpInt
+  {
+    int value = 0;
+
+    ExpInt() = default;
+    __host__ __device__ explicit ExpInt(int v) : value(v) {}
+  };
+
+  // nvcc 13.2.51 rejects this conversion, in host code as much as in a kernel; clang and g++ accept it.
+#if !defined(__NVCC__)
+  __global__ void convert(char* flags)
+  {
+    auto in  = kumi::tuple{1, 2};
+    auto out = static_cast<kumi::tuple<ExpInt, ExpInt>>(in);
+
+    flags[0] = (kumi::get<0>(out).value == 1);
+    flags[1] = (kumi::get<1>(out).value == 2);
+  }
+#endif
+}
+
+#if !defined(__NVCC__)
+TTS_CASE("Check tuple to constructible type device conversion")
+{
+  auto r = run_on_device(convert, 2);
+
+  TTS_EXPECT(r.ran);
+  TTS_EXPECT(r[0]);
+  TTS_EXPECT(r[1]);
+};
+#endif

--- a/test/cuda/tuple/api/ebo.cu
+++ b/test/cuda/tuple/api/ebo.cu
@@ -1,0 +1,30 @@
+//==================================================================================================
+/*
+  KUMI - Compact Tuple Tools
+  Copyright : KUMI Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#define TTS_MAIN
+#include <kumi/tuple.hpp>
+#include <tts/tts.hpp>
+#include "device.hpp"
+
+namespace
+{
+  __global__ void sizes(char* flags)
+  {
+    // A device laying the type out otherwise reports another size here than the host does.
+    flags[0] = (sizeof(kumi::tuple<int>) == sizeof(int));
+    flags[1] = (sizeof(kumi::tuple<int, double>) == sizeof(double) * 2);
+  }
+}
+
+TTS_CASE("Check EBO device behavior of kumi::tuple construction")
+{
+  auto r = run_on_device(sizes, 2);
+
+  TTS_EXPECT(r.ran);
+  TTS_EXPECT(r[0]);
+  TTS_EXPECT(r[1]);
+};

--- a/test/cuda/tuple/api/make_tuple.cu
+++ b/test/cuda/tuple/api/make_tuple.cu
@@ -1,0 +1,40 @@
+//==================================================================================================
+/*
+  KUMI - Compact Tuple Tools
+  Copyright : KUMI Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#define TTS_MAIN
+#include <kumi/tuple.hpp>
+#include <tts/tts.hpp>
+#include "device.hpp"
+
+namespace
+{
+  __global__ void make_and_read(char* flags)
+  {
+    auto t = kumi::make_tuple(1, 2.f, '3');
+
+    flags[0] = (t.size() == 3);
+    flags[1] = (kumi::get<0>(t) == 1);
+    flags[2] = (kumi::get<1>(t) == 2.f);
+    flags[3] = (kumi::get<2>(t) == '3');
+
+    auto copy          = t;
+    kumi::get<0>(copy) = 42;
+    flags[4]           = (kumi::get<0>(copy) == 42) && (kumi::get<0>(t) == 1);
+  }
+}
+
+TTS_CASE("Check construction of kumi::tuple via device make_tuple")
+{
+  auto r = run_on_device(make_and_read, 5);
+
+  TTS_EXPECT(r.ran);
+  TTS_EXPECT(r[0]);
+  TTS_EXPECT(r[1]);
+  TTS_EXPECT(r[2]);
+  TTS_EXPECT(r[3]);
+  TTS_EXPECT(r[4]);
+};

--- a/test/device.hpp
+++ b/test/device.hpp
@@ -15,7 +15,7 @@
 //! Running a kernel and reading back what it checked
 //==================================================================================================
 
-// A run that never reached a device reports every flag false, so a machine without a card fails its tests.
+// A run that never reached a device reports every flag false, so a machine without a GPU fails its tests.
 struct device_result
 {
   bool ran = false;

--- a/test/device.hpp
+++ b/test/device.hpp
@@ -1,0 +1,47 @@
+//==================================================================================================
+/*
+  KUMI - Compact Tuple Tools
+  Copyright : KUMI Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cstddef>
+#include <vector>
+
+//==================================================================================================
+//! Running a kernel and reading back what it checked
+//==================================================================================================
+
+// A run that never reached a device reports every flag false, so a machine without a card fails its tests.
+struct device_result
+{
+  bool ran = false;
+  std::vector<char> flags = {};
+
+  bool operator[](std::size_t i) const { return ran && (i < flags.size()) && (flags[i] != 0); }
+};
+
+// Every CUDA call is checked before the flags are trusted.
+template<typename Kernel> inline device_result run_on_device(Kernel kernel, std::size_t count)
+{
+  int devices = 0;
+  if (cudaGetDeviceCount(&devices) != cudaSuccess || devices == 0) return {};
+
+  char* on_device = nullptr;
+  if (cudaMalloc(&on_device, count) != cudaSuccess) return {};
+  cudaMemset(on_device, 0, count);
+
+  kernel<<<1, 1>>>(on_device);
+
+  std::vector<char> flags(count, 0);
+  auto launched = cudaGetLastError();
+  auto ran = cudaDeviceSynchronize();
+  auto copied = cudaMemcpy(flags.data(), on_device, count, cudaMemcpyDeviceToHost);
+  cudaFree(on_device);
+
+  if (launched != cudaSuccess || ran != cudaSuccess || copied != cudaSuccess) return {};
+  return {true, flags};
+}


### PR DESCRIPTION
Eight device tests mirror their host counterparts, file for file, and run on the card the self-hosted
runner carries. They build under clang only: every kumi entry point is an `inline constexpr` in host
memory, which a kernel compiled by nvcc cannot name, so the new matrix carries a single `clang-cuda`
row and #192 stays open on that count. The conversion to members with an explicit constructor is
guarded under `__NVCC__` for a neighbouring reason: nvcc 13.2.51 refuses it in host code as much as in
a kernel, where clang and g++ accept it.

`CMAKE_CUDA_ARCHITECTURES` moves into the nvidia preset. It was unset and cost nothing while no kernel
ran; it now decides whether one launches, and 75 is what the card reports.
