### PR TITLE
Name the fleet's nightly ladder in the schedule comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,9 @@
 name: Unit Tests
 on:
   ## Main gets the matrix once a night rather than on every merge: a run of its own queued behind each merge held
-  ## the pull requests back. 01:20 UTC, which is 02:20 in Paris in winter, and off the hour that every other
-  ## scheduled workflow on the platform asks for.
+  ## the pull requests back. 01:20 UTC, one rung of the fleet's 45 minute ladder, which starts at 00:35 and
+  ## never lands on the hour every other scheduled workflow on the platform asks for. kyosu opens it and polyfloat
+  ## sits in its middle, the two heaviest matrices taking the emptiest slots.
   schedule:
     - cron: '20 1 * * *'
   pull_request:


### PR DESCRIPTION
Three repositories asked for the same minute, while the offsets exist so that they do not compete for the self-hosted agents at once. The fleet now runs a 45 minute ladder starting at 00:35, no rung of which lands on the hour every other scheduled workflow on the platform asks for: kyosu, kumi, spy, polyfloat, tts, raberu, fluxion.

kyosu opens the ladder and polyfloat sits in its middle, their matrices being the two heaviest, so each has the emptiest slot ahead of it. This repository keeps 01:20, the ladder being built around it; only the comment changes, so that the seven files tell one story.
