### PR TITLE
Fetch TTS on a cold configure too

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -14,7 +14,9 @@ include(${CMAKE_CURRENT_LIST_DIR}/CPM.cmake)
 ##======================================================================================================================
 CPMAddPackage(NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana GIT_TAG v7)
 
-if(KUMI_BUILD_TEST)
+# This file runs before the option is declared, so a cold configure sees it undefined and would
+# skip TTS, leaving tts::tts dangling. A warm cache hides it.
+if(NOT DEFINED KUMI_BUILD_TEST OR KUMI_BUILD_TEST)
   CPMAddPackage ( NAME TTS   GITHUB_REPOSITORY jfalcou/tts
                   GIT_TAG main
                   OPTIONS "TTS_BUILD_TEST OFF"


### PR DESCRIPTION
cmake/dependencies.cmake runs before CMakeLists.txt declares KUMI_BUILD_TEST, so the guard around the TTS package reads an undefined variable on a cold configure and skips it. cmake/compiler.cmake then asks for a tts::tts target nobody created and the generate step fails. A second configure succeeds because the option is in the cache by then, which is why only a fresh clone meets it, and why eve's externals job is the place it shows up.

The option comes from copa_add_option, which comes from copacabana, which this same file fetches, so the declaration cannot move ahead of the include. Giving the guard the option's own default covers the cold case and leaves an explicit -DKUMI_BUILD_TEST=OFF skipping TTS as before.
