### PR TITLE
Move the nightly to a European night and give the doc stable URLs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,10 @@
 name: Unit Tests
 on:
   ## Main gets the matrix once a night rather than on every merge: a run of its own queued behind each merge held
-  ## the pull requests back. 03:00 UTC.
+  ## the pull requests back. 01:20 UTC, which is 02:20 in Paris in winter, and off the hour that every other
+  ## scheduled workflow on the platform asks for.
   schedule:
-    - cron: '0 3 * * *'
+    - cron: '20 1 * * *'
   pull_request:
     branches:
       - main
@@ -19,50 +20,11 @@ concurrency:
 
 jobs:
   ##################################################################################################
-  ## A nightly run of main is expendable: a pull request needs the runners more, and the next night
-  ## measures main again. Fire and forget, so nothing here can hold the matrix back.
-  ##################################################################################################
-  yield-to-pull-requests:
-    name: Yield
-    runs-on: [self-hosted, avx512]
-    continue-on-error: true
-    permissions:
-      actions: write
-    steps:
-      ## The condition sits on the step, not on the job: everything below waits for this job, and a job skipped by its
-      ## own condition skips whatever needs it, which would leave the nightly run of main with nothing to do.
-      - name: Cancel what main has in flight
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const runs = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'ci.yml',
-              branch: 'main',
-              per_page: 20
-            });
-
-            for (const run of runs.data.workflow_runs)
-            {
-              if (run.status === 'queued' || run.status === 'in_progress')
-              {
-                await github.rest.actions.cancelWorkflowRun({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  run_id: run.id
-                });
-              }
-            }
-
-  ##################################################################################################
   ## Fast gate: pre-commit checks, standalone generation and sanitizers all start together with no
   ## interdependency - only once all three pass does the (much heavier) compiler matrix start below.
   ##################################################################################################
   precommit:
     name: Meta Checks
-    needs: [yield-to-pull-requests]
     uses: jfalcou/copacabana/.github/workflows/precommit.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
 
   ##======================================================================================================================
@@ -70,7 +32,6 @@ jobs:
   ##======================================================================================================================
   standalone-generation:
     name: Standalone Generation
-    needs: [yield-to-pull-requests]
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/jfalcou/compilers:v10
@@ -93,7 +54,6 @@ jobs:
   ##################################################################################################
   sanitizer-tests:
     name: Sanitizers
-    needs: [yield-to-pull-requests]
     uses: jfalcou/copacabana/.github/workflows/sanitizers.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       build-targets: unit.exe doc.exe
@@ -104,7 +64,6 @@ jobs:
   ##################################################################################################
   coverage-report:
     name: Coverage
-    needs: [yield-to-pull-requests]
     uses: jfalcou/copacabana/.github/workflows/coverage.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       project: kumi

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 # KUMI - C++20 Compact Tuple Tools
 
+[![Release](https://img.shields.io/github/v/release/jfalcou/kumi?style=plastic&label=release)](https://github.com/jfalcou/kumi/releases/latest)
 [![License](https://img.shields.io/badge/license-BSL-green?style=plastic)](./LICENSE.md)
 [![Discord](https://img.shields.io/discord/692734675726237696?style=plastic)](https://discord.com/channels/692734675726237696/916823794230886481)
-[![CI Status](https://github.com/jfalcou/kumi/actions/workflows/integration.yml/badge.svg)](https://github.com/jfalcou/kumi/actions/workflows/integration.yml)
+[![Integration](https://github.com/jfalcou/kumi/actions/workflows/integration.yml/badge.svg)](https://github.com/jfalcou/kumi/actions/workflows/integration.yml)
 [![Coverage](https://img.shields.io/endpoint?url=https://jfalcou.github.io/kumi/coverage/badge.json&style=plastic&cacheSeconds=1800)](https://jfalcou.github.io/kumi/coverage/)
+[![CI](https://github.com/jfalcou/kumi/actions/workflows/ci.yml/badge.svg?event=schedule)](https://github.com/jfalcou/kumi/actions/workflows/ci.yml?query=event%3Aschedule)
 
 <br clear="left"/>
 
@@ -109,9 +111,9 @@ int main()
 ```
 ## Getting Started
 
- - [Installing the library](https://jfalcou.github.io/kumi/setup.html)
- - [Glossary](https://jfalcou.github.io/kumi/usergroup1.html)
- - [References Documentation](https://jfalcou.github.io/kumi/usergroup3.html)
+ - [Installing the library](https://jfalcou.github.io/kumi/kumi_setup.html)
+ - [Glossary](https://jfalcou.github.io/kumi/kumi_glossary.html)
+ - [Reference Documentation](https://jfalcou.github.io/kumi/kumi_reference.html)
 
 ## Currently supported compilers
 

--- a/doc/glossary/glossary.hpp
+++ b/doc/glossary/glossary.hpp
@@ -1,0 +1,14 @@
+#error This file is for documentation only - DO NOT INCLUDE
+/**
+
+  @page kumi_glossary Glossary
+
+  The vocabulary **KUMI** uses, and the type theory it rests on.
+
+  - @subpage kumi_introduction
+  - @subpage kumi_identity
+  - @subpage kumi_product
+  - @subpage kumi_cpp_spec
+  - @subpage kumi_nomenclature
+
+**/

--- a/doc/glossary/nomenclature.hpp
+++ b/doc/glossary/nomenclature.hpp
@@ -1,4 +1,4 @@
-#error This file is for ducomentation only - DO NOT INCLUDE
+#error This file is for documentation only - DO NOT INCLUDE
 /**
 
   @page kumi_nomenclature Nomenclature

--- a/doc/layout.xml
+++ b/doc/layout.xml
@@ -3,13 +3,13 @@
   <!-- Navigation index tabs for HTML output -->
   <navindex>
     <tab type="mainpage" visible="yes" title=""/>
-    <tab type="usergroup" visible="yes" title="About The Library">
+    <tab type="usergroup" visible="yes" title="About The Library" url="@ref kumi_setup">
       <tab type="user" url="@ref kumi_setup"     title="Setup"/>
       <tab type="user" url="@ref kumi_changelog" title="Changelog"/>
       <tab type="user" url="@ref kumi_licence"   title="Licence"/>
     </tab>
-    <tab type="usergroup" visible="yes" title="Glossary">
-      <tab type="usergroup" visible="yes" title="Type Theory">
+    <tab type="usergroup" visible="yes" title="Glossary" url="@ref kumi_glossary">
+      <tab type="usergroup" visible="yes" title="Type Theory" url="@ref kumi_introduction">
         <tab type="user" url="@ref kumi_introduction" title="Introduction"/>
         <tab type="user" url="@ref kumi_identity" title="Identity Types"/>
         <tab type="user" url="@ref kumi_product" title="Product Types"/>
@@ -17,19 +17,19 @@
       <tab type="user" url="@ref kumi_cpp_spec" title="C++ Vocabulary"/>
       <tab type="user" url="@ref kumi_nomenclature" title="Nomenclature"/>
     </tab>
-    <tab type="usergroup" visible="yes"   title="Reference Documentation">
-      <tab type="usergroup" visible="yes"   title="Types">
+    <tab type="usergroup" visible="yes"   title="Reference Documentation" url="@ref kumi_reference">
+      <tab type="usergroup" visible="yes"   title="Types" url="@ref kumi_tuple_related">
         <tab type="user" url="@ref kumi_tuple_related"   title="Product Types and Functions"/>
         <tab type="user" url="@ref kumi_record_related"  title="Record Types and Functions"/>
         <tab type="user" url="@ref kumi_types"   title="Types"/>
       </tab>
-      <tab type="usergroup" visible="yes" title="Algorithms">
+      <tab type="usergroup" visible="yes" title="Algorithms" url="@ref kumi_transforms">
         <tab type="user" url="@ref kumi_transforms"  title="Transformations"/>
         <tab type="user" url="@ref kumi_queries"     title="Queries"/>
         <tab type="user" url="@ref kumi_generators"  title="Generators"/>
         <tab type="user" url="@ref kumi_reductions"  title="Reductions"/>
       </tab>
-      <tab type="usergroup" visible="yes" title="Helpers">
+      <tab type="usergroup" visible="yes" title="Helpers" url="@ref kumi_traits">
         <tab type="user" url="@ref kumi_traits"    title="Traits"/>
         <tab type="user" url="@ref kumi_concepts"  title="Concepts"/>
         <tab type="user" url="@ref kumi_utility"   title="Utility"/>

--- a/doc/reference.hpp
+++ b/doc/reference.hpp
@@ -1,0 +1,28 @@
+#error This file is for documentation only - DO NOT INCLUDE
+/**
+
+  @page kumi_reference Reference Documentation
+
+  Every type, algorithm and helper the library exposes, gathered by role.
+
+  ### Types
+
+  - @ref kumi_tuple_related
+  - @ref kumi_record_related
+  - @ref kumi_types
+
+  ### Algorithms
+
+  - @ref kumi_transforms
+  - @ref kumi_queries
+  - @ref kumi_generators
+  - @ref kumi_reductions
+
+  ### Helpers
+
+  - @ref kumi_traits
+  - @ref kumi_concepts
+  - @ref kumi_utility
+  - @ref kumi_functional
+
+**/


### PR DESCRIPTION
The nightly moves off 03:00 UTC, which is breakfast in Paris, and Yield goes with it: it existed to
cancel a run of main queued behind a merge, and merges have not started one since the schedule
replaced the push. The self-hosted runner it ran on is no longer needed either.

The documentation menu had no stable URLs. Doxygen serves a container tab as usergroupN.html,
numbered by position, so inserting one entry silently moves what every other link points to, which is
how the README ended up citing the Glossary and getting Type Theory. Each container now names a page,
and the setup link, dead since that page became kumi_setup, is fixed along the way.
