### PR TITLE
Keep the CI of main off the critical path

### DIFF
--- a/.github/matrices/nvidia-debug.yml
+++ b/.github/matrices/nvidia-debug.yml
@@ -5,7 +5,7 @@
 ##======================================================================================================================
 ## Read by copacabana's matrix.yml: the nvidia jobs in Debug. Two files for one platform because the documentation
 ## examples are built and run in Debug only, and a file carries one target list.
-runs-on: self-hosted
+runs-on: [self-hosted, cuda]
 configs: [Debug]
 build-targets: unit.exe doc.exe
 test-targets: unit|doc

--- a/.github/matrices/nvidia-debug.yml
+++ b/.github/matrices/nvidia-debug.yml
@@ -5,7 +5,7 @@
 ##======================================================================================================================
 ## Read by copacabana's matrix.yml: the nvidia jobs in Debug. Two files for one platform because the documentation
 ## examples are built and run in Debug only, and a file carries one target list.
-runs-on: [self-hosted, cuda]
+runs-on: cuda
 configs: [Debug]
 build-targets: unit.exe doc.exe
 test-targets: unit|doc

--- a/.github/matrices/nvidia-release.yml
+++ b/.github/matrices/nvidia-release.yml
@@ -5,7 +5,7 @@
 ##======================================================================================================================
 ## Read by copacabana's matrix.yml: the nvidia jobs in Release. Two files for one platform because the documentation
 ## examples are built and run in Debug only, and a file carries one target list.
-runs-on: self-hosted
+runs-on: [self-hosted, cuda]
 configs: [Release]
 build-targets: unit.exe
 test-targets: unit

--- a/.github/matrices/nvidia-release.yml
+++ b/.github/matrices/nvidia-release.yml
@@ -5,7 +5,7 @@
 ##======================================================================================================================
 ## Read by copacabana's matrix.yml: the nvidia jobs in Release. Two files for one platform because the documentation
 ## examples are built and run in Debug only, and a file carries one target list.
-runs-on: [self-hosted, cuda]
+runs-on: cuda
 configs: [Release]
 build-targets: unit.exe
 test-targets: unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   ##################################################################################################
   yield-to-pull-requests:
     name: Yield
-    runs-on: self-hosted
+    runs-on: [self-hosted, avx512]
     continue-on-error: true
     permissions:
       actions: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,10 @@
 ##======================================================================================================================
 name: Unit Tests
 on:
-  ## Also on a merge: nothing else says main is broken, and the matrix takes minutes here.
-  push:
-    branches:
-      - main
+  ## Main gets the matrix once a night rather than on every merge: a run of its own queued behind each merge held
+  ## the pull requests back. 03:00 UTC.
+  schedule:
+    - cron: '0 3 * * *'
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,23 +24,37 @@ jobs:
   ##################################################################################################
   yield-to-pull-requests:
     name: Yield
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     continue-on-error: true
     permissions:
       actions: write
     steps:
+      ## The condition sits on the step, not on the job: everything below waits for this job, and a job skipped by its
+      ## own condition skips whatever needs it, which would leave the nightly run of main with nothing to do.
       - name: Cancel what main has in flight
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # The jq filter stays on one line: a backslash inside single quotes is a backslash, not a continuation.
-          in_flight=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow ci.yml --branch main --limit 20 \
-                                  --json databaseId,status \
-                                  --jq '.[] | select(.status == "queued" or .status == "in_progress") | .databaseId')
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ci.yml',
+              branch: 'main',
+              per_page: 20
+            });
 
-          for run in $in_flight; do gh run cancel --repo "$GITHUB_REPOSITORY" "$run"; done
+            for (const run of runs.data.workflow_runs)
+            {
+              if (run.status === 'queued' || run.status === 'in_progress')
+              {
+                await github.rest.actions.cancelWorkflowRun({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: run.id
+                });
+              }
+            }
 
   ##################################################################################################
   ## Fast gate: pre-commit checks, standalone generation and sanitizers all start together with no
@@ -48,6 +62,7 @@ jobs:
   ##################################################################################################
   precommit:
     name: Meta Checks
+    needs: [yield-to-pull-requests]
     uses: jfalcou/copacabana/.github/workflows/precommit.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
 
   ##======================================================================================================================
@@ -55,6 +70,7 @@ jobs:
   ##======================================================================================================================
   standalone-generation:
     name: Standalone Generation
+    needs: [yield-to-pull-requests]
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/jfalcou/compilers:v10
@@ -77,6 +93,7 @@ jobs:
   ##################################################################################################
   sanitizer-tests:
     name: Sanitizers
+    needs: [yield-to-pull-requests]
     uses: jfalcou/copacabana/.github/workflows/sanitizers.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
     with:
       build-targets: unit.exe doc.exe
@@ -87,6 +104,7 @@ jobs:
   ##################################################################################################
   coverage-report:
     name: Coverage
+    needs: [yield-to-pull-requests]
     uses: jfalcou/copacabana/.github/workflows/coverage.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
     with:
       project: kumi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,30 @@ concurrency:
 
 jobs:
   ##################################################################################################
+  ## A nightly run of main is expendable: a pull request needs the runners more, and the next night
+  ## measures main again. Fire and forget, so nothing here can hold the matrix back.
+  ##################################################################################################
+  yield-to-pull-requests:
+    name: Yield
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel what main has in flight
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # The jq filter stays on one line: a backslash inside single quotes is a backslash, not a continuation.
+          in_flight=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow ci.yml --branch main --limit 20 \
+                                  --json databaseId,status \
+                                  --jq '.[] | select(.status == "queued" or .status == "in_progress") | .databaseId')
+
+          for run in $in_flight; do gh run cancel --repo "$GITHUB_REPOSITORY" "$run"; done
+
+  ##################################################################################################
   ## Fast gate: pre-commit checks, standalone generation and sanitizers all start together with no
   ## interdependency - only once all three pass does the (much heavier) compiler matrix start below.
   ##################################################################################################


### PR DESCRIPTION
A run of main behind every merge queued the pull requests behind 49 jobs, twelve of which sit on the
single self-hosted agent kumi has. Main now gets the matrix at 03:00 UTC instead, and a pull request
cancels whatever that nightly still has in flight. Concurrency groups cannot express this: they are
per ref, so a scheduled run and a pull request never see each other.

The `push` on main stays in `compile-cost.yml`. It is one job, no matrix, and it is what leaves the
reference artifact every later pull request subtracts against.
