### PR TITLE
Fetch TTS where its option exists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ copa_add_option(KUMI_ENABLE_COVERAGE "Build tests with code coverage instrumenta
 copa_add_option(KUMI_COMPILE_COST "Measure what every test unit costs to compile" OFF)
 
 if(KUMI_BUILD_TEST)
+  CPMGetPackage(TTS)
   include(${PROJECT_SOURCE_DIR}/cmake/compiler.cmake)
 endif()
 copa_project_version(MAJOR 5 MINOR 0 PATCH 0 REPOSITORY https://github.com/jfalcou/kumi)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -11,16 +11,15 @@ include(${CMAKE_CURRENT_LIST_DIR}/CPM.cmake)
 
 ##======================================================================================================================
 ## Retrieve dependencies
+##
+## This file runs before the project can declare an option, copa_add_option arriving with copacabana, so a package
+## wanted only under an option is declared here and fetched after the options, in CMakeLists.txt.
 ##======================================================================================================================
 CPMAddPackage(NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana GIT_TAG v8)
 
-# This file runs before the option is declared, so a cold configure sees it undefined and would
-# skip TTS, leaving tts::tts dangling. A warm cache hides it.
-if(NOT DEFINED KUMI_BUILD_TEST OR KUMI_BUILD_TEST)
-  CPMAddPackage ( NAME TTS   GITHUB_REPOSITORY jfalcou/tts
-                  GIT_TAG main
-                  OPTIONS "TTS_BUILD_TEST OFF"
-                          "TTS_BUILD_DOCUMENTATION OFF"
-                          "TTS_QUIET ON"
-                )
-endif()
+CPMDeclarePackage ( TTS   NAME TTS   GITHUB_REPOSITORY jfalcou/tts
+                    GIT_TAG main
+                    OPTIONS "TTS_BUILD_TEST OFF"
+                            "TTS_BUILD_DOCUMENTATION OFF"
+                            "TTS_QUIET ON"
+                  )

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -19,6 +19,7 @@ CPMAddPackage(NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana GIT_TAG v8)
 
 CPMDeclarePackage ( TTS   NAME TTS   GITHUB_REPOSITORY jfalcou/tts
                     GIT_TAG main
+                    SYSTEM YES
                     OPTIONS "TTS_BUILD_TEST OFF"
                             "TTS_BUILD_DOCUMENTATION OFF"
                             "TTS_QUIET ON"


### PR DESCRIPTION
`cmake/dependencies.cmake` runs before `copa_add_option` exists, so the guard around TTS had to
duplicate the option's default to survive a cold configure. TTS is now declared there and fetched
under the option in `CMakeLists.txt`, the form copacabana carries since its `Fix #113`.

The second commit marks TTS as `SYSTEM`, so a warning introduced upstream cannot break this
repository's build.
