### PR TITLE
Follow copacabana main, and keep the compile cost over time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
   ##################################################################################################
   precommit:
     name: Meta Checks
-    uses: jfalcou/copacabana/.github/workflows/precommit.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
+    uses: jfalcou/copacabana/.github/workflows/precommit.yml@main
 
   ##======================================================================================================================
   ## Ensure Standalone is viable
@@ -55,7 +55,7 @@ jobs:
   ##################################################################################################
   sanitizer-tests:
     name: Sanitizers
-    uses: jfalcou/copacabana/.github/workflows/sanitizers.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
+    uses: jfalcou/copacabana/.github/workflows/sanitizers.yml@main
     with:
       build-targets: unit.exe doc.exe
       test-targets: unit|doc
@@ -65,7 +65,7 @@ jobs:
   ##################################################################################################
   coverage-report:
     name: Coverage
-    uses: jfalcou/copacabana/.github/workflows/coverage.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
+    uses: jfalcou/copacabana/.github/workflows/coverage.yml@main
     with:
       project: kumi
       build-targets: kumi-test
@@ -76,56 +76,56 @@ jobs:
   linux-debug-tests:
     name: Linux
     needs: [precommit, standalone-generation, sanitizer-tests]
-    uses: jfalcou/copacabana/.github/workflows/matrix.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
+    uses: jfalcou/copacabana/.github/workflows/matrix.yml@main
     with:
       file: .github/matrices/linux-debug.yml
 
   linux-release-tests:
     name: Linux
     needs: [precommit, standalone-generation, sanitizer-tests]
-    uses: jfalcou/copacabana/.github/workflows/matrix.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
+    uses: jfalcou/copacabana/.github/workflows/matrix.yml@main
     with:
       file: .github/matrices/linux-release.yml
 
   macos-debug-tests:
     name: MacOS
     needs: [precommit, standalone-generation, sanitizer-tests]
-    uses: jfalcou/copacabana/.github/workflows/matrix.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
+    uses: jfalcou/copacabana/.github/workflows/matrix.yml@main
     with:
       file: .github/matrices/macos-debug.yml
 
   macos-release-tests:
     name: MacOS
     needs: [precommit, standalone-generation, sanitizer-tests]
-    uses: jfalcou/copacabana/.github/workflows/matrix.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
+    uses: jfalcou/copacabana/.github/workflows/matrix.yml@main
     with:
       file: .github/matrices/macos-release.yml
 
   windows-debug-tests:
     name: Windows
     needs: [precommit, standalone-generation, sanitizer-tests]
-    uses: jfalcou/copacabana/.github/workflows/matrix.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
+    uses: jfalcou/copacabana/.github/workflows/matrix.yml@main
     with:
       file: .github/matrices/windows-debug.yml
 
   windows-release-tests:
     name: Windows
     needs: [precommit, standalone-generation, sanitizer-tests]
-    uses: jfalcou/copacabana/.github/workflows/matrix.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
+    uses: jfalcou/copacabana/.github/workflows/matrix.yml@main
     with:
       file: .github/matrices/windows-release.yml
 
   nvidia-debug-tests:
     name: Nvidia
     needs: [precommit, standalone-generation, sanitizer-tests]
-    uses: jfalcou/copacabana/.github/workflows/matrix.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
+    uses: jfalcou/copacabana/.github/workflows/matrix.yml@main
     with:
       file: .github/matrices/nvidia-debug.yml
 
   nvidia-release-tests:
     name: Nvidia
     needs: [precommit, standalone-generation, sanitizer-tests]
-    uses: jfalcou/copacabana/.github/workflows/matrix.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
+    uses: jfalcou/copacabana/.github/workflows/matrix.yml@main
     with:
       file: .github/matrices/nvidia-release.yml
 
@@ -135,6 +135,6 @@ jobs:
   nvidia-device-tests:
     name: Device
     needs: [precommit, standalone-generation, sanitizer-tests]
-    uses: jfalcou/copacabana/.github/workflows/matrix.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
+    uses: jfalcou/copacabana/.github/workflows/matrix.yml@main
     with:
       file: .github/matrices/nvidia-device.yml

--- a/.github/workflows/compile-cost.yml
+++ b/.github/workflows/compile-cost.yml
@@ -19,10 +19,12 @@ concurrency:
 
 jobs:
   compile-cost:
-    ## Reading the reference off another run asks more than the contents scope the token defaults to.
+    ## Reading the reference off another run asks more than the contents scope the token defaults to, and keeping the
+    ## series asks for a write: the job that publishes it is the only one that uses it.
     permissions:
       actions: read
-      contents: read
-    uses: jfalcou/copacabana/.github/workflows/compile-cost.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
+      contents: write
+    uses: jfalcou/copacabana/.github/workflows/compile-cost.yml@main
     with:
       project: kumi
+      series: true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,7 @@ jobs:
   documentation:
     permissions:
       contents: write
-    uses: jfalcou/copacabana/.github/workflows/documentation.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
+    uses: jfalcou/copacabana/.github/workflows/documentation.yml@main
     with:
       project: kumi
       coverage: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   integration:
-    uses: jfalcou/copacabana/.github/workflows/integration.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
+    uses: jfalcou/copacabana/.github/workflows/integration.yml@main
     with:
       project: kumi
       cxx-compiler: clang++

--- a/.github/workflows/package-standalone.yml
+++ b/.github/workflows/package-standalone.yml
@@ -14,6 +14,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: jfalcou/copacabana/.github/workflows/package-standalone.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
+    uses: jfalcou/copacabana/.github/workflows/package-standalone.yml@main
     with:
       project: kumi

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -15,7 +15,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/CPM.cmake)
 ## This file runs before the project can declare an option, copa_add_option arriving with copacabana, so a package
 ## wanted only under an option is declared here and fetched after the options, in CMakeLists.txt.
 ##======================================================================================================================
-CPMAddPackage(NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana GIT_TAG v8)
+CPMAddPackage(NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana GIT_TAG main)
 
 CPMDeclarePackage ( TTS   NAME TTS   GITHUB_REPOSITORY jfalcou/tts
                     GIT_TAG main


### PR DESCRIPTION
Both pins follow `copacabana@main` now, the sixteen `uses:` and the `GIT_TAG`, so what is written
there can be tried here before it is released rather than after. The day kumi is tagged, both move to
the copacabana tag of that day, which is what makes a release reproducible.

`compile-cost.yml` also turns the series on. Every push to `main` then leaves its measurement on the
`ct-measures` branch, which the reader of the documentation draws a curve from; the thirteen runs that
still hold an artifact are already there. Publishing writes to the repository, hence the
`contents: write` the calling job now grants, used by nothing but that one job.
